### PR TITLE
Feature: Rate limit detection

### DIFF
--- a/PyViCare/Feature.py
+++ b/PyViCare/Feature.py
@@ -1,4 +1,4 @@
 # Feature flag to raise an exception in case of a non existing device feature.
-# The flag should be fully removed in a later release. 
+# The flag should be fully removed in a later release.
 # It allows dependend libraries to gracefully migrate to the new behaviour
 raise_exception_on_not_supported_device_feature = False

--- a/PyViCare/Feature.py
+++ b/PyViCare/Feature.py
@@ -2,3 +2,6 @@
 # The flag should be fully removed in a later release.
 # It allows dependend libraries to gracefully migrate to the new behaviour
 raise_exception_on_not_supported_device_feature = False
+
+# Feature flag to raise exception if rate limit of the API is hit
+raise_exception_on_rate_limit = False

--- a/PyViCare/PyViCare.py
+++ b/PyViCare/PyViCare.py
@@ -1,4 +1,5 @@
 import PyViCare.Feature
+import datetime
 
 # This decorator handles access to underlying JSON properties.
 # If the property is not found (KeyError) or the index does not 
@@ -24,3 +25,18 @@ def handleNotSupported(func):
 
 class PyViCareNotSupportedFeatureError(Exception):
     pass
+
+class PyViCareRateLimitError(Exception):
+
+    def __init__(self, response):
+        extended_payload = response["extendedPayload"]
+        name = extended_payload["name"]
+        requestCountLimit = extended_payload["requestCountLimit"]
+        limitReset = extended_payload["limitReset"]
+        limitResetDate = datetime.datetime.utcfromtimestamp(limitReset/1000)
+
+        msg = f'API rate limit {name} exceeded. Max {requestCountLimit} calls in timewindow. Limit reset at {limitResetDate.isoformat()}.'
+
+        super().__init__(self, msg)
+        self.message = msg
+        self.limitResetDate = limitResetDate

--- a/PyViCare/PyViCareService.py
+++ b/PyViCare/PyViCareService.py
@@ -12,6 +12,7 @@ from pickle import UnpicklingError
 import simplejson as json
 from simplejson import JSONDecodeError
 from PyViCare.PyViCare import PyViCareNotSupportedFeatureError, PyViCareRateLimitError
+import PyViCare.Feature
 
 client_id = '79742319e39245de5f91d15ff4cac2a8'
 client_secret = '8ad97aceb92c5892e102b093c7c083fa'
@@ -177,10 +178,9 @@ class ViCareService:
             #    self.renewToken()
             logger.debug(self.oauth)
             r=self.oauth.get(url).json()
-
+            logger.debug("Response to get request: "+str(r))
             self.handleRateLimit(r)
 
-            logger.debug("Response to get request: "+str(r))
             if(r=={'error': 'EXPIRED TOKEN'}):
                 logger.warning("Abnormal token, renewing") # apparently forged tokens TODO investigate
                 self.renewToken()
@@ -191,6 +191,9 @@ class ViCareService:
             return self.__get(url)
 
     def handleRateLimit(self, response):
+        if not PyViCare.Feature.raise_exception_on_rate_limit:
+            return
+
         if("statusCode" in response and response["statusCode"] == 429):
             raise PyViCareRateLimitError(response)
             

--- a/README.md
+++ b/README.md
@@ -86,3 +86,7 @@ Follow these steps to access the API in Postman:
 - Use `GazBoiler` for gas heatings
 - Use `HeatPump` for heat pumps
 - Use `FuelCell` for fuel cells
