### PR TITLE
Update setup.py, add exclusion for 'tests' package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/somm15/PyViCare",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=["tests"]),
     install_requires=['requests-oauthlib>=1.1.0','simplejson'],
     setup_requires=['setuptools-git-versioning'],
     classifiers=[


### PR DESCRIPTION
otherwise it tries to install a package called 'tests' at top level, which is very bad style and forbidden.
```
>>> Jobs: 0 of 1 complete, 1 failed                 Load avg: 0.72, 0.76, 0.68
 * Package:    dev-python/PyViCare-0.2.5
 * Repository: HomeAssistantRepository
 * Maintainer: b@edevau.net
 * Upstream:   mail+pyvicare@gillet.ninja
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux python_targets_python3_8 test userland_GNU
 * FEATURES:   network-sandbox preserve-libs sandbox userpriv usersandbox
>>> Unpacking source...
>>> Unpacking PyViCare-0.2.5.tar.gz to /var/tmp/portage/dev-python/PyViCare-0.2.5/work
>>> Source unpacked in /var/tmp/portage/dev-python/PyViCare-0.2.5/work
>>> Preparing source in /var/tmp/portage/dev-python/PyViCare-0.2.5/work/PyViCare-0.2.5 ...
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/dev-python/PyViCare-0.2.5/work/PyViCare-0.2.5 ...
>>> Source configured.
>>> Compiling source in /var/tmp/portage/dev-python/PyViCare-0.2.5/work/PyViCare-0.2.5 ...
 * python3_8: running distutils-r1_run_phase distutils-r1_python_compile
python3.8 setup.py build -j 10
running build
running build_py
...
writing PyViCare.egg-info/PKG-INFO
writing dependency_links to PyViCare.egg-info/dependency_links.txt
writing requirements to PyViCare.egg-info/requires.txt
writing top-level names to PyViCare.egg-info/top_level.txt
reading manifest file 'PyViCare.egg-info/SOURCES.txt'
writing manifest file 'PyViCare.egg-info/SOURCES.txt'
Copying PyViCare.egg-info to /var/tmp/portage/dev-python/PyViCare-0.2.5/image/_python3.8/usr/lib/python3.8/site-packages/PyViCare-0.2.5-py3.8.egg-info
running install_scripts
 * ERROR: dev-python/PyViCare-0.2.5::HomeAssistantRepository failed (install phase):
 *   Package installs 'tests' package which is forbidden and likely a bug in the build system.
```