### PR TITLE
Feature: Raise exception instead of returning error string

### DIFF
--- a/PyViCare/Feature.py
+++ b/PyViCare/Feature.py
@@ -1,2 +1,4 @@
-#feature flag to have a release which still returns an error string
+# Feature flag to raise an exception in case of a non existing device feature.
+# The flag should be fully removed in a later release. 
+# It allows dependend libraries to gracefully migrate to the new behaviour
 raise_exception_instead_of_returning_error = False

--- a/PyViCare/Feature.py
+++ b/PyViCare/Feature.py
@@ -1,4 +1,4 @@
 # Feature flag to raise an exception in case of a non existing device feature.
 # The flag should be fully removed in a later release. 
 # It allows dependend libraries to gracefully migrate to the new behaviour
-raise_exception_instead_of_returning_error = False
+raise_exception_on_not_supported_device_feature = False

--- a/PyViCare/Feature.py
+++ b/PyViCare/Feature.py
@@ -1,0 +1,2 @@
+#feature flag to have a release which still returns an error string
+raise_exception_instead_of_returning_error = False

--- a/PyViCare/PyViCare.py
+++ b/PyViCare/PyViCare.py
@@ -1,5 +1,3 @@
-from PyViCare.PyViCareGazBoiler import GazBoiler
-
 # This decorator handles access to underlying JSON properties.
 # If the property is not found (KeyError) or the index does not 
 # exists (IndexError), the requested feature is not supported by 
@@ -8,13 +6,9 @@ def handleNotSupported(func):
     def wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except KeyError as err:
-        	return "KeyError: " + str(err)
-        except IndexError as err:
-            return "IndexError: " + str(err)
+        except (KeyError, IndexError):
+        	raise PyViCareNotSupportedFeatureError(func.__name__)
     return wrapper
 
-# DEPRECATED
-class ViCareSession(GazBoiler):
-    def dummy(self):
-        print("done")
+class PyViCareNotSupportedFeatureError(Exception):
+    pass

--- a/PyViCare/PyViCare.py
+++ b/PyViCare/PyViCare.py
@@ -6,7 +6,7 @@ def handleNotSupported(func):
     def wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except (KeyError, IndexError):
+        except (IndexError):
         	raise PyViCareNotSupportedFeatureError(func.__name__)
     return wrapper
 

--- a/PyViCare/PyViCare.py
+++ b/PyViCare/PyViCare.py
@@ -6,7 +6,7 @@ def handleNotSupported(func):
     def wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except (IndexError):
+        except (KeyError, IndexError):
         	raise PyViCareNotSupportedFeatureError(func.__name__)
     return wrapper
 

--- a/PyViCare/PyViCare.py
+++ b/PyViCare/PyViCare.py
@@ -7,16 +7,20 @@ import PyViCare.Feature
 def handleNotSupported(func):
     def wrapper(*args, **kwargs):
         try:
-            try:
-                return func(*args, **kwargs)
-            except (KeyError, IndexError):
-                raise PyViCareNotSupportedFeatureError(func.__name__)
+            return func(*args, **kwargs)
+        except (KeyError, IndexError):
+            raise PyViCareNotSupportedFeatureError(func.__name__)
+
+    #You can remove that wrapper after the feature flag gets removed entirely.
+    def feature_flag_wrapper(*args, **kwargs):
+        try:
+            return wrapper(*args, **kwargs)
         except PyViCareNotSupportedFeatureError:
             if PyViCare.Feature.raise_exception_instead_of_returning_error:
                 raise
             else:
                 return "error"
-    return wrapper
+    return feature_flag_wrapper
 
 class PyViCareNotSupportedFeatureError(Exception):
     pass

--- a/PyViCare/PyViCare.py
+++ b/PyViCare/PyViCare.py
@@ -1,3 +1,5 @@
+import PyViCare.Feature
+
 # This decorator handles access to underlying JSON properties.
 # If the property is not found (KeyError) or the index does not 
 # exists (IndexError), the requested feature is not supported by 
@@ -5,9 +7,15 @@
 def handleNotSupported(func):
     def wrapper(*args, **kwargs):
         try:
-            return func(*args, **kwargs)
-        except (KeyError, IndexError):
-        	raise PyViCareNotSupportedFeatureError(func.__name__)
+            try:
+                return func(*args, **kwargs)
+            except (KeyError, IndexError):
+                raise PyViCareNotSupportedFeatureError(func.__name__)
+        except PyViCareNotSupportedFeatureError:
+            if PyViCare.Feature.raise_exception_instead_of_returning_error:
+                raise
+            else:
+                return "error"
     return wrapper
 
 class PyViCareNotSupportedFeatureError(Exception):

--- a/PyViCare/PyViCare.py
+++ b/PyViCare/PyViCare.py
@@ -16,7 +16,7 @@ def handleNotSupported(func):
         try:
             return wrapper(*args, **kwargs)
         except PyViCareNotSupportedFeatureError:
-            if PyViCare.Feature.raise_exception_instead_of_returning_error:
+            if PyViCare.Feature.raise_exception_on_not_supported_device_feature:
                 raise
             else:
                 return "error"

--- a/PyViCare/PyViCareService.py
+++ b/PyViCare/PyViCareService.py
@@ -10,6 +10,7 @@ from pickle import UnpicklingError
 
 import simplejson as json
 from simplejson import JSONDecodeError
+from PyViCare.PyViCare import PyViCareNotSupportedFeatureError
 
 client_id = '79742319e39245de5f91d15ff4cac2a8'
 client_secret = '8ad97aceb92c5892e102b093c7c083fa'
@@ -23,7 +24,11 @@ logger.addHandler(logging.NullHandler())
 
 
 def readFeature(entities, property_name):
-    feature = next((f for f in entities if f["class"][0] == property_name and f["class"][1] == "feature"), {})
+    feature = next((f for f in entities if f["class"][0] == property_name and f["class"][1] == "feature"), None)
+
+    if(feature is None):
+        raise PyViCareNotSupportedFeatureError(property_name)
+
     return feature
 
 # https://api.viessmann-platform.io/general-management/v1/installations/DDDDD gives the type like VitoconnectOptolink
@@ -239,8 +244,10 @@ class ViCareService:
    #TODO should move to device after refactoring 
     def getProperty(self,property_name):
         url = apiURLBase + '/operational-data/installations/' + str(self.id) + '/gateways/' + str(self.serial) + '/devices/0/features/' + property_name
-        j=self.__get(url)
-        return j
+        response = self.__get(url)
+        if "statusCode" in response and response["statusCode"] == 404:
+            raise PyViCareNotSupportedFeatureError(property_name)
+        return response
 
     def setProperty(self,property_name,action,data):
         url = apiURLBase + '/operational-data/v1/installations/' + str(self.id) + '/gateways/' + str(self.serial) + '/devices/0/features/' + property_name +"/"+action

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ from PyViCare.PyViCareHeatPump import HeatPump # heat pump
 
 ## Device Features / Errors
 
-Depending on the device, some features are not available/supported. This results in a raising of a `PyViCareNotSupportedFeatureError` if the dedicated method is called. This is (mostly) likely not a bug, but a limitation of the device itself.
+Depending on the device, some features are not available/supported. This results in a raising of a `PyViCareNotSupportedFeatureError` if the dedicated method is called. This is most likely not a bug, but a limitation of the device itself.
 
 ## Basic usage
 Simple example:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A few nice feature removed from the app are available though the API (Comfort an
 
 ## Version 0.1.0
 Note that the version 0.1.0 DOES BREAK a few things.
-ViCareSession is deprecated (but you can still import it using `from PyViCare.PyViCare import ViCareSession`).
+`ViCareSession` is now removed.
 You can now use the following objects:
 ```python
 from PyViCare.PyViCareDevice import Device # generic device

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ from PyViCare.PyViCareHeatPump import HeatPump # heat pump
 
 ## Device Features / Errors
 
-Depending on the device, some features are not available/supported. This results in a response of `error` if the dedicated method is called. This is (mostly) not a bug, but a limitation of the device itself.
+Depending on the device, some features are not available/supported. This results in a raising of a `PyViCareNotSupportedFeatureError` if the dedicated method is called. This is (mostly) likely not a bug, but a limitation of the device itself.
 
 ## Basic usage
 Simple example:

--- a/tests/test_Vitodens111W.py
+++ b/tests/test_Vitodens111W.py
@@ -2,12 +2,14 @@ import unittest
 from tests.ViCareServiceForTesting import ViCareServiceForTesting
 from PyViCare.PyViCareGazBoiler import GazBoiler
 from PyViCare.PyViCare import PyViCareNotSupportedFeatureError
+import PyViCare.Feature
 
 class Vitodens111W(unittest.TestCase):
     def setUp(self):
         self.service = ViCareServiceForTesting('response_Vitodens111W.json', 0)
         self.gaz = GazBoiler(None, None, None, 0, 0, self.service)
-
+        PyViCare.Feature.raise_exception_instead_of_returning_error = True
+        
     def test_getBurnerActive(self):
         self.assertEqual(self.gaz.getBurnerActive(), False)
 
@@ -22,3 +24,7 @@ class Vitodens111W(unittest.TestCase):
 
     def test_getPrograms_fails(self):
         self.assertRaises(PyViCareNotSupportedFeatureError, self.gaz.getPrograms)
+
+    def test_ensure_old_behavior_non_supported_feature_returns_error(self):
+        PyViCare.Feature.raise_exception_instead_of_returning_error = False
+        self.assertEqual(self.gaz.getPowerConsumptionDays(), "error")

--- a/tests/test_Vitodens111W.py
+++ b/tests/test_Vitodens111W.py
@@ -8,7 +8,7 @@ class Vitodens111W(unittest.TestCase):
     def setUp(self):
         self.service = ViCareServiceForTesting('response_Vitodens111W.json', 0)
         self.gaz = GazBoiler(None, None, None, 0, 0, self.service)
-        PyViCare.Feature.raise_exception_instead_of_returning_error = True
+        PyViCare.Feature.raise_exception_on_not_supported_device_feature = True
         
     def test_getBurnerActive(self):
         self.assertEqual(self.gaz.getBurnerActive(), False)
@@ -26,5 +26,5 @@ class Vitodens111W(unittest.TestCase):
         self.assertRaises(PyViCareNotSupportedFeatureError, self.gaz.getPrograms)
 
     def test_ensure_old_behavior_non_supported_feature_returns_error(self):
-        PyViCare.Feature.raise_exception_instead_of_returning_error = False
+        PyViCare.Feature.raise_exception_on_not_supported_device_feature = False
         self.assertEqual(self.gaz.getPowerConsumptionDays(), "error")

--- a/tests/test_Vitodens111W.py
+++ b/tests/test_Vitodens111W.py
@@ -1,6 +1,7 @@
 import unittest
 from tests.ViCareServiceForTesting import ViCareServiceForTesting
 from PyViCare.PyViCareGazBoiler import GazBoiler
+from PyViCare.PyViCare import PyViCareNotSupportedFeatureError
 
 class Vitodens111W(unittest.TestCase):
     def setUp(self):
@@ -14,10 +15,10 @@ class Vitodens111W(unittest.TestCase):
         self.assertEqual(self.gaz.getBurnerStarts(), 12648)
 
     def test_getPowerConsumptionDays_fails(self):
-        self.assertEqual(self.gaz.getPowerConsumptionDays(), 'error')
+        self.assertRaises(PyViCareNotSupportedFeatureError, self.gaz.getPowerConsumptionDays)
 
     def test_getMonthSinceLastService_fails(self):
-        self.assertEqual(self.gaz.getMonthSinceLastService(), "KeyError: 'properties'")
+        self.assertRaises(PyViCareNotSupportedFeatureError, self.gaz.getMonthSinceLastService)
 
     def test_getPrograms_fails(self):
-        self.assertRaises(IndexError, self.gaz.getPrograms)
+        self.assertRaises(PyViCareNotSupportedFeatureError, self.gaz.getPrograms)

--- a/tests/test_Vitodens222F.py
+++ b/tests/test_Vitodens222F.py
@@ -2,11 +2,13 @@ import unittest
 from tests.ViCareServiceForTesting import ViCareServiceForTesting
 from PyViCare.PyViCareGazBoiler import GazBoiler
 from PyViCare.PyViCare import PyViCareNotSupportedFeatureError
+import PyViCare.Feature
 
 class Vitodens222F(unittest.TestCase):
     def setUp(self):
         self.service = ViCareServiceForTesting('response_Vitodens222F.json', 0)
         self.gaz = GazBoiler(None, None, None, 0, 0, self.service)
+        PyViCare.Feature.raise_exception_instead_of_returning_error = True
 
     def test_getBurnerActive(self):
         self.assertEqual(self.gaz.getBurnerActive(), False)

--- a/tests/test_Vitodens222F.py
+++ b/tests/test_Vitodens222F.py
@@ -8,7 +8,7 @@ class Vitodens222F(unittest.TestCase):
     def setUp(self):
         self.service = ViCareServiceForTesting('response_Vitodens222F.json', 0)
         self.gaz = GazBoiler(None, None, None, 0, 0, self.service)
-        PyViCare.Feature.raise_exception_instead_of_returning_error = True
+        PyViCare.Feature.raise_exception_on_not_supported_device_feature = True
 
     def test_getBurnerActive(self):
         self.assertEqual(self.gaz.getBurnerActive(), False)

--- a/tests/test_Vitodens222F.py
+++ b/tests/test_Vitodens222F.py
@@ -1,6 +1,7 @@
 import unittest
 from tests.ViCareServiceForTesting import ViCareServiceForTesting
 from PyViCare.PyViCareGazBoiler import GazBoiler
+from PyViCare.PyViCare import PyViCareNotSupportedFeatureError
 
 class Vitodens222F(unittest.TestCase):
     def setUp(self):
@@ -17,7 +18,7 @@ class Vitodens222F(unittest.TestCase):
         self.assertEqual(self.gaz.getPowerConsumptionToday(), 1)
 
     def test_getMonthSinceLastService_fails(self):
-        self.assertEqual(self.gaz.getMonthSinceLastService(), "KeyError: 'properties'")
+        self.assertRaises(PyViCareNotSupportedFeatureError, self.gaz.getMonthSinceLastService)
 
     def test_getSupplyTemperature(self):
         self.assertAlmostEqual(self.gaz.getSupplyTemperature(), 41.9)


### PR DESCRIPTION
This PR changes the error handling as discussed in #52, to raise an `PyViCareNotSupportedFeatureError` if the feature is not supported.

The feature is hidden behind a feature flag, so that the old behavior can still be retained.

I also moved part of the raising of the error to the underlying logic, so that it's not triggered by another a `KeyError`. This should uncover some possible bugs. This should allow us also to remove the decorator all together (except for the `IndexError`). But we lack a few test samples to make this 💯 .

Lastly the PR fixes a circular dependency which fails the build, by removing the already deprecated `ViCareSession` (of course we could just move the decorator, but I think the cleanup is the better approach).