### PR TITLE
add new property for supply and return temperature of primary circuit

### DIFF
--- a/PyViCare/PyViCareHeatPump.py
+++ b/PyViCare/PyViCareHeatPump.py
@@ -28,3 +28,15 @@ class HeatPump(Device):
             return self.service.getProperty("heating.compressor.statistics")["properties"]["hours"]["value"]
         except KeyError:
             return "error"
+
+    def getSupplyTemperaturePrimaryCircuit(self):
+        try:
+            return self.service.getProperty("heating.primaryCircuit.sensors.temperature.supply")["properties"]["value"]["value"]
+        except KeyError:
+            return "error"
+
+    def getReturnTemperaturePrimaryCircuit(self):
+        try:
+            return self.service.getProperty("heating.primaryCircuit.sensors.temperature.return")["properties"]["value"]["value"]
+        except KeyError:
+            return "error"


### PR DESCRIPTION
The heatpumps also measure the supply and return temperature of the primary circuit. Would like to have this properties later on also in home assistant.  