### PR TITLE
Add GitHub Action workflow for publishing to pypi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_APITOKEN }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="PyViCare",
-    version="0.1.7",
+    version_config=True,
     author="Simon Gillet",
     author_email="mail+pyvicare@gillet.ninja",
     description="Library to communicate with the Viessmann ViCare API",
@@ -14,6 +14,7 @@ setuptools.setup(
     url="https://github.com/somm15/PyViCare",
     packages=setuptools.find_packages(),
     install_requires=['requests-oauthlib>=1.1.0','simplejson'],
+    setup_requires=['setuptools-git-versioning'],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
This PR adds a GitHub Action workflow to publish the package to PyPi.

It uses `https://pypi.org/project/setuptools-git-versioning/` to automatically read the version number in `setup.py` from git.

You only need to add your PyPi API token to the repository as `PYPI_APITOKEN`.

After that, you need to create a release via GitHub (and tag a specific commit, e.g. `v0.2`). Then the new version should automatically be published with that specific version.

See #67 