+
+## Rate Limits
+
+[Due to latest changes in the Viessmann API](https://www.viessmann-community.com/t5/Konnektivitaet/Q-amp-A-Viessmann-API/td-p/127660) rate limits can be hit. In that case a `PyViCareRateLimitError` is raised. You can read from the error (`limitResetDate`) when the rate limit is reset.

--- a/tests/ViCareServiceMock.py
+++ b/tests/ViCareServiceMock.py
@@ -1,17 +1,11 @@
-import simplejson as json
-import os
 from PyViCare.PyViCareService import ViCareService, readFeature, buildSetPropertyUrl
+from tests.helper import readJson
 
-class ViCareServiceForTesting(ViCareService):
+class ViCareServiceMock(ViCareService):
     
     def __init__(self, filename, circuit, rawInput = None):
         if rawInput is None:
-            test_filename = os.path.join(os.path.dirname(__file__), filename)
-            try:
-                json_file = open(test_filename, mode='rb')
-                testData = json.load(json_file)
-            finally:
-                json_file.close()
+            testData = readJson(filename)
             self.testData = testData
         else:
             self.testData = rawInput

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,0 +1,10 @@
+import os
+import simplejson as json
+
+def readJson(fileName):
+    test_filename = os.path.join(os.path.dirname(__file__), fileName)
+    json_file = open(test_filename, mode='rb')
+    try:
+        return json.load(json_file)
+    finally:
+        json_file.close()

--- a/tests/response_rate_limit.json
+++ b/tests/response_rate_limit.json
@@ -1,0 +1,13 @@
+{
+    "errorType": "RATE_LIMIT_EXCEEDED",
+    "extendedPayload": {
+        "clientId": "XXXX",
+        "limitReset": 1584462010106,
+        "name": "ViCare day limit",
+        "requestCountLimit": 1450,
+        "userId": "XXXX"
+    },
+    "message": "API calls rate limit has been exceeded. Please wait until your limit will renew.",
+    "statusCode": 429,
+    "viErrorId": "XXX"
+}

--- a/tests/test_GenericDevice.py
+++ b/tests/test_GenericDevice.py
@@ -1,10 +1,10 @@
 import unittest
-from tests.ViCareServiceForTesting import ViCareServiceForTesting
+from tests.ViCareServiceMock import ViCareServiceMock
 from PyViCare.PyViCareDevice import Device
 
 class GenericDevice(unittest.TestCase):
     def setUp(self):
-        self.service = ViCareServiceForTesting(None, 0, {})
+        self.service = ViCareServiceMock(None, 0, {})
         self.device = Device(None, None, None, 0, 0, self.service)
         
     def test_activateComfort(self):

--- a/tests/test_PyViCareExceptions.py
+++ b/tests/test_PyViCareExceptions.py
@@ -1,0 +1,19 @@
+import unittest
+import datetime
+from PyViCare.PyViCare import PyViCareRateLimitError, PyViCareRateLimitError
+from tests.helper import readJson
+
+
+class TestPyViCareRateLimitError(unittest.TestCase):
+
+    def test_createFromResponse(self):
+        mockResponse = readJson('response_rate_limit.json')
+
+        error = PyViCareRateLimitError(mockResponse)
+
+        self.assertEqual(error.message, 'API rate limit ViCare day limit exceeded. Max 1450 calls in timewindow. Limit reset at 2020-03-17T16:20:10.106000.')
+        self.assertEqual(error.limitResetDate, datetime.datetime(2020, 3, 17, 16, 20, 10, 106000))
+
+
+        
+

--- a/tests/test_Vitocal200.py
+++ b/tests/test_Vitocal200.py
@@ -1,12 +1,12 @@
 import unittest
-from tests.ViCareServiceForTesting import ViCareServiceForTesting
+from tests.ViCareServiceMock import ViCareServiceMock
 from PyViCare.PyViCareHeatPump import HeatPump
 from PyViCare.PyViCare import PyViCareNotSupportedFeatureError
 import PyViCare.Feature
 
 class Vitodens111W(unittest.TestCase):
     def setUp(self):
-        self.service = ViCareServiceForTesting('response_Vitocal200.json', 0)
+        self.service = ViCareServiceMock('response_Vitocal200.json', 0)
         self.heat = HeatPump(None, None, None, 0, 0, self.service)
         PyViCare.Feature.raise_exception_on_not_supported_device_feature = True
         

--- a/tests/test_Vitodens111W.py
+++ b/tests/test_Vitodens111W.py
@@ -1,12 +1,12 @@
 import unittest
-from tests.ViCareServiceForTesting import ViCareServiceForTesting
+from tests.ViCareServiceMock import ViCareServiceMock
 from PyViCare.PyViCareGazBoiler import GazBoiler
 from PyViCare.PyViCare import PyViCareNotSupportedFeatureError
 import PyViCare.Feature
 
 class Vitodens111W(unittest.TestCase):
     def setUp(self):
-        self.service = ViCareServiceForTesting('response_Vitodens111W.json', 0)
+        self.service = ViCareServiceMock('response_Vitodens111W.json', 0)
         self.gaz = GazBoiler(None, None, None, 0, 0, self.service)
         PyViCare.Feature.raise_exception_on_not_supported_device_feature = True
         

--- a/tests/test_Vitodens222F.py
+++ b/tests/test_Vitodens222F.py
@@ -1,12 +1,12 @@
 import unittest
-from tests.ViCareServiceForTesting import ViCareServiceForTesting
+from tests.ViCareServiceMock import ViCareServiceMock
 from PyViCare.PyViCareGazBoiler import GazBoiler
 from PyViCare.PyViCare import PyViCareNotSupportedFeatureError
 import PyViCare.Feature
 
 class Vitodens222F(unittest.TestCase):
     def setUp(self):
-        self.service = ViCareServiceForTesting('response_Vitodens222F.json', 0)
+        self.service = ViCareServiceMock('response_Vitodens222F.json', 0)
         self.gaz = GazBoiler(None, None, None, 0, 0, self.service)
         PyViCare.Feature.raise_exception_on_not_supported_device_feature = True
 


### PR DESCRIPTION
This PR adds support to detect rate limits. In that case, it raises the `PyViCareRateLimitError` error, where you can read from the  `limitResetDate` field when the limit is over.

I decided against implementing a suppression logic, as it would make to many assumptions about the usage of that library. Thus, I  think the suppression of the calls should be done in the using applications (e.g. home-assistant) itself.

Fyi, @oischinger

This also includes some refactoring to reuse the JSON read logic in unit tests.

The feature is hidden behind the flag `PyViCare.Feature.raise_exception_on_rate_limit`