### PR TITLE
Fix issue for get Hotwater and Circulation Pump status

### DIFF
--- a/PyViCare/PyViCareDevice.py
+++ b/PyViCare/PyViCareDevice.py
@@ -272,8 +272,7 @@ class Device:
 
     def getDomesticHotWaterPumpActive(self):
         try:
-            status =  self.service.getProperty("heating.dhw.pumps.primary")["properties"]["status"]["value"]
-            return status == 'on'
+            return self.service.getProperty("heating.dhw.pumps.primary")["properties"]["status"]["value"]
         except KeyError:
             return "error"
 
@@ -318,8 +317,7 @@ class Device:
 
     def getCirculationPumpActive(self):
         try:
-            status =  self.service.getProperty("heating.circuits." + str(self.service.circuit) + ".circulation.pump")["properties"]["status"]["value"]
-            return status == 'on'
+            return self.service.getProperty("heating.circuits." + str(self.service.circuit) + ".circulation.pump")["properties"]["status"]["value"]
         except KeyError:
             return "error"
     


### PR DESCRIPTION
I faced an issue while reading Pump staus of my Installation. In Vitoguide the Pumps are shown as active, but the code returns always that the Pumps where off. This code change fixed my issue.