### PR TITLE
Sync requirements.txt with setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests-oauthlib>=1.0.0
+requests-oauthlib>=1.1.0
 simplejson


### PR DESCRIPTION
This is a tiny PR. It just syncs the version of the `requests-oauthlib` dependency to `1.1.0` as configured in `setup.py`. Not sure if we should generally bump that dependency to `1.3.0` as this is the current latest version (see: https://pypi.org/project/requests-oauthlib/)