### PR TITLE
Reduce log level from warning to info for token renew

### DIFF
--- a/PyViCare/PyViCareService.py
+++ b/PyViCare/PyViCareService.py
@@ -138,7 +138,7 @@ class ViCareService:
         # TODO tranform to exception
         
     def renewToken(self):
-        logger.warning("Token expired, renewing")
+        logger.info("Token expired, renewing")
         self.oauth=self.__getNewToken(self.username,self.password,self.token_file)
         logger.info("Token renewed successfully")
             


### PR DESCRIPTION
This PR changes the log level for a token renew from `warning` to `info`.

This reduces the log output in dependent applications (e.g. homeassistant) for a pretty usual use-case. To renew a token is basically the intended workflow for OAuth, is I think this lower level is more appropriate.