### PR TITLE
Proposal for batching requests

### DIFF
--- a/PyViCare/PyViCareCachedService.py
+++ b/PyViCare/PyViCareCachedService.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+
+from PyViCare.PyViCareService import apiURLBase, ViCareService
+
+class ViCareCachedService(ViCareService):
+    
+    def __init__(self, username, password, cacheDuration, token_file=None,circuit=0):
+        ViCareService.__init__(self, username, password, token_file, circuit)
+        self.cacheDuration = cacheDuration
+        self.cache = None
+        self.cacheTime = None
+
+    def __setCache(self):
+        url = apiURLBase + '/operational-data/installations/' + str(self.id) + '/gateways/' + str(self.serial) + '/devices/0/features/'
+        self.cache = self.get(url)
+        self.cacheTime = datetime.now()
+
+    def getProperty(self,property_name):
+        if self.cache is None or self.cacheTime is None or (datetime.now() - self.cacheTime).seconds > self.cacheDuration:
+            self.__setCache()
+        
+        entities = self.cache["entities"]
+        feature = next((f for f in entities if f["class"][0] == property_name and f["class"][1] == "feature"), {})
+        return feature

--- a/PyViCare/PyViCareDevice.py
+++ b/PyViCare/PyViCareDevice.py
@@ -119,6 +119,9 @@ class Device:
     def deactivateComfort(self):
         return self.deactivateProgram("comfort")
 
+    def fetchAndCacheFeatures(self):
+        self.service.fetchAndCacheFeatures()
+
     def getMonthSinceLastService(self):
         try:
             return self.service.getProperty("heating.service.timeBased")["properties"]["activeMonthSinceLastService"]["value"]
@@ -172,7 +175,6 @@ class Device:
             return self.service.getProperty("heating.circuits." + str(self.service.circuit) + ".heating.curve")["properties"]["slope"]["value"]
         except KeyError:
             return "error"
-
 
     def getActiveProgram(self):
         try:

--- a/PyViCare/PyViCareDevice.py
+++ b/PyViCare/PyViCareDevice.py
@@ -24,7 +24,7 @@ class Device:
     """
 
     # TODO cirtcuit management should move at method level
-    def __init__(self, username, password,token_file=None,circuit=0):
+    def __init__(self, username, password,token_file=None,circuit=0,service=None):
         """Init function. Create the necessary oAuth2 sessions
         Parameters
         ----------
@@ -37,7 +37,10 @@ class Device:
         -------
         """
 
-        self.service = ViCareService(username, password, token_file, circuit)
+        if service is None:
+            self.service = ViCareService(username, password, token_file, circuit)
+        else:
+            self.service = service
 
     """ Set the active mode
     Parameters
@@ -118,9 +121,6 @@ class Device:
         return self.service.setProperty("heating.circuits." + str(self.service.circuit) + ".operating.programs."+program,"deactivate","{}")
     def deactivateComfort(self):
         return self.deactivateProgram("comfort")
-
-    def fetchAndCacheFeatures(self):
-        self.service.fetchAndCacheFeatures()
 
     def getMonthSinceLastService(self):
         try:

--- a/PyViCare/PyViCareDevice.py
+++ b/PyViCare/PyViCareDevice.py
@@ -3,6 +3,7 @@ import json
 import os
 import logging
 from PyViCare.PyViCareService import ViCareService
+from PyViCare.PyViCareCachedService import ViCareCachedService
 
 logger = logging.getLogger('ViCare')
 logger.addHandler(logging.NullHandler())
@@ -24,7 +25,7 @@ class Device:
     """
 
     # TODO cirtcuit management should move at method level
-    def __init__(self, username, password,token_file=None,circuit=0,service=None):
+    def __init__(self, username, password,token_file=None,circuit=0,cacheDuration=0):
         """Init function. Create the necessary oAuth2 sessions
         Parameters
         ----------
@@ -37,10 +38,10 @@ class Device:
         -------
         """
 
-        if service is None:
+        if cacheDuration == 0:
             self.service = ViCareService(username, password, token_file, circuit)
         else:
-            self.service = service
+            self.service = ViCareCachedService(username, password, cacheDuration, token_file, circuit)
 
     """ Set the active mode
     Parameters

--- a/PyViCare/PyViCareService.py
+++ b/PyViCare/PyViCareService.py
@@ -223,15 +223,14 @@ class ViCareService:
     def getInstallations(self):
         return self.installations
 
-    def fetchAndCacheFeatures(self):
-        url = apiURLBase + '/operational-data/installations/' + str(self.id) + '/gateways/' + str(self.serial) + '/devices/0/features/'
-        self.j = self.__get(url)
+    def get(self, url):
+        return self.__get(url)
 
    #TODO should move to device after refactoring 
     def getProperty(self,property_name):
-        entities = self.j["entities"]
-        feature = next((f for f in entities if f["class"][0] == property_name and f["class"][1] == "feature"), {})
-        return feature
+        url = apiURLBase + '/operational-data/installations/' + str(self.id) + '/gateways/' + str(self.serial) + '/devices/0/features/' + property_name
+        j=self.__get(url)
+        return j
 
     def setProperty(self,property_name,action,data):
         url = apiURLBase + '/operational-data/v1/installations/' + str(self.id) + '/gateways/' + str(self.serial) + '/devices/0/features/' + property_name +"/"+action

--- a/PyViCare/PyViCareService.py
+++ b/PyViCare/PyViCareService.py
@@ -223,11 +223,15 @@ class ViCareService:
     def getInstallations(self):
         return self.installations
 
+    def fetchAndCacheFeatures(self):
+        url = apiURLBase + '/operational-data/installations/' + str(self.id) + '/gateways/' + str(self.serial) + '/devices/0/features/'
+        self.j = self.__get(url)
+
    #TODO should move to device after refactoring 
     def getProperty(self,property_name):
-        url = apiURLBase + '/operational-data/installations/' + str(self.id) + '/gateways/' + str(self.serial) + '/devices/0/features/' + property_name
-        j=self.__get(url)
-        return j
+        entities = self.j["entities"]
+        feature = next((f for f in entities if f["class"][0] == property_name and f["class"][1] == "feature"), {})
+        return feature
 
     def setProperty(self,property_name,action,data):
         url = apiURLBase + '/operational-data/v1/installations/' + str(self.id) + '/gateways/' + str(self.serial) + '/devices/0/features/' + property_name +"/"+action

--- a/PyViCare/__init__.py
+++ b/PyViCare/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ['PyViCareService''PyViCareDevice','PyViCareGazBoiler','PyViCareHeatPump']
+__all__ = ['PyViCareService''PyViCareDevice','PyViCareGazBoiler','PyViCareHeatPump','PyViCareCachedService']


### PR DESCRIPTION
To overcome the Viessmann API limits I implemented a proposal for batching (issue #22)

I noticed that the normal call to the "features" endpoint already delivers all data, so there is no need to call each feature on its own.

Example:
```Python
t=HeatPump("xxx","xxx","token.save")
t.fetchAndCacheFeatures()
print(t.getDomesticHotWaterConfiguredTemperature()) 
```

Returns the same result as before.
Naming can be improved, but I couldnt come up with something else.

@oischinger Also looking forward to your feedback ;)