### PR TITLE
Feature: Calculate target supply temperature

### DIFF
--- a/PyViCare/PyViCareDevice.py
+++ b/PyViCare/PyViCareDevice.py
@@ -312,3 +312,12 @@ class Device:
             "sat": properties["entries"]["value"]["sat"],
             "sun": properties["entries"]["value"]["sun"]
         }
+
+    def getTargetSupplyTemperature(self):
+        inside = self.getCurrentDesiredTemperature()
+        outside = self.getOutsideTemperature()
+        delta_outside_inside = (outside - inside)
+        shift = self.getHeatingCurveShift()
+        slope = self.getHeatingCurveSlope()
+        targetSupply = inside + shift - slope * delta_outside_inside * (1.4347 + 0.021 * delta_outside_inside + 247.9 * 0.000001 * pow(delta_outside_inside, 2))
+        return round(targetSupply, 1)

--- a/PyViCare/PyViCareDevice.py
+++ b/PyViCare/PyViCareDevice.py
@@ -313,11 +313,13 @@ class Device:
             "sun": properties["entries"]["value"]["sun"]
         }
 
+    # Calculates target supply temperature based on data from Viessmann
+    # See: https://www.viessmann-community.com/t5/Gas/Mathematische-Formel-fuer-Vorlauftemperatur-aus-den-vier/m-p/68890#M27556
     def getTargetSupplyTemperature(self):
         inside = self.getCurrentDesiredTemperature()
         outside = self.getOutsideTemperature()
         delta_outside_inside = (outside - inside)
         shift = self.getHeatingCurveShift()
         slope = self.getHeatingCurveSlope()
-        targetSupply = inside + shift - slope * delta_outside_inside * (1.4347 + 0.021 * delta_outside_inside + 247.9 * 0.000001 * pow(delta_outside_inside, 2))
+        targetSupply = inside + shift - slope * delta_outside_inside * (1.4347 + 0.021 * delta_outside_inside + 247.9 * pow(10, -6) * pow(delta_outside_inside, 2))
         return round(targetSupply, 1)

--- a/tests/test_Vitodens222F.py
+++ b/tests/test_Vitodens222F.py
@@ -56,3 +56,7 @@ class Vitodens222F(unittest.TestCase):
     def test_getModes(self):
         expected_modes = ['standby', 'heating', 'dhw', 'dhwAndHeating']
         self.assertListEqual(self.gaz.getModes(), expected_modes)
+
+    def test_getTargetSupplyTemperature(self):
+        self.assertAlmostEqual(self.gaz.getTargetSupplyTemperature(), 45.1)
+        


### PR DESCRIPTION
This PR adds the calculation of the target supply temperature based on the provided information on the Viessmann forum.

![Formel HKL](https://user-images.githubusercontent.com/2535856/103813207-feb01580-505f-11eb-9902-e016eb51bef6.JPG)

Source: https://www.viessmann-community.com/t5/Gas/Mathematische-Formel-fuer-Vorlauftemperatur-aus-den-vier/m-p/68890#M27556

