### PR TITLE
Update PyViCareGazBoiler.py

### DIFF
--- a/PyViCare/PyViCareGazBoiler.py
+++ b/PyViCare/PyViCareGazBoiler.py
@@ -122,3 +122,15 @@ class GazBoiler(Device):
             return self.service.getProperty('heating.burner.current.power')['properties']['value']['value']
         except KeyError:
             return "error"
+    
+    def getBurnerHours(self):
+        try:
+            return self.service.getProperty('heating.burner.statistics')['properties']['hours']['value']
+        except KeyError:
+            return "error"
+
+    def getBurnerStarts(self):
+        try:
+            return self.service.getProperty('heating.burner.statistics')['properties']['starts']['value']
+        except KeyError:
+            return "error"


### PR DESCRIPTION
ViCare delivers information about the burner starts and burner hours (time how long the burner was used, e.g. 6200h). Added these two statistic values of burner.