### PR TITLE
Remove heat pump methods 

### DIFF
--- a/PyViCare/PyViCareHeatPump.py
+++ b/PyViCare/PyViCareHeatPump.py
@@ -66,24 +66,3 @@ class HeatPump(Device):
     @handleNotSupported
     def getHeatingRodStatusLevel3(self):
         return self.service.getProperty("heating.heatingRod.status")["properties"]["level3"]["value"]
-        
-    @handleNotSupported
-    def getCompressorPower(self):
-        """Get compressor power percentage"""
-        return self.service.getProperty("heating.compressors." + str(self.service.circuit) + ".sensors.power")["properties"]["value"]["value"]
-        
-    @handleNotSupported
-    def getExpansionValve(self):
-        """Get expansion valve percentage"""
-        return self.service.getProperty("heating.sensors.valve.expansion")["properties"]["value"]["value"]
-        
-    @handleNotSupported
-    def getSuctionGasPressure(self):
-        """Get suction gas pressure in bar"""
-        return self.service.getProperty("heating.sensors.pressure.suctionGas")["properties"]["value"]["value"]
-        
-    @handleNotSupported
-    def getHotGasPressure(self):
-        """Get hot gas pressure in bar"""
-        return self.service.getProperty("heating.sensors.pressure.hotGas")["properties"]["value"]["value"]
-        

--- a/tests/test_Vitocal200.py
+++ b/tests/test_Vitocal200.py
@@ -22,20 +22,8 @@ class Vitodens111W(unittest.TestCase):
     def test_getHeatingRodStatusLevel1(self):
         self.assertEqual(self.heat.getHeatingRodStatusLevel1(), False)
 
-    def test_getSuctionGasPressure(self):
-        self.assertRaises(PyViCareNotSupportedFeatureError, self.heat.getSuctionGasPressure)
-        
-    def test_getHotGasPressure(self):
-        self.assertRaises(PyViCareNotSupportedFeatureError, self.heat.getHotGasPressure)
-
     def test_getReturnTemperature(self):
         self.assertAlmostEqual(self.heat.getReturnTemperature(), 25.8)
-
-    def test_getExpansionValve(self):
-        self.assertRaises(PyViCareNotSupportedFeatureError, self.heat.getExpansionValve)
-        
-    def test_getCompressorPower_fails(self):
-        self.assertRaises(PyViCareNotSupportedFeatureError, self.heat.getCompressorPower)
 
     def test_getMonthSinceLastService_fails(self):
         self.assertRaises(PyViCareNotSupportedFeatureError, self.heat.getMonthSinceLastService)


### PR DESCRIPTION
Remove heat pump methods which are not supported anymore. Viessmann removed those values from the API.