### PR TITLE
Add current desired dhw temperature

### DIFF
--- a/PyViCare/PyViCareDevice.py
+++ b/PyViCare/PyViCareDevice.py
@@ -302,6 +302,19 @@ class Device:
     def setDomesticHotWaterTemperature(self,temperature):
         return self.service.setProperty("heating.dhw.temperature","setTargetTemperature","{\"temperature\":"+str(temperature)+"}")
         
+    """ Set the target temperature 2 for domestic host water
+    Parameters
+    ----------
+    temperature : int
+        Target temperature
+
+    Returns
+    -------
+    result: json
+        json representation of the answer
+    """
+    def setDomesticHotWaterTemperature2(self,temperature):
+        return self.service.setProperty("heating.dhw.temperature.temp2","setTargetTemperature","{\"temperature\":"+str(temperature)+"}")
 
     def getCirculationPumpActive(self):
         try:


### PR DESCRIPTION
Add current desired dhw temperature by parsing the schedule.

Fixes #24 

Unfortunately the API does not provide any information on which temperature mode is currently active. So we have to parse the schedule to get the current mode.

When there are two scheduled temperature modes active at the same time, the "temperature 2" overrides all other modes according to the documentation of vitotronic.

@oischinger: Would you mind trying this out aswell? My dhw schedule is pretty basic so any other tests would be great ;) Also if this is approved, the HA integration should use the new property as target temperature in water_heater instead of the current configured temperature.