### PR TITLE
Add tests for getModes

### DIFF
--- a/tests/test_Vitodens111W.py
+++ b/tests/test_Vitodens111W.py
@@ -21,3 +21,7 @@ class Vitodens111W(unittest.TestCase):
 
     def test_getPrograms_fails(self):
         self.assertRaises(IndexError, self.gaz.getPrograms)
+    
+    def test_getModes(self):
+        expected_modes = ['standby', 'dhw', 'dhwAndHeating']
+        self.assertListEqual(self.gaz.getModes(), expected_modes)

--- a/tests/test_Vitodens222F.py
+++ b/tests/test_Vitodens222F.py
@@ -32,3 +32,7 @@ class Vitodens222F(unittest.TestCase):
                             'reduced',
                             'standby']
         self.assertListEqual(self.gaz.getPrograms(), expected_programs)
+
+    def test_getModes(self):
+        expected_modes = ['standby', 'heating', 'dhw', 'dhwAndHeating']
+        self.assertListEqual(self.gaz.getModes(), expected_modes)


### PR DESCRIPTION
This PR adds a unit test to ensure correct functioning of the `getModes` method. Additionally, this shows that depending on the device there are different values available.