### PR TITLE
Check for support of required fields

### DIFF
--- a/PyViCare/PyViCareDevice.py
+++ b/PyViCare/PyViCareDevice.py
@@ -25,6 +25,13 @@ VICARE_DHW_TEMP2 = "temp-2"
 
 """"Viessmann ViCare API Python tools"""
 
+def isSupported(method):
+    try:
+        result = method()
+        return result != 'error'
+    except:
+        return False
+
 class Device:
     """This class connects to the Viesmann ViCare API.
     The authentication is done through OAuth2.
@@ -320,6 +327,12 @@ class Device:
     # Calculates target supply temperature based on data from Viessmann
     # See: https://www.viessmann-community.com/t5/Gas/Mathematische-Formel-fuer-Vorlauftemperatur-aus-den-vier/m-p/68890#M27556
     def getTargetSupplyTemperature(self):
+        if(not isSupported(self.getCurrentDesiredTemperature) 
+            or not isSupported(self.getOutsideTemperature)
+            or not isSupported(self.getHeatingCurveShift)
+            or not isSupported(self.getHeatingCurveSlope)):
+            return None
+
         inside = self.getCurrentDesiredTemperature()
         outside = self.getOutsideTemperature()
         delta_outside_inside = (outside - inside)
@@ -327,3 +340,5 @@ class Device:
         slope = self.getHeatingCurveSlope()
         targetSupply = inside + shift - slope * delta_outside_inside * (1.4347 + 0.021 * delta_outside_inside + 247.9 * pow(10, -6) * pow(delta_outside_inside, 2))
         return round(targetSupply, 1)
+
+    

--- a/tests/response_Vitodens222F_notarget.json
+++ b/tests/response_Vitodens222F_notarget.json
@@ -1,0 +1,14323 @@
+{
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+        },
+        {
+            "rel": [
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+            ],
+            "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+        }
+    ],
+    "properties": {},
+    "entities": [
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.sensors.temperature"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.sensors.temperature"
+                }
+            ],
+            "class": [
+                "heating.circuits.1.sensors.temperature",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.sensors.temperature",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.1.sensors.temperature",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#room",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-room",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.sensors.temperature.room"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#supply",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-supply",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.sensors.temperature.supply"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "room",
+                            "supply"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.statistics"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.statistics"
+                }
+            ],
+            "class": [
+                "heating.solar.statistics",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.statistics",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.solar.statistics",
+                        "timestamp": "2021-01-01T16:03:22.319Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.sensors.temperature.supply"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.sensors.temperature.supply"
+                }
+            ],
+            "class": [
+                "heating.circuits.3.sensors.temperature.supply",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.sensors.temperature.supply",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.3.sensors.temperature.supply",
+                        "timestamp": "2021-01-01T16:03:22.478Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.forcedLastFromSchedule"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.forcedLastFromSchedule"
+                }
+            ],
+            "class": [
+                "heating.circuits.2.operating.programs.forcedLastFromSchedule",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.forcedLastFromSchedule",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.2.operating.programs.forcedLastFromSchedule",
+                        "timestamp": "2021-01-01T16:03:22.423Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.sensors.pressure"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.sensors.pressure"
+                }
+            ],
+            "class": [
+                "heating.sensors.pressure",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.sensors.pressure",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.sensors.pressure",
+                        "timestamp": "2021-01-01T16:03:21.717Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#supply",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-supply",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.sensors.pressure.supply"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "supply"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.gas.consumption"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.gas.consumption"
+                }
+            ],
+            "class": [
+                "heating.gas.consumption",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.gas.consumption",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.gas.consumption",
+                        "timestamp": "2021-01-01T16:03:21.717Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#dhw",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-dhw",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.gas.consumption.dhw"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#heating",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-heating",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.gas.consumption.heating"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#total",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-total",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.gas.consumption.total"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "dhw",
+                            "heating",
+                            "total"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.sensors.temperature.room"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.sensors.temperature.room"
+                }
+            ],
+            "class": [
+                "heating.circuits.2.sensors.temperature.room",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.sensors.temperature.room",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.2.sensors.temperature.room",
+                        "timestamp": "2021-01-01T16:03:22.466Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.modes"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.modes"
+                }
+            ],
+            "class": [
+                "heating.circuits.3.operating.modes",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.modes",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.3.operating.modes",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#active",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-active",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.modes.active"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#dhw",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-dhw",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.modes.dhw"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#dhwAndHeating",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-dhwAndHeating",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.modes.dhwAndHeating"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#heating",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-heating",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.modes.heating"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#standby",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-standby",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.modes.standby"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "active",
+                            "dhw",
+                            "dhwAndHeating",
+                            "heating",
+                            "standby"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3"
+                }
+            ],
+            "class": [
+                "heating.circuits.3",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.3",
+                        "timestamp": "2021-01-01T16:03:22.237Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#circulation",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-circulation",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.circulation"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#frostprotection",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-frostprotection",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.frostprotection"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#heating",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-heating",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.heating"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#operating",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-operating",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#sensors",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-sensors",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.sensors"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "circulation",
+                            "frostprotection",
+                            "heating",
+                            "operating",
+                            "sensors"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.modes.dhwAndHeating"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.modes.dhwAndHeating"
+                }
+            ],
+            "class": [
+                "heating.circuits.3.operating.modes.dhwAndHeating",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.modes.dhwAndHeating",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.3.operating.modes.dhwAndHeating",
+                        "timestamp": "2021-01-01T16:03:22.443Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.sensors.temperature.supply"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.sensors.temperature.supply"
+                }
+            ],
+            "class": [
+                "heating.circuits.0.sensors.temperature.supply",
+                "feature"
+            ],
+            "properties": {
+                "value": {
+                    "value": 41.9,
+                    "type": "number"
+                },
+                "status": {
+                    "value": "connected",
+                    "type": "string"
+                },
+                "unit": {
+                    "value": "celsius",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.sensors.temperature.supply",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.0.sensors.temperature.supply",
+                        "timestamp": "2021-01-01T22:43:35.636Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.sensors"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.sensors"
+                }
+            ],
+            "class": [
+                "heating.solar.sensors",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.sensors",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.solar.sensors",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#temperature",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-temperature",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.sensors.temperature"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "temperature"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.active"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.active"
+                }
+            ],
+            "class": [
+                "heating.circuits.1.operating.programs.active",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.active",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.1.operating.programs.active",
+                        "timestamp": "2021-01-01T16:03:22.320Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.sensors.temperature.outside"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.sensors.temperature.outside"
+                }
+            ],
+            "class": [
+                "heating.sensors.temperature.outside",
+                "feature"
+            ],
+            "properties": {
+                "value": {
+                    "value": 2.9,
+                    "type": "number"
+                },
+                "status": {
+                    "value": "connected",
+                    "type": "string"
+                },
+                "unit": {
+                    "value": "celsius",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.sensors.temperature.outside",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.sensors.temperature.outside",
+                        "timestamp": "2021-01-01T22:43:50.853Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.normal"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.normal"
+                }
+            ],
+            "class": [
+                "heating.circuits.0.operating.programs.normal",
+                "feature"
+            ],
+            "properties": {
+                "active": {
+                    "value": true,
+                    "type": "boolean"
+                },
+                "demand": {
+                    "value": "unknown",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.normal",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.0.operating.programs.normal",
+                        "timestamp": "2021-01-01T16:03:22.362Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "method": "POST",
+                    "isExecutable": true,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.normal/setTemperature",
+                    "name": "setTemperature",
+                    "title": "setTemperature",
+                    "fields": [
+                        {
+                            "name": "targetTemperature",
+                            "type": "number",
+                            "required": true,
+                            "min": 3,
+                            "max": 37,
+                            "stepping": 1
+                        }
+                    ],
+                    "type": "application/json"
+                }
+            ]
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.comfort"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.comfort"
+                }
+            ],
+            "class": [
+                "heating.circuits.0.operating.programs.comfort",
+                "feature"
+            ],
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                },
+                "demand": {
+                    "value": "unknown",
+                    "type": "string"
+                },
+                "temperature": {
+                    "value": 24,
+                    "type": "number"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.comfort",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.0.operating.programs.comfort",
+                        "timestamp": "2021-01-01T16:03:22.366Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "method": "POST",
+                    "isExecutable": true,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.comfort/setTemperature",
+                    "name": "setTemperature",
+                    "title": "setTemperature",
+                    "fields": [
+                        {
+                            "name": "targetTemperature",
+                            "type": "number",
+                            "required": true,
+                            "min": 3,
+                            "max": 37,
+                            "stepping": 1
+                        }
+                    ],
+                    "type": "application/json"
+                },
+                {
+                    "method": "POST",
+                    "isExecutable": false,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.comfort/activate",
+                    "name": "activate",
+                    "title": "activate",
+                    "fields": [
+                        {
+                            "name": "temperature",
+                            "type": "number",
+                            "required": false,
+                            "min": 3,
+                            "max": 37,
+                            "stepping": 1
+                        }
+                    ],
+                    "type": "application/json"
+                },
+                {
+                    "method": "POST",
+                    "isExecutable": false,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.comfort/deactivate",
+                    "name": "deactivate",
+                    "title": "deactivate",
+                    "fields": [],
+                    "type": "application/json"
+                }
+            ]
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.power.consumption.dhw"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.power.consumption.dhw"
+                }
+            ],
+            "class": [
+                "heating.power.consumption.dhw",
+                "feature"
+            ],
+            "properties": {
+                "day": {
+                    "value": [
+                        0,
+                        0,
+                        0.2,
+                        0.2,
+                        0.2,
+                        0.2,
+                        0.3,
+                        0.2
+                    ],
+                    "type": "array"
+                },
+                "week": {
+                    "value": [
+                        0.6000000000000001,
+                        1.4999999999999998,
+                        1.4,
+                        1.4
+                    ],
+                    "type": "array"
+                },
+                "month": {
+                    "value": [
+                        0,
+                        7.4,
+                        7,
+                        7.4,
+                        6.1,
+                        5.8,
+                        5.9,
+                        5.9,
+                        6.2,
+                        4.4,
+                        0,
+                        0,
+                        0
+                    ],
+                    "type": "array"
+                },
+                "year": {
+                    "value": [
+                        0,
+                        56.4
+                    ],
+                    "type": "array"
+                },
+                "unit": {
+                    "value": "kilowattHour",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.power.consumption.dhw",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.power.consumption.dhw",
+                        "timestamp": "2021-01-01T22:03:27.080Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.operating"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.operating"
+                }
+            ],
+            "class": [
+                "heating.operating",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.operating",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.operating",
+                        "timestamp": "2021-01-01T16:03:21.717Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#programs",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-programs",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.operating.programs"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "programs"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.power.production"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.power.production"
+                }
+            ],
+            "class": [
+                "heating.solar.power.production",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.power.production",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.solar.power.production",
+                        "timestamp": "2021-01-01T22:03:27.098Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.modes.heating"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.modes.heating"
+                }
+            ],
+            "class": [
+                "heating.circuits.2.operating.modes.heating",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.modes.heating",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.2.operating.modes.heating",
+                        "timestamp": "2021-01-01T16:03:22.449Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
+                }
+            ],
+            "class": [
+                "heating.boiler.sensors.temperature.commonSupply",
+                "feature"
+            ],
+            "properties": {
+                "value": {
+                    "value": 41.9,
+                    "type": "number"
+                },
+                "status": {
+                    "value": "connected",
+                    "type": "string"
+                },
+                "unit": {
+                    "value": "celsius",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.boiler.sensors.temperature.commonSupply",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.boiler.sensors.temperature.commonSupply",
+                        "timestamp": "2021-01-01T22:43:38.637Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.normal"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.normal"
+                }
+            ],
+            "class": [
+                "heating.circuits.2.operating.programs.normal",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.normal",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.2.operating.programs.normal",
+                        "timestamp": "2021-01-01T16:03:22.275Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.modes.active"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.modes.active"
+                }
+            ],
+            "class": [
+                "heating.circuits.2.operating.modes.active",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.modes.active",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.2.operating.modes.active",
+                        "timestamp": "2021-01-01T16:03:22.407Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.power.consumption.total"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.power.consumption.total"
+                }
+            ],
+            "class": [
+                "heating.power.consumption.total",
+                "feature"
+            ],
+            "properties": {
+                "day": {
+                    "value": [
+                        1,
+                        0.9,
+                        1.1,
+                        1.2,
+                        1.2,
+                        1.1,
+                        1.2,
+                        1.2
+                    ],
+                    "type": "array"
+                },
+                "week": {
+                    "value": [
+                        5.4,
+                        7.999999999999999,
+                        7.9,
+                        8.4
+                    ],
+                    "type": "array"
+                },
+                "month": {
+                    "value": [
+                        1,
+                        38.7,
+                        37.2,
+                        36.7,
+                        32.4,
+                        23.8,
+                        27.5,
+                        27.799999999999997,
+                        34.800000000000004,
+                        24.200000000000003,
+                        0,
+                        0,
+                        0
+                    ],
+                    "type": "array"
+                },
+                "year": {
+                    "value": [
+                        1,
+                        284
+                    ],
+                    "type": "array"
+                },
+                "unit": {
+                    "value": "kilowattHour",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.power.consumption.total",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.power.consumption.total",
+                        "timestamp": "2021-01-01T22:03:27.121Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.circulation.pump"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.circulation.pump"
+                }
+            ],
+            "class": [
+                "heating.circuits.0.circulation.pump",
+                "feature"
+            ],
+            "properties": {
+                "status": {
+                    "value": "on",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.circulation.pump",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.0.circulation.pump",
+                        "timestamp": "2021-01-01T16:03:22.326Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.operating.programs.holidayAtHome"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.operating.programs.holidayAtHome"
+                }
+            ],
+            "class": [
+                "heating.operating.programs.holidayAtHome",
+                "feature"
+            ],
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                },
+                "start": {
+                    "value": "",
+                    "type": "string"
+                },
+                "end": {
+                    "value": "",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.operating.programs.holidayAtHome",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.operating.programs.holidayAtHome",
+                        "timestamp": "2021-01-01T16:03:22.521Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "method": "POST",
+                    "isExecutable": false,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.operating.programs.holidayAtHome/changeEndDate",
+                    "name": "changeEndDate",
+                    "title": "changeEndDate",
+                    "fields": [
+                        {
+                            "name": "end",
+                            "type": "string",
+                            "required": true,
+                            "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
+                            "sameDayAllowed": true
+                        }
+                    ],
+                    "type": "application/json"
+                },
+                {
+                    "method": "POST",
+                    "isExecutable": true,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.operating.programs.holidayAtHome/schedule",
+                    "name": "schedule",
+                    "title": "schedule",
+                    "fields": [
+                        {
+                            "name": "start",
+                            "type": "string",
+                            "required": true,
+                            "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$"
+                        },
+                        {
+                            "name": "end",
+                            "type": "string",
+                            "required": true,
+                            "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
+                            "sameDayAllowed": true
+                        }
+                    ],
+                    "type": "application/json"
+                },
+                {
+                    "method": "POST",
+                    "isExecutable": true,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.operating.programs.holidayAtHome/unschedule",
+                    "name": "unschedule",
+                    "title": "unschedule",
+                    "fields": [],
+                    "type": "application/json"
+                }
+            ]
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.sensors.temperature.supply"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.sensors.temperature.supply"
+                }
+            ],
+            "class": [
+                "heating.circuits.2.sensors.temperature.supply",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.sensors.temperature.supply",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.2.sensors.temperature.supply",
+                        "timestamp": "2021-01-01T16:03:22.473Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule"
+                }
+            ],
+            "class": [
+                "heating.circuits.0.operating.programs.forcedLastFromSchedule",
+                "feature"
+            ],
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.0.operating.programs.forcedLastFromSchedule",
+                        "timestamp": "2021-01-01T16:03:22.429Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "method": "POST",
+                    "isExecutable": true,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule/activate",
+                    "name": "activate",
+                    "title": "activate",
+                    "fields": [],
+                    "type": "application/json"
+                },
+                {
+                    "method": "POST",
+                    "isExecutable": false,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule/deactivate",
+                    "name": "deactivate",
+                    "title": "deactivate",
+                    "fields": [],
+                    "type": "application/json"
+                }
+            ]
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.sensors"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.sensors"
+                }
+            ],
+            "class": [
+                "heating.circuits.2.sensors",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.sensors",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.2.sensors",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#temperature",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-temperature",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.sensors.temperature"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "temperature"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.sensors.temperature"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.sensors.temperature"
+                }
+            ],
+            "class": [
+                "heating.solar.sensors.temperature",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.sensors.temperature",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.solar.sensors.temperature",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#collector",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-collector",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.sensors.temperature.collector"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#dhw",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-dhw",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.sensors.temperature.dhw"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "collector",
+                            "dhw"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits"
+                }
+            ],
+            "class": [
+                "heating.circuits",
+                "feature"
+            ],
+            "properties": {
+                "enabled": {
+                    "value": [
+                        "0"
+                    ],
+                    "type": "array"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits",
+                        "timestamp": "2021-01-01T16:03:22.238Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#0",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-0",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#1",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-1",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#2",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-2",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#3",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-3",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "0",
+                            "1",
+                            "2",
+                            "3"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs"
+                }
+            ],
+            "class": [
+                "heating.circuits.0.operating.programs",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.0.operating.programs",
+                        "timestamp": "2021-01-01T16:03:21.717Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#active",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-active",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.active"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#comfort",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-comfort",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.comfort"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#forcedLastFromSchedule",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-forcedLastFromSchedule",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#holiday",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-holiday",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.holiday"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#holidayAtHome",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-holidayAtHome",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.holidayAtHome"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#normal",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-normal",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.normal"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#reduced",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-reduced",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.reduced"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#standby",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-standby",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.standby"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "active",
+                            "comfort",
+                            "forcedLastFromSchedule",
+                            "holiday",
+                            "holidayAtHome",
+                            "normal",
+                            "reduced",
+                            "standby"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.circulation"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.circulation"
+                }
+            ],
+            "class": [
+                "heating.circuits.0.circulation",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.circulation",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.0.circulation",
+                        "timestamp": "2021-01-01T16:03:21.717Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#pump",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-pump",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.circulation.pump"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#schedule",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-schedule",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.circulation.schedule"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "pump",
+                            "schedule"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.power.consumption"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.power.consumption"
+                }
+            ],
+            "class": [
+                "heating.power.consumption",
+                "feature"
+            ],
+            "properties": {
+                "day": {
+                    "value": [
+                        1,
+                        0.9,
+                        1.1,
+                        1.2,
+                        1.2,
+                        1.1,
+                        1.2,
+                        1.2
+                    ],
+                    "type": "array"
+                },
+                "week": {
+                    "value": [
+                        5.4,
+                        7.999999999999999,
+                        7.9,
+                        8.4
+                    ],
+                    "type": "array"
+                },
+                "month": {
+                    "value": [
+                        1,
+                        38.7,
+                        37.2,
+                        36.7,
+                        32.4,
+                        23.8,
+                        27.5,
+                        27.799999999999997,
+                        34.800000000000004,
+                        24.200000000000003,
+                        0,
+                        0,
+                        0
+                    ],
+                    "type": "array"
+                },
+                "year": {
+                    "value": [
+                        1,
+                        284
+                    ],
+                    "type": "array"
+                },
+                "unit": {
+                    "value": "kilowattHour",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.power.consumption",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.power.consumption",
+                        "timestamp": "2021-01-01T22:03:27.119Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#dhw",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-dhw",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.power.consumption.dhw"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#heating",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-heating",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.power.consumption.heating"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#total",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-total",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.power.consumption.total"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "dhw",
+                            "heating",
+                            "total"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.circulation.pump"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.circulation.pump"
+                }
+            ],
+            "class": [
+                "heating.circuits.3.circulation.pump",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.circulation.pump",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.3.circulation.pump",
+                        "timestamp": "2021-01-01T16:03:22.122Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.holidayAtHome"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.holidayAtHome"
+                }
+            ],
+            "class": [
+                "heating.circuits.2.operating.programs.holidayAtHome",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.holidayAtHome",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.2.operating.programs.holidayAtHome",
+                        "timestamp": "2021-01-01T16:03:22.396Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.forcedLastFromSchedule"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.forcedLastFromSchedule"
+                }
+            ],
+            "class": [
+                "heating.circuits.3.operating.programs.forcedLastFromSchedule",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.forcedLastFromSchedule",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.3.operating.programs.forcedLastFromSchedule",
+                        "timestamp": "2021-01-01T16:03:22.425Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.modes.standby"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.modes.standby"
+                }
+            ],
+            "class": [
+                "heating.circuits.2.operating.modes.standby",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.modes.standby",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.2.operating.modes.standby",
+                        "timestamp": "2021-01-01T16:03:22.416Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.configuration"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.configuration"
+                }
+            ],
+            "class": [
+                "heating.configuration",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.configuration",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.configuration",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#multiFamilyHouse",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-multiFamilyHouse",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.configuration.multiFamilyHouse"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#regulation",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-regulation",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.configuration.regulation"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "multiFamilyHouse",
+                            "regulation"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.gas.consumption.total"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.gas.consumption.total"
+                }
+            ],
+            "class": [
+                "heating.gas.consumption.total",
+                "feature"
+            ],
+            "properties": {
+                "day": {
+                    "value": [
+                        3.4,
+                        2.6,
+                        8,
+                        10.899999999999999,
+                        11.600000000000001,
+                        10.9,
+                        10.3,
+                        9.2
+                    ],
+                    "type": "array"
+                },
+                "week": {
+                    "value": [
+                        36.5,
+                        62.800000000000004,
+                        59.2,
+                        83.10000000000001
+                    ],
+                    "type": "array"
+                },
+                "month": {
+                    "value": [
+                        3.4,
+                        316.3,
+                        273.4,
+                        212,
+                        102.69999999999999,
+                        42.400000000000006,
+                        48,
+                        61.8,
+                        133.5,
+                        97.9,
+                        0,
+                        0,
+                        0
+                    ],
+                    "type": "array"
+                },
+                "year": {
+                    "value": [
+                        3.4,
+                        1288.6
+                    ],
+                    "type": "array"
+                },
+                "unit": {
+                    "value": "cubicMeter",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.gas.consumption.total",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.gas.consumption.total",
+                        "timestamp": "2021-01-01T22:03:27.115Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.comfort"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.comfort"
+                }
+            ],
+            "class": [
+                "heating.circuits.3.operating.programs.comfort",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.comfort",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.3.operating.programs.comfort",
+                        "timestamp": "2021-01-01T16:03:22.372Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.standby"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.standby"
+                }
+            ],
+            "class": [
+                "heating.circuits.3.operating.programs.standby",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.standby",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.3.operating.programs.standby",
+                        "timestamp": "2021-01-01T16:03:22.350Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.flue.sensors.temperature"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.flue.sensors.temperature"
+                }
+            ],
+            "class": [
+                "heating.flue.sensors.temperature",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.flue.sensors.temperature",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.flue.sensors.temperature",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#main",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-main",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.flue.sensors.temperature.main"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "main"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.sensors"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.sensors"
+                }
+            ],
+            "class": [
+                "heating.sensors",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.sensors",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.sensors",
+                        "timestamp": "2021-01-01T16:03:21.717Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#pressure",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-pressure",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.sensors.pressure"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#temperature",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-temperature",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.sensors.temperature"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "pressure",
+                            "temperature"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.operating.programs"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.operating.programs"
+                }
+            ],
+            "class": [
+                "heating.operating.programs",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.operating.programs",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.operating.programs",
+                        "timestamp": "2021-01-01T16:03:21.717Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#holiday",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-holiday",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.operating.programs.holiday"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#holidayAtHome",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-holidayAtHome",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.operating.programs.holidayAtHome"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "holiday",
+                            "holidayAtHome"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.standby"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.standby"
+                }
+            ],
+            "class": [
+                "heating.circuits.0.operating.programs.standby",
+                "feature"
+            ],
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.standby",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.0.operating.programs.standby",
+                        "timestamp": "2021-01-01T16:03:22.341Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.device.time"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.device.time"
+                }
+            ],
+            "class": [
+                "heating.device.time",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.device.time",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.device.time",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#offset",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-offset",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.device.time.offset"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "offset"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.heat"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.heat"
+                }
+            ],
+            "class": [
+                "heating.heat",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.heat",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.heat",
+                        "timestamp": "2021-01-01T16:03:21.717Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#production",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-production",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.heat.production"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "production"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.oneTimeCharge"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.oneTimeCharge"
+                }
+            ],
+            "class": [
+                "heating.dhw.oneTimeCharge",
+                "feature"
+            ],
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.oneTimeCharge",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.dhw.oneTimeCharge",
+                        "timestamp": "2021-01-01T16:03:22.457Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "method": "POST",
+                    "isExecutable": true,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.oneTimeCharge/activate",
+                    "name": "activate",
+                    "title": "activate",
+                    "fields": [],
+                    "type": "application/json"
+                },
+                {
+                    "method": "POST",
+                    "isExecutable": false,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.oneTimeCharge/deactivate",
+                    "name": "deactivate",
+                    "title": "deactivate",
+                    "fields": [],
+                    "type": "application/json"
+                }
+            ]
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.rechargeSuppression"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.rechargeSuppression"
+                }
+            ],
+            "class": [
+                "heating.solar.rechargeSuppression",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.rechargeSuppression",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.solar.rechargeSuppression",
+                        "timestamp": "2021-01-01T16:03:22.313Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating"
+                }
+            ],
+            "class": [
+                "heating.circuits.0.operating.modes.dhwAndHeating",
+                "feature"
+            ],
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.0.operating.modes.dhwAndHeating",
+                        "timestamp": "2021-01-01T16:03:22.438Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.reduced"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.reduced"
+                }
+            ],
+            "class": [
+                "heating.circuits.2.operating.programs.reduced",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.reduced",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.2.operating.programs.reduced",
+                        "timestamp": "2021-01-01T16:03:22.358Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.circulation.schedule"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.circulation.schedule"
+                }
+            ],
+            "class": [
+                "heating.circuits.0.circulation.schedule",
+                "feature"
+            ],
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                },
+                "entries": {
+                    "value": {
+                        "mon": [
+                            {
+                                "mode": "on",
+                                "start": "05:30",
+                                "end": "08:00",
+                                "position": 0
+                            },
+                            {
+                                "mode": "on",
+                                "start": "11:30",
+                                "end": "13:00",
+                                "position": 1
+                            },
+                            {
+                                "mode": "on",
+                                "start": "16:30",
+                                "end": "22:00",
+                                "position": 2
+                            }
+                        ],
+                        "tue": [
+                            {
+                                "mode": "on",
+                                "start": "05:30",
+                                "end": "08:00",
+                                "position": 0
+                            },
+                            {
+                                "mode": "on",
+                                "start": "11:30",
+                                "end": "13:00",
+                                "position": 1
+                            },
+                            {
+                                "mode": "on",
+                                "start": "16:30",
+                                "end": "22:00",
+                                "position": 2
+                            }
+                        ],
+                        "wed": [
+                            {
+                                "mode": "on",
+                                "start": "05:30",
+                                "end": "08:00",
+                                "position": 0
+                            },
+                            {
+                                "mode": "on",
+                                "start": "11:30",
+                                "end": "13:00",
+                                "position": 1
+                            },
+                            {
+                                "mode": "on",
+                                "start": "16:30",
+                                "end": "22:00",
+                                "position": 2
+                            }
+                        ],
+                        "thu": [
+                            {
+                                "mode": "on",
+                                "start": "05:30",
+                                "end": "08:00",
+                                "position": 0
+                            },
+                            {
+                                "mode": "on",
+                                "start": "11:30",
+                                "end": "13:00",
+                                "position": 1
+                            },
+                            {
+                                "mode": "on",
+                                "start": "16:30",
+                                "end": "22:00",
+                                "position": 2
+                            }
+                        ],
+                        "fri": [
+                            {
+                                "mode": "on",
+                                "start": "05:30",
+                                "end": "08:00",
+                                "position": 0
+                            },
+                            {
+                                "mode": "on",
+                                "start": "11:30",
+                                "end": "13:00",
+                                "position": 1
+                            },
+                            {
+                                "mode": "on",
+                                "start": "16:30",
+                                "end": "22:00",
+                                "position": 2
+                            }
+                        ],
+                        "sat": [
+                            {
+                                "mode": "on",
+                                "start": "06:30",
+                                "end": "09:30",
+                                "position": 0
+                            },
+                            {
+                                "mode": "on",
+                                "start": "11:30",
+                                "end": "13:00",
+                                "position": 1
+                            },
+                            {
+                                "mode": "on",
+                                "start": "16:30",
+                                "end": "22:00",
+                                "position": 2
+                            }
+                        ],
+                        "sun": [
+                            {
+                                "mode": "on",
+                                "start": "06:30",
+                                "end": "09:30",
+                                "position": 0
+                            },
+                            {
+                                "mode": "on",
+                                "start": "11:30",
+                                "end": "13:00",
+                                "position": 1
+                            },
+                            {
+                                "mode": "on",
+                                "start": "16:30",
+                                "end": "22:00",
+                                "position": 2
+                            }
+                        ]
+                    },
+                    "type": "Schedule"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.circulation.schedule",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.0.circulation.schedule",
+                        "timestamp": "2021-01-01T16:03:22.511Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "method": "POST",
+                    "isExecutable": true,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.circulation.schedule/setSchedule",
+                    "name": "setSchedule",
+                    "title": "setSchedule",
+                    "fields": [
+                        {
+                            "name": "newSchedule",
+                            "type": "Schedule",
+                            "required": true,
+                            "modes": [
+                                "on"
+                            ],
+                            "maxEntries": 4,
+                            "resolution": 10,
+                            "defaultMode": "off",
+                            "overlapAllowed": false
+                        }
+                    ],
+                    "type": "application/json"
+                }
+            ]
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.boiler.temperature"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.boiler.temperature"
+                }
+            ],
+            "class": [
+                "heating.boiler.temperature",
+                "feature"
+            ],
+            "properties": {
+                "value": {
+                    "value": 20,
+                    "type": "number"
+                },
+                "unit": {
+                    "value": "celsius",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.boiler.temperature",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.boiler.temperature",
+                        "timestamp": "2021-01-01T16:03:21.973Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.temperature.main"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.temperature.main"
+                }
+            ],
+            "class": [
+                "heating.dhw.temperature.main",
+                "feature"
+            ],
+            "properties": {
+                "value": {
+                    "value": 55,
+                    "type": "number"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.temperature.main",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.dhw.temperature.main",
+                        "timestamp": "2021-01-01T16:03:22.274Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "method": "POST",
+                    "isExecutable": true,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.temperature.main/setTargetTemperature",
+                    "name": "setTargetTemperature",
+                    "title": "setTargetTemperature",
+                    "fields": [
+                        {
+                            "name": "temperature",
+                            "type": "number",
+                            "required": true,
+                            "min": 10,
+                            "efficientLowerBorder": 10,
+                            "efficientUpperBorder": 60,
+                            "max": 60,
+                            "stepping": 1
+                        }
+                    ],
+                    "type": "application/json"
+                }
+            ]
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.gas.consumption.dhw"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.gas.consumption.dhw"
+                }
+            ],
+            "class": [
+                "heating.gas.consumption.dhw",
+                "feature"
+            ],
+            "properties": {
+                "day": {
+                    "value": [
+                        0,
+                        0.8,
+                        2.5,
+                        2.3,
+                        2.7,
+                        2.5,
+                        3,
+                        2.6
+                    ],
+                    "type": "array"
+                },
+                "week": {
+                    "value": [
+                        8.3,
+                        18.1,
+                        15.500000000000002,
+                        16.5
+                    ],
+                    "type": "array"
+                },
+                "month": {
+                    "value": [
+                        0,
+                        74.5,
+                        68.9,
+                        70.7,
+                        36.6,
+                        33.1,
+                        34.1,
+                        35,
+                        35.6,
+                        26.6,
+                        0,
+                        0,
+                        0
+                    ],
+                    "type": "array"
+                },
+                "year": {
+                    "value": [
+                        0,
+                        415.4
+                    ],
+                    "type": "array"
+                },
+                "unit": {
+                    "value": "cubicMeter",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.gas.consumption.dhw",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.gas.consumption.dhw",
+                        "timestamp": "2021-01-01T22:03:27.069Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.modes.dhw"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.modes.dhw"
+                }
+            ],
+            "class": [
+                "heating.circuits.1.operating.modes.dhw",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.modes.dhw",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.1.operating.modes.dhw",
+                        "timestamp": "2021-01-01T16:03:22.484Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.normal"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.normal"
+                }
+            ],
+            "class": [
+                "heating.circuits.3.operating.programs.normal",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.normal",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.3.operating.programs.normal",
+                        "timestamp": "2021-01-01T16:03:22.277Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.modes.heating"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.modes.heating"
+                }
+            ],
+            "class": [
+                "heating.circuits.3.operating.modes.heating",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.modes.heating",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.3.operating.modes.heating",
+                        "timestamp": "2021-01-01T16:03:22.452Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule"
+                }
+            ],
+            "class": [
+                "heating.circuits.1.operating.programs.forcedLastFromSchedule",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.1.operating.programs.forcedLastFromSchedule",
+                        "timestamp": "2021-01-01T16:03:22.432Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.sensors.temperature.supply"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.sensors.temperature.supply"
+                }
+            ],
+            "class": [
+                "heating.circuits.1.sensors.temperature.supply",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.sensors.temperature.supply",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.1.sensors.temperature.supply",
+                        "timestamp": "2021-01-01T16:03:22.471Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.sensors.temperature"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.sensors.temperature"
+                }
+            ],
+            "class": [
+                "heating.sensors.temperature",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.sensors.temperature",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.sensors.temperature",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#outside",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-outside",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.sensors.temperature.outside"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "outside"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1"
+                }
+            ],
+            "class": [
+                "heating.circuits.1",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.1",
+                        "timestamp": "2021-01-01T16:03:22.182Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#circulation",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-circulation",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.circulation"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#frostprotection",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-frostprotection",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.frostprotection"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#heating",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-heating",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.heating"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#operating",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-operating",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#sensors",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-sensors",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.sensors"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "circulation",
+                            "frostprotection",
+                            "heating",
+                            "operating",
+                            "sensors"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.reduced"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.reduced"
+                }
+            ],
+            "class": [
+                "heating.circuits.0.operating.programs.reduced",
+                "feature"
+            ],
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                },
+                "demand": {
+                    "value": "unknown",
+                    "type": "string"
+                },
+                "temperature": {
+                    "value": 18,
+                    "type": "number"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.reduced",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.0.operating.programs.reduced",
+                        "timestamp": "2021-01-01T16:03:22.353Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "method": "POST",
+                    "isExecutable": true,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.reduced/setTemperature",
+                    "name": "setTemperature",
+                    "title": "setTemperature",
+                    "fields": [
+                        {
+                            "name": "targetTemperature",
+                            "type": "number",
+                            "required": true,
+                            "min": 3,
+                            "max": 37,
+                            "stepping": 1
+                        }
+                    ],
+                    "type": "application/json"
+                }
+            ]
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.circulation"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.circulation"
+                }
+            ],
+            "class": [
+                "heating.circuits.2.circulation",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.circulation",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.2.circulation",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#pump",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-pump",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.circulation.pump"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "pump"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar"
+                }
+            ],
+            "class": [
+                "heating.solar",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.solar",
+                        "timestamp": "2021-01-01T16:03:22.311Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#power",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-power",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.power"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#rechargeSuppression",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-rechargeSuppression",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.rechargeSuppression"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#sensors",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-sensors",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.sensors"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#statistics",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-statistics",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.statistics"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "power",
+                            "rechargeSuppression",
+                            "sensors",
+                            "statistics"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.power"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.power"
+                }
+            ],
+            "class": [
+                "heating.solar.power",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.power",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.solar.power",
+                        "timestamp": "2021-01-01T16:03:21.717Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#production",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-production",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.power.production"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "production"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.holidayAtHome"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.holidayAtHome"
+                }
+            ],
+            "class": [
+                "heating.circuits.1.operating.programs.holidayAtHome",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.holidayAtHome",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.1.operating.programs.holidayAtHome",
+                        "timestamp": "2021-01-01T16:03:22.391Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.errors.history"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.errors.history"
+                }
+            ],
+            "class": [
+                "heating.errors.history",
+                "feature"
+            ],
+            "properties": {
+                "entries": {
+                    "type": "ErrorListChanges",
+                    "constraints": {},
+                    "value": {
+                        "new": [],
+                        "current": [],
+                        "gone": []
+                    }
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.errors.history",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.errors.history",
+                        "timestamp": "2021-01-01T22:03:27.067Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.heating"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.heating"
+                }
+            ],
+            "class": [
+                "heating.circuits.1.heating",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.heating",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.1.heating",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#curve",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-curve",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.heating.curve"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#schedule",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-schedule",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.heating.schedule"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "curve",
+                            "schedule"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.sensors.temperature"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.sensors.temperature"
+                }
+            ],
+            "class": [
+                "heating.dhw.sensors.temperature",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.sensors.temperature",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.dhw.sensors.temperature",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#hotWaterStorage",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-hotWaterStorage",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#outlet",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-outlet",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.sensors.temperature.outlet"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "hotWaterStorage",
+                            "outlet"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.modes.active"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.modes.active"
+                }
+            ],
+            "class": [
+                "heating.circuits.1.operating.modes.active",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.modes.active",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.1.operating.modes.active",
+                        "timestamp": "2021-01-01T16:03:22.431Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.heating.curve"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.heating.curve"
+                }
+            ],
+            "class": [
+                "heating.circuits.0.heating.curve",
+                "feature"
+            ],
+            "properties": {
+                "shift": {
+                    "type": "number",
+                    "value": 3
+                },
+                "slope": {
+                    "type": "number",
+                    "value": 1.5
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.heating.curve",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.0.heating.curve",
+                        "timestamp": "2021-01-01T22:17:08.499Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "method": "POST",
+                    "isExecutable": true,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.heating.curve/setCurve",
+                    "name": "setCurve",
+                    "title": "setCurve",
+                    "fields": [
+                        {
+                            "name": "slope",
+                            "type": "number",
+                            "required": true,
+                            "min": 0.2,
+                            "max": 3.5,
+                            "stepping": 0.1
+                        },
+                        {
+                            "name": "shift",
+                            "type": "number",
+                            "required": true,
+                            "min": -13,
+                            "max": 40,
+                            "stepping": 1
+                        }
+                    ],
+                    "type": "application/json"
+                }
+            ]
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.holiday"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.holiday"
+                }
+            ],
+            "class": [
+                "heating.circuits.1.operating.programs.holiday",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.holiday",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.1.operating.programs.holiday",
+                        "timestamp": "2021-01-01T16:03:22.377Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.heating"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.heating"
+                }
+            ],
+            "class": [
+                "heating.circuits.0.heating",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.heating",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.0.heating",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#curve",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-curve",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.heating.curve"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#schedule",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-schedule",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.heating.schedule"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "curve",
+                            "schedule"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.burner.modulation"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.burner.modulation"
+                }
+            ],
+            "class": [
+                "heating.burner.modulation",
+                "feature"
+            ],
+            "properties": {
+                "value": {
+                    "value": 0,
+                    "type": "number"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.burner.modulation",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.burner.modulation",
+                        "timestamp": "2021-01-01T22:37:16.850Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.burner"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.burner"
+                }
+            ],
+            "class": [
+                "heating.burner",
+                "feature"
+            ],
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.burner",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.burner",
+                        "timestamp": "2021-01-01T22:37:14.218Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#modulation",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-modulation",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.burner.modulation"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#statistics",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-statistics",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.burner.statistics"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "modulation",
+                            "statistics"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.standby"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.standby"
+                }
+            ],
+            "class": [
+                "heating.circuits.2.operating.programs.standby",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.standby",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.2.operating.programs.standby",
+                        "timestamp": "2021-01-01T16:03:22.345Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeating"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeating"
+                }
+            ],
+            "class": [
+                "heating.circuits.2.operating.modes.dhwAndHeating",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeating",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.2.operating.modes.dhwAndHeating",
+                        "timestamp": "2021-01-01T16:03:22.441Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0"
+                }
+            ],
+            "class": [
+                "heating.circuits.0",
+                "feature"
+            ],
+            "properties": {
+                "active": {
+                    "value": true,
+                    "type": "boolean"
+                },
+                "name": {
+                    "value": "Heizkreis 1",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.0",
+                        "timestamp": "2021-01-01T16:03:22.124Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#circulation",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-circulation",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.circulation"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#frostprotection",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-frostprotection",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.frostprotection"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#heating",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-heating",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.heating"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#operating",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-operating",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#sensors",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-sensors",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.sensors"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "circulation",
+                            "frostprotection",
+                            "heating",
+                            "operating",
+                            "sensors"
+                        ]
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "method": "POST",
+                    "isExecutable": true,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0/setName",
+                    "name": "setName",
+                    "title": "setName",
+                    "fields": [
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "required": true,
+                            "minLength": 1,
+                            "maxLength": 20
+                        }
+                    ],
+                    "type": "application/json"
+                }
+            ]
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.modes"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.modes"
+                }
+            ],
+            "class": [
+                "heating.circuits.1.operating.modes",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.modes",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.1.operating.modes",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#active",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-active",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.modes.active"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#dhw",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-dhw",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.modes.dhw"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#dhwAndHeating",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-dhwAndHeating",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#heating",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-heating",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.modes.heating"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#standby",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-standby",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.modes.standby"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "active",
+                            "dhw",
+                            "dhwAndHeating",
+                            "heating",
+                            "standby"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.burner.statistics"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.burner.statistics"
+                }
+            ],
+            "class": [
+                "heating.burner.statistics",
+                "feature"
+            ],
+            "properties": {
+                "hours": {
+                    "value": 2978,
+                    "type": "number"
+                },
+                "starts": {
+                    "value": 5898,
+                    "type": "number"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.burner.statistics",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.burner.statistics",
+                        "timestamp": "2021-01-01T22:21:35.825Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw"
+                }
+            ],
+            "class": [
+                "heating.dhw",
+                "feature"
+            ],
+            "properties": {
+                "active": {
+                    "value": true,
+                    "type": "boolean"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.dhw",
+                        "timestamp": "2021-01-01T16:03:22.264Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#oneTimeCharge",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-oneTimeCharge",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.oneTimeCharge"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#pumps",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-pumps",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.pumps"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#schedule",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-schedule",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.schedule"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#sensors",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-sensors",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.sensors"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#temperature",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-temperature",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.temperature"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "oneTimeCharge",
+                            "pumps",
+                            "schedule",
+                            "sensors",
+                            "temperature"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.standby"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.standby"
+                }
+            ],
+            "class": [
+                "heating.circuits.1.operating.programs.standby",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.standby",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.1.operating.programs.standby",
+                        "timestamp": "2021-01-01T16:03:22.343Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.reduced"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.reduced"
+                }
+            ],
+            "class": [
+                "heating.circuits.3.operating.programs.reduced",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.reduced",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.3.operating.programs.reduced",
+                        "timestamp": "2021-01-01T16:03:22.361Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.sensors"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.sensors"
+                }
+            ],
+            "class": [
+                "heating.dhw.sensors",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.sensors",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.dhw.sensors",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#temperature",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-temperature",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.sensors.temperature"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "temperature"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs"
+                }
+            ],
+            "class": [
+                "heating.circuits.3.operating.programs",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.3.operating.programs",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#active",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-active",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.active"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#comfort",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-comfort",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.comfort"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#forcedLastFromSchedule",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-forcedLastFromSchedule",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.forcedLastFromSchedule"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#holiday",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-holiday",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.holiday"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#holidayAtHome",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-holidayAtHome",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.holidayAtHome"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#normal",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-normal",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.normal"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#reduced",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-reduced",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.reduced"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#standby",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-standby",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.standby"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "active",
+                            "comfort",
+                            "forcedLastFromSchedule",
+                            "holiday",
+                            "holidayAtHome",
+                            "normal",
+                            "reduced",
+                            "standby"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.holidayAtHome"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.holidayAtHome"
+                }
+            ],
+            "class": [
+                "heating.circuits.3.operating.programs.holidayAtHome",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.holidayAtHome",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.3.operating.programs.holidayAtHome",
+                        "timestamp": "2021-01-01T16:03:22.403Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.frostprotection"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.frostprotection"
+                }
+            ],
+            "class": [
+                "heating.circuits.2.frostprotection",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.frostprotection",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.2.frostprotection",
+                        "timestamp": "2021-01-01T16:03:22.338Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating"
+                }
+            ],
+            "class": [
+                "heating.circuits.2.operating",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.2.operating",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#modes",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-modes",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.modes"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#programs",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-programs",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "modes",
+                            "programs"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.schedule"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.schedule"
+                }
+            ],
+            "class": [
+                "heating.dhw.schedule",
+                "feature"
+            ],
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                },
+                "entries": {
+                    "value": {
+                        "mon": [
+                            {
+                                "mode": "on",
+                                "start": "05:30",
+                                "end": "09:00",
+                                "position": 0
+                            },
+                            {
+                                "mode": "on",
+                                "start": "11:00",
+                                "end": "12:30",
+                                "position": 1
+                            },
+                            {
+                                "mode": "on",
+                                "start": "16:00",
+                                "end": "18:00",
+                                "position": 2
+                            },
+                            {
+                                "mode": "on",
+                                "start": "20:00",
+                                "end": "22:00",
+                                "position": 3
+                            }
+                        ],
+                        "tue": [
+                            {
+                                "mode": "on",
+                                "start": "05:30",
+                                "end": "09:00",
+                                "position": 0
+                            },
+                            {
+                                "mode": "on",
+                                "start": "11:00",
+                                "end": "12:30",
+                                "position": 1
+                            },
+                            {
+                                "mode": "on",
+                                "start": "16:00",
+                                "end": "18:00",
+                                "position": 2
+                            },
+                            {
+                                "mode": "on",
+                                "start": "20:00",
+                                "end": "22:00",
+                                "position": 3
+                            }
+                        ],
+                        "wed": [
+                            {
+                                "mode": "on",
+                                "start": "05:30",
+                                "end": "09:00",
+                                "position": 0
+                            },
+                            {
+                                "mode": "on",
+                                "start": "11:00",
+                                "end": "12:30",
+                                "position": 1
+                            },
+                            {
+                                "mode": "on",
+                                "start": "16:00",
+                                "end": "18:00",
+                                "position": 2
+                            },
+                            {
+                                "mode": "on",
+                                "start": "20:00",
+                                "end": "22:00",
+                                "position": 3
+                            }
+                        ],
+                        "thu": [
+                            {
+                                "mode": "on",
+                                "start": "05:30",
+                                "end": "09:00",
+                                "position": 0
+                            },
+                            {
+                                "mode": "on",
+                                "start": "11:00",
+                                "end": "12:30",
+                                "position": 1
+                            },
+                            {
+                                "mode": "on",
+                                "start": "16:00",
+                                "end": "18:00",
+                                "position": 2
+                            },
+                            {
+                                "mode": "on",
+                                "start": "20:00",
+                                "end": "22:00",
+                                "position": 3
+                            }
+                        ],
+                        "fri": [
+                            {
+                                "mode": "on",
+                                "start": "05:30",
+                                "end": "09:00",
+                                "position": 0
+                            },
+                            {
+                                "mode": "on",
+                                "start": "11:00",
+                                "end": "12:30",
+                                "position": 1
+                            },
+                            {
+                                "mode": "on",
+                                "start": "16:00",
+                                "end": "18:00",
+                                "position": 2
+                            },
+                            {
+                                "mode": "on",
+                                "start": "20:00",
+                                "end": "22:00",
+                                "position": 3
+                            }
+                        ],
+                        "sat": [
+                            {
+                                "mode": "on",
+                                "start": "06:30",
+                                "end": "09:00",
+                                "position": 0
+                            },
+                            {
+                                "mode": "on",
+                                "start": "11:00",
+                                "end": "12:30",
+                                "position": 1
+                            },
+                            {
+                                "mode": "on",
+                                "start": "16:00",
+                                "end": "18:00",
+                                "position": 2
+                            },
+                            {
+                                "mode": "on",
+                                "start": "20:00",
+                                "end": "22:00",
+                                "position": 3
+                            }
+                        ],
+                        "sun": [
+                            {
+                                "mode": "on",
+                                "start": "06:30",
+                                "end": "09:00",
+                                "position": 0
+                            },
+                            {
+                                "mode": "on",
+                                "start": "11:00",
+                                "end": "12:30",
+                                "position": 1
+                            },
+                            {
+                                "mode": "on",
+                                "start": "16:00",
+                                "end": "18:00",
+                                "position": 2
+                            },
+                            {
+                                "mode": "on",
+                                "start": "20:00",
+                                "end": "22:00",
+                                "position": 3
+                            }
+                        ]
+                    },
+                    "type": "Schedule"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.schedule",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.dhw.schedule",
+                        "timestamp": "2021-01-01T16:03:22.496Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "method": "POST",
+                    "isExecutable": true,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.schedule/setSchedule",
+                    "name": "setSchedule",
+                    "title": "setSchedule",
+                    "fields": [
+                        {
+                            "name": "newSchedule",
+                            "type": "Schedule",
+                            "required": true,
+                            "modes": [
+                                "on"
+                            ],
+                            "maxEntries": 4,
+                            "resolution": 10,
+                            "defaultMode": "off",
+                            "overlapAllowed": false
+                        }
+                    ],
+                    "type": "application/json"
+                }
+            ]
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.sensors.temperature.room"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.sensors.temperature.room"
+                }
+            ],
+            "class": [
+                "heating.circuits.3.sensors.temperature.room",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.sensors.temperature.room",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.3.sensors.temperature.room",
+                        "timestamp": "2021-01-01T16:03:22.467Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.pumps"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.pumps"
+                }
+            ],
+            "class": [
+                "heating.dhw.pumps",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.pumps",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.dhw.pumps",
+                        "timestamp": "2021-01-01T16:03:21.717Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#circulation",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-circulation",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.pumps.circulation"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "circulation"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs"
+                }
+            ],
+            "class": [
+                "heating.circuits.1.operating.programs",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.1.operating.programs",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#active",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-active",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.active"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#comfort",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-comfort",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.comfort"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#forcedLastFromSchedule",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-forcedLastFromSchedule",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#holiday",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-holiday",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.holiday"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#holidayAtHome",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-holidayAtHome",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.holidayAtHome"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#normal",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-normal",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.normal"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#reduced",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-reduced",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.reduced"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#standby",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-standby",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.standby"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "active",
+                            "comfort",
+                            "forcedLastFromSchedule",
+                            "holiday",
+                            "holidayAtHome",
+                            "normal",
+                            "reduced",
+                            "standby"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.modes.dhw"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.modes.dhw"
+                }
+            ],
+            "class": [
+                "heating.circuits.3.operating.modes.dhw",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.modes.dhw",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.3.operating.modes.dhw",
+                        "timestamp": "2021-01-01T16:03:22.434Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.reduced"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.reduced"
+                }
+            ],
+            "class": [
+                "heating.circuits.1.operating.programs.reduced",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.reduced",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.1.operating.programs.reduced",
+                        "timestamp": "2021-01-01T16:03:22.355Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.power.consumption.heating"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.power.consumption.heating"
+                }
+            ],
+            "class": [
+                "heating.power.consumption.heating",
+                "feature"
+            ],
+            "properties": {
+                "day": {
+                    "value": [
+                        1,
+                        0.9,
+                        0.9,
+                        1,
+                        1,
+                        0.9,
+                        0.9,
+                        1
+                    ],
+                    "type": "array"
+                },
+                "week": {
+                    "value": [
+                        4.8,
+                        6.5,
+                        6.5,
+                        7
+                    ],
+                    "type": "array"
+                },
+                "month": {
+                    "value": [
+                        1,
+                        31.3,
+                        30.2,
+                        29.3,
+                        26.3,
+                        18,
+                        21.6,
+                        21.9,
+                        28.6,
+                        19.8,
+                        0,
+                        0,
+                        0
+                    ],
+                    "type": "array"
+                },
+                "year": {
+                    "value": [
+                        1,
+                        227.6
+                    ],
+                    "type": "array"
+                },
+                "unit": {
+                    "value": "kilowattHour",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.power.consumption.heating",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.power.consumption.heating",
+                        "timestamp": "2021-01-01T22:03:27.117Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2"
+                }
+            ],
+            "class": [
+                "heating.circuits.2",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.2",
+                        "timestamp": "2021-01-01T16:03:22.208Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#circulation",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-circulation",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.circulation"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#frostprotection",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-frostprotection",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.frostprotection"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#heating",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-heating",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.heating"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#operating",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-operating",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#sensors",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-sensors",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.sensors"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "circulation",
+                            "frostprotection",
+                            "heating",
+                            "operating",
+                            "sensors"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating"
+                }
+            ],
+            "class": [
+                "heating.circuits.1.operating.modes.dhwAndHeating",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.1.operating.modes.dhwAndHeating",
+                        "timestamp": "2021-01-01T16:03:22.440Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.holidayAtHome"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.holidayAtHome"
+                }
+            ],
+            "class": [
+                "heating.circuits.0.operating.programs.holidayAtHome",
+                "feature"
+            ],
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                },
+                "start": {
+                    "value": "",
+                    "type": "string"
+                },
+                "end": {
+                    "value": "",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.holidayAtHome",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.0.operating.programs.holidayAtHome",
+                        "timestamp": "2021-01-01T16:03:22.387Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "method": "POST",
+                    "isExecutable": false,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.holidayAtHome/changeEndDate",
+                    "name": "changeEndDate",
+                    "title": "changeEndDate",
+                    "fields": [
+                        {
+                            "name": "end",
+                            "type": "string",
+                            "required": true,
+                            "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
+                            "sameDayAllowed": true
+                        }
+                    ],
+                    "type": "application/json"
+                },
+                {
+                    "method": "POST",
+                    "isExecutable": true,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.holidayAtHome/schedule",
+                    "name": "schedule",
+                    "title": "schedule",
+                    "fields": [
+                        {
+                            "name": "start",
+                            "type": "string",
+                            "required": true,
+                            "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$"
+                        },
+                        {
+                            "name": "end",
+                            "type": "string",
+                            "required": true,
+                            "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
+                            "sameDayAllowed": true
+                        }
+                    ],
+                    "type": "application/json"
+                },
+                {
+                    "method": "POST",
+                    "isExecutable": true,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.holidayAtHome/unschedule",
+                    "name": "unschedule",
+                    "title": "unschedule",
+                    "fields": [],
+                    "type": "application/json"
+                }
+            ]
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.comfort"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.comfort"
+                }
+            ],
+            "class": [
+                "heating.circuits.1.operating.programs.comfort",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.comfort",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.1.operating.programs.comfort",
+                        "timestamp": "2021-01-01T16:03:22.368Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.sensors.temperature.dhw"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.sensors.temperature.dhw"
+                }
+            ],
+            "class": [
+                "heating.solar.sensors.temperature.dhw",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.sensors.temperature.dhw",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.solar.sensors.temperature.dhw",
+                        "timestamp": "2021-01-01T16:03:22.089Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.active"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.active"
+                }
+            ],
+            "class": [
+                "heating.circuits.0.operating.programs.active",
+                "feature"
+            ],
+            "properties": {
+                "value": {
+                    "value": "normal",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.active",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.0.operating.programs.active",
+                        "timestamp": "2021-01-01T16:03:22.116Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.modes.heating"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.modes.heating"
+                }
+            ],
+            "class": [
+                "heating.circuits.0.operating.modes.heating",
+                "feature"
+            ],
+            "properties": {
+                "active": {
+                    "value": true,
+                    "type": "boolean"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.modes.heating",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.0.operating.modes.heating",
+                        "timestamp": "2021-01-01T16:03:22.445Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.flue.sensors.temperature.main"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.flue.sensors.temperature.main"
+                }
+            ],
+            "class": [
+                "heating.flue.sensors.temperature.main",
+                "feature"
+            ],
+            "properties": {
+                "status": {
+                    "value": "connected",
+                    "type": "string"
+                },
+                "value": {
+                    "value": 41.9,
+                    "type": "number"
+                },
+                "unit": {
+                    "value": "celsius",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.flue.sensors.temperature.main",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.flue.sensors.temperature.main",
+                        "timestamp": "2021-01-01T22:43:46.908Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.heat.production"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.heat.production"
+                }
+            ],
+            "class": [
+                "heating.heat.production",
+                "feature"
+            ],
+            "properties": {
+                "day": {
+                    "value": [
+                        34,
+                        18,
+                        55,
+                        86,
+                        89,
+                        84,
+                        73,
+                        66
+                    ],
+                    "type": "array"
+                },
+                "week": {
+                    "value": [
+                        282,
+                        447,
+                        437,
+                        666
+                    ],
+                    "type": "array"
+                },
+                "month": {
+                    "value": [
+                        34,
+                        2418.7,
+                        2045.3,
+                        1413.7,
+                        661.3,
+                        93,
+                        139,
+                        268.1,
+                        979.5,
+                        713.4,
+                        0,
+                        0,
+                        0
+                    ],
+                    "type": "array"
+                },
+                "year": {
+                    "value": [
+                        34,
+                        8732.4
+                    ],
+                    "type": "array"
+                },
+                "unit": {
+                    "value": "kilowattHour",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.heat.production",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.heat.production",
+                        "timestamp": "2021-01-01T22:03:29.917Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.sensors.temperature.room"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.sensors.temperature.room"
+                }
+            ],
+            "class": [
+                "heating.circuits.0.sensors.temperature.room",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.sensors.temperature.room",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.0.sensors.temperature.room",
+                        "timestamp": "2021-01-01T16:03:22.461Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.heating"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.heating"
+                }
+            ],
+            "class": [
+                "heating.circuits.3.heating",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.heating",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.3.heating",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#curve",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-curve",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.heating.curve"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#schedule",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-schedule",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.heating.schedule"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "curve",
+                            "schedule"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/device"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/device"
+                }
+            ],
+            "class": [
+                "device",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/device",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "device",
+                        "timestamp": "2021-01-01T16:03:21.717Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#serial",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-serial",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/device.serial"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#zigbee",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-zigbee",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/device.zigbee"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "serial",
+                            "zigbee"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.sensors.temperature"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.sensors.temperature"
+                }
+            ],
+            "class": [
+                "heating.circuits.0.sensors.temperature",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.sensors.temperature",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.0.sensors.temperature",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#room",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-room",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.sensors.temperature.room"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#supply",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-supply",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.sensors.temperature.supply"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "room",
+                            "supply"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.sensors.temperature.outlet"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.sensors.temperature.outlet"
+                }
+            ],
+            "class": [
+                "heating.dhw.sensors.temperature.outlet",
+                "feature"
+            ],
+            "properties": {
+                "value": {
+                    "value": 35.3,
+                    "type": "number"
+                },
+                "status": {
+                    "value": "connected",
+                    "type": "string"
+                },
+                "unit": {
+                    "value": "celsius",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.sensors.temperature.outlet",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.dhw.sensors.temperature.outlet",
+                        "timestamp": "2021-01-01T22:42:09.439Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating"
+                }
+            ],
+            "class": [
+                "heating",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating",
+                        "timestamp": "2021-01-01T16:03:21.717Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#boiler",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-boiler",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.boiler"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#burner",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-burner",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.burner"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#circuits",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-circuits",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#configuration",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-configuration",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.configuration"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#device",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-device",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.device"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#dhw",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-dhw",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#errors",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-errors",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.errors"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#flue",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-flue",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.flue"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#gas",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-gas",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.gas"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#heat",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-heat",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.heat"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#operating",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-operating",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.operating"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#power",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-power",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.power"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#sensors",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-sensors",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.sensors"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#solar",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-solar",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#valves",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-valves",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.valves"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "boiler",
+                            "burner",
+                            "circuits",
+                            "configuration",
+                            "device",
+                            "dhw",
+                            "errors",
+                            "flue",
+                            "gas",
+                            "heat",
+                            "operating",
+                            "power",
+                            "sensors",
+                            "solar",
+                            "valves"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.pumps.circulation.schedule"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.pumps.circulation.schedule"
+                }
+            ],
+            "class": [
+                "heating.dhw.pumps.circulation.schedule",
+                "feature"
+            ],
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                },
+                "entries": {
+                    "value": {
+                        "mon": [
+                            {
+                                "mode": "on",
+                                "start": "05:30",
+                                "end": "08:00",
+                                "position": 0
+                            },
+                            {
+                                "mode": "on",
+                                "start": "11:30",
+                                "end": "13:00",
+                                "position": 1
+                            },
+                            {
+                                "mode": "on",
+                                "start": "16:30",
+                                "end": "22:00",
+                                "position": 2
+                            }
+                        ],
+                        "tue": [
+                            {
+                                "mode": "on",
+                                "start": "05:30",
+                                "end": "08:00",
+                                "position": 0
+                            },
+                            {
+                                "mode": "on",
+                                "start": "11:30",
+                                "end": "13:00",
+                                "position": 1
+                            },
+                            {
+                                "mode": "on",
+                                "start": "16:30",
+                                "end": "22:00",
+                                "position": 2
+                            }
+                        ],
+                        "wed": [
+                            {
+                                "mode": "on",
+                                "start": "05:30",
+                                "end": "08:00",
+                                "position": 0
+                            },
+                            {
+                                "mode": "on",
+                                "start": "11:30",
+                                "end": "13:00",
+                                "position": 1
+                            },
+                            {
+                                "mode": "on",
+                                "start": "16:30",
+                                "end": "22:00",
+                                "position": 2
+                            }
+                        ],
+                        "thu": [
+                            {
+                                "mode": "on",
+                                "start": "05:30",
+                                "end": "08:00",
+                                "position": 0
+                            },
+                            {
+                                "mode": "on",
+                                "start": "11:30",
+                                "end": "13:00",
+                                "position": 1
+                            },
+                            {
+                                "mode": "on",
+                                "start": "16:30",
+                                "end": "22:00",
+                                "position": 2
+                            }
+                        ],
+                        "fri": [
+                            {
+                                "mode": "on",
+                                "start": "05:30",
+                                "end": "08:00",
+                                "position": 0
+                            },
+                            {
+                                "mode": "on",
+                                "start": "11:30",
+                                "end": "13:00",
+                                "position": 1
+                            },
+                            {
+                                "mode": "on",
+                                "start": "16:30",
+                                "end": "22:00",
+                                "position": 2
+                            }
+                        ],
+                        "sat": [
+                            {
+                                "mode": "on",
+                                "start": "06:30",
+                                "end": "09:30",
+                                "position": 0
+                            },
+                            {
+                                "mode": "on",
+                                "start": "11:30",
+                                "end": "13:00",
+                                "position": 1
+                            },
+                            {
+                                "mode": "on",
+                                "start": "16:30",
+                                "end": "22:00",
+                                "position": 2
+                            }
+                        ],
+                        "sun": [
+                            {
+                                "mode": "on",
+                                "start": "06:30",
+                                "end": "09:30",
+                                "position": 0
+                            },
+                            {
+                                "mode": "on",
+                                "start": "11:30",
+                                "end": "13:00",
+                                "position": 1
+                            },
+                            {
+                                "mode": "on",
+                                "start": "16:30",
+                                "end": "22:00",
+                                "position": 2
+                            }
+                        ]
+                    },
+                    "type": "Schedule"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.pumps.circulation.schedule",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.dhw.pumps.circulation.schedule",
+                        "timestamp": "2021-01-01T16:03:22.513Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "method": "POST",
+                    "isExecutable": true,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.pumps.circulation.schedule/setSchedule",
+                    "name": "setSchedule",
+                    "title": "setSchedule",
+                    "fields": [
+                        {
+                            "name": "newSchedule",
+                            "type": "Schedule",
+                            "required": true,
+                            "modes": [
+                                "on"
+                            ],
+                            "maxEntries": 4,
+                            "resolution": 10,
+                            "defaultMode": "off",
+                            "overlapAllowed": false
+                        }
+                    ],
+                    "type": "application/json"
+                }
+            ]
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.frostprotection"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.frostprotection"
+                }
+            ],
+            "class": [
+                "heating.circuits.1.frostprotection",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.frostprotection",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.1.frostprotection",
+                        "timestamp": "2021-01-01T16:03:22.334Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.normal"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.normal"
+                }
+            ],
+            "class": [
+                "heating.circuits.1.operating.programs.normal",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs.normal",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.1.operating.programs.normal",
+                        "timestamp": "2021-01-01T16:03:22.364Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.operating.programs.holiday"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.operating.programs.holiday"
+                }
+            ],
+            "class": [
+                "heating.operating.programs.holiday",
+                "feature"
+            ],
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                },
+                "start": {
+                    "value": "",
+                    "type": "string"
+                },
+                "end": {
+                    "value": "",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.operating.programs.holiday",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.operating.programs.holiday",
+                        "timestamp": "2021-01-01T16:03:22.517Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "method": "POST",
+                    "isExecutable": false,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.operating.programs.holiday/changeEndDate",
+                    "name": "changeEndDate",
+                    "title": "changeEndDate",
+                    "fields": [
+                        {
+                            "name": "end",
+                            "type": "string",
+                            "required": true,
+                            "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
+                            "sameDayAllowed": true
+                        }
+                    ],
+                    "type": "application/json"
+                },
+                {
+                    "method": "POST",
+                    "isExecutable": true,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.operating.programs.holiday/schedule",
+                    "name": "schedule",
+                    "title": "schedule",
+                    "fields": [
+                        {
+                            "name": "start",
+                            "type": "string",
+                            "required": true,
+                            "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$"
+                        },
+                        {
+                            "name": "end",
+                            "type": "string",
+                            "required": true,
+                            "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
+                            "sameDayAllowed": true
+                        }
+                    ],
+                    "type": "application/json"
+                },
+                {
+                    "method": "POST",
+                    "isExecutable": true,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.operating.programs.holiday/unschedule",
+                    "name": "unschedule",
+                    "title": "unschedule",
+                    "fields": [],
+                    "type": "application/json"
+                }
+            ]
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.valves"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.valves"
+                }
+            ],
+            "class": [
+                "heating.valves",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.valves",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.valves",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#diverter",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-diverter",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.valves.diverter"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "diverter"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs"
+                }
+            ],
+            "class": [
+                "heating.circuits.2.operating.programs",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.2.operating.programs",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#active",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-active",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.active"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#comfort",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-comfort",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.comfort"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#forcedLastFromSchedule",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-forcedLastFromSchedule",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.forcedLastFromSchedule"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#holiday",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-holiday",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.holiday"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#holidayAtHome",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-holidayAtHome",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.holidayAtHome"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#normal",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-normal",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.normal"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#reduced",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-reduced",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.reduced"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#standby",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-standby",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.standby"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "active",
+                            "comfort",
+                            "forcedLastFromSchedule",
+                            "holiday",
+                            "holidayAtHome",
+                            "normal",
+                            "reduced",
+                            "standby"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.sensors.temperature.room"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.sensors.temperature.room"
+                }
+            ],
+            "class": [
+                "heating.circuits.1.sensors.temperature.room",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.sensors.temperature.room",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.1.sensors.temperature.room",
+                        "timestamp": "2021-01-01T16:03:22.464Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.configuration.regulation"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.configuration.regulation"
+                }
+            ],
+            "class": [
+                "heating.configuration.regulation",
+                "feature"
+            ],
+            "properties": {
+                "mode": {
+                    "value": "WeatherByOutsideSensorControlled",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.configuration.regulation",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.configuration.regulation",
+                        "timestamp": "2021-01-01T16:03:21.998Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.boiler.sensors"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.boiler.sensors"
+                }
+            ],
+            "class": [
+                "heating.boiler.sensors",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.boiler.sensors",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.boiler.sensors",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#temperature",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-temperature",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.boiler.sensors.temperature"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "temperature"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.heating.curve"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.heating.curve"
+                }
+            ],
+            "class": [
+                "heating.circuits.3.heating.curve",
+                "feature"
+            ],
+            "properties": {
+                "shift": {
+                    "type": "number",
+                    "value": 0
+                },
+                "slope": {
+                    "type": "number",
+                    "value": 1.4
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.heating.curve",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.3.heating.curve",
+                        "timestamp": "2021-01-01T16:03:22.504Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "method": "POST",
+                    "isExecutable": true,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.heating.curve/setCurve",
+                    "name": "setCurve",
+                    "title": "setCurve",
+                    "fields": [
+                        {
+                            "name": "slope",
+                            "type": "number",
+                            "required": true,
+                            "min": 0.2,
+                            "max": 3.5,
+                            "stepping": 0.1
+                        },
+                        {
+                            "name": "shift",
+                            "type": "number",
+                            "required": true,
+                            "min": -13,
+                            "max": 40,
+                            "stepping": 1
+                        }
+                    ],
+                    "type": "application/json"
+                }
+            ]
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.frostprotection"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.frostprotection"
+                }
+            ],
+            "class": [
+                "heating.circuits.0.frostprotection",
+                "feature"
+            ],
+            "properties": {
+                "status": {
+                    "value": "off",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.frostprotection",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.0.frostprotection",
+                        "timestamp": "2021-01-01T16:03:22.332Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.holiday"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.holiday"
+                }
+            ],
+            "class": [
+                "heating.circuits.3.operating.programs.holiday",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.holiday",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.3.operating.programs.holiday",
+                        "timestamp": "2021-01-01T16:03:22.383Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.boiler.sensors.temperature"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.boiler.sensors.temperature"
+                }
+            ],
+            "class": [
+                "heating.boiler.sensors.temperature",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.boiler.sensors.temperature",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.boiler.sensors.temperature",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#commonSupply",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-commonSupply",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "commonSupply"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/device.serial"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/device.serial"
+                }
+            ],
+            "class": [
+                "device.serial",
+                "feature"
+            ],
+            "properties": {
+                "value": {
+                    "value": "xxxxxxxxxxxxxxxxx",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/device.serial",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "device.serial",
+                        "timestamp": "2021-01-01T16:03:22.278Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.boiler"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.boiler"
+                }
+            ],
+            "class": [
+                "heating.boiler",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.boiler",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.boiler",
+                        "timestamp": "2021-01-01T16:03:21.717Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#sensors",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-sensors",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.boiler.sensors"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#serial",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-serial",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.boiler.serial"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#temperature",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-temperature",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.boiler.temperature"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "sensors",
+                            "serial",
+                            "temperature"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.valves.diverter.heatDhw"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.valves.diverter.heatDhw"
+                }
+            ],
+            "class": [
+                "heating.valves.diverter.heatDhw",
+                "feature"
+            ],
+            "properties": {
+                "position": {
+                    "value": "heating",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.valves.diverter.heatDhw",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.valves.diverter.heatDhw",
+                        "timestamp": "2021-01-01T16:03:22.525Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.errors.active"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.errors.active"
+                }
+            ],
+            "class": [
+                "heating.errors.active",
+                "feature"
+            ],
+            "properties": {
+                "entries": {
+                    "type": "ErrorListChanges",
+                    "constraints": {},
+                    "value": {
+                        "new": [],
+                        "current": [],
+                        "gone": []
+                    }
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.errors.active",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.errors.active",
+                        "timestamp": "2020-10-13T23:23:13.568Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating"
+                }
+            ],
+            "class": [
+                "heating.circuits.3.operating",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.3.operating",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#modes",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-modes",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.modes"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#programs",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-programs",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "modes",
+                            "programs"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating"
+                }
+            ],
+            "class": [
+                "heating.circuits.0.operating",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.0.operating",
+                        "timestamp": "2021-01-01T16:03:21.717Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#modes",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-modes",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.modes"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#programs",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-programs",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "modes",
+                            "programs"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.modes"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.modes"
+                }
+            ],
+            "class": [
+                "heating.circuits.2.operating.modes",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.modes",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.2.operating.modes",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#active",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-active",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.modes.active"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#dhw",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-dhw",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.modes.dhw"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#dhwAndHeating",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-dhwAndHeating",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeating"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#heating",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-heating",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.modes.heating"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#standby",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-standby",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.modes.standby"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "active",
+                            "dhw",
+                            "dhwAndHeating",
+                            "heating",
+                            "standby"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.sensors.pressure.supply"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.sensors.pressure.supply"
+                }
+            ],
+            "class": [
+                "heating.sensors.pressure.supply",
+                "feature"
+            ],
+            "properties": {
+                "value": {
+                    "value": 1.9,
+                    "type": "number"
+                },
+                "status": {
+                    "value": "connected",
+                    "type": "string"
+                },
+                "unit": {
+                    "value": "bar",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.sensors.pressure.supply",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.sensors.pressure.supply",
+                        "timestamp": "2021-01-01T22:38:06.648Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.gas"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.gas"
+                }
+            ],
+            "class": [
+                "heating.gas",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.gas",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.gas",
+                        "timestamp": "2021-01-01T16:03:21.717Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#consumption",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-consumption",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.gas.consumption"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "consumption"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.modes.active"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.modes.active"
+                }
+            ],
+            "class": [
+                "heating.circuits.3.operating.modes.active",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.modes.active",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.3.operating.modes.active",
+                        "timestamp": "2021-01-01T16:03:22.410Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.active"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.active"
+                }
+            ],
+            "class": [
+                "heating.circuits.3.operating.programs.active",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.programs.active",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.3.operating.programs.active",
+                        "timestamp": "2021-01-01T16:03:22.324Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.sensors.temperature.collector"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.sensors.temperature.collector"
+                }
+            ],
+            "class": [
+                "heating.solar.sensors.temperature.collector",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.solar.sensors.temperature.collector",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.solar.sensors.temperature.collector",
+                        "timestamp": "2021-01-01T16:03:22.315Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.comfort"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.comfort"
+                }
+            ],
+            "class": [
+                "heating.circuits.2.operating.programs.comfort",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.comfort",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.2.operating.programs.comfort",
+                        "timestamp": "2021-01-01T16:03:22.370Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.modes.dhw"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.modes.dhw"
+                }
+            ],
+            "class": [
+                "heating.circuits.2.operating.modes.dhw",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.modes.dhw",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.2.operating.modes.dhw",
+                        "timestamp": "2021-01-01T16:03:22.485Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/device.zigbee"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/device.zigbee"
+                }
+            ],
+            "class": [
+                "device.zigbee",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/device.zigbee",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "device.zigbee",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.sensors"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.sensors"
+                }
+            ],
+            "class": [
+                "heating.circuits.3.sensors",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.sensors",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.3.sensors",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#temperature",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-temperature",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.sensors.temperature"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "temperature"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.holiday"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.holiday"
+                }
+            ],
+            "class": [
+                "heating.circuits.0.operating.programs.holiday",
+                "feature"
+            ],
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                },
+                "start": {
+                    "value": "",
+                    "type": "string"
+                },
+                "end": {
+                    "value": "",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.holiday",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.0.operating.programs.holiday",
+                        "timestamp": "2021-01-01T16:03:22.373Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "method": "POST",
+                    "isExecutable": false,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.holiday/changeEndDate",
+                    "name": "changeEndDate",
+                    "title": "changeEndDate",
+                    "fields": [
+                        {
+                            "name": "end",
+                            "type": "string",
+                            "required": true,
+                            "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
+                            "sameDayAllowed": true
+                        }
+                    ],
+                    "type": "application/json"
+                },
+                {
+                    "method": "POST",
+                    "isExecutable": true,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.holiday/schedule",
+                    "name": "schedule",
+                    "title": "schedule",
+                    "fields": [
+                        {
+                            "name": "start",
+                            "type": "string",
+                            "required": true,
+                            "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$"
+                        },
+                        {
+                            "name": "end",
+                            "type": "string",
+                            "required": true,
+                            "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
+                            "sameDayAllowed": true
+                        }
+                    ],
+                    "type": "application/json"
+                },
+                {
+                    "method": "POST",
+                    "isExecutable": true,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.programs.holiday/unschedule",
+                    "name": "unschedule",
+                    "title": "unschedule",
+                    "fields": [],
+                    "type": "application/json"
+                }
+            ]
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.heating.schedule"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.heating.schedule"
+                }
+            ],
+            "class": [
+                "heating.circuits.3.heating.schedule",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.heating.schedule",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.3.heating.schedule",
+                        "timestamp": "2021-01-01T16:03:22.490Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.pumps.circulation"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.pumps.circulation"
+                }
+            ],
+            "class": [
+                "heating.dhw.pumps.circulation",
+                "feature"
+            ],
+            "properties": {
+                "status": {
+                    "value": "off",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.pumps.circulation",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.dhw.pumps.circulation",
+                        "timestamp": "2021-01-01T16:03:22.509Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#schedule",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-schedule",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.pumps.circulation.schedule"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "schedule"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.heating.curve"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.heating.curve"
+                }
+            ],
+            "class": [
+                "heating.circuits.1.heating.curve",
+                "feature"
+            ],
+            "properties": {
+                "shift": {
+                    "type": "number",
+                    "value": 0
+                },
+                "slope": {
+                    "type": "number",
+                    "value": 1.4
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.heating.curve",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.1.heating.curve",
+                        "timestamp": "2021-01-01T16:03:22.500Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "method": "POST",
+                    "isExecutable": true,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.heating.curve/setCurve",
+                    "name": "setCurve",
+                    "title": "setCurve",
+                    "fields": [
+                        {
+                            "name": "slope",
+                            "type": "number",
+                            "required": true,
+                            "min": 0.2,
+                            "max": 3.5,
+                            "stepping": 0.1
+                        },
+                        {
+                            "name": "shift",
+                            "type": "number",
+                            "required": true,
+                            "min": -13,
+                            "max": 40,
+                            "stepping": 1
+                        }
+                    ],
+                    "type": "application/json"
+                }
+            ]
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.device"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.device"
+                }
+            ],
+            "class": [
+                "heating.device",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.device",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.device",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#time",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-time",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.device.time"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "time"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.heating.schedule"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.heating.schedule"
+                }
+            ],
+            "class": [
+                "heating.circuits.1.heating.schedule",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.heating.schedule",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.1.heating.schedule",
+                        "timestamp": "2021-01-01T16:03:22.486Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.gas.consumption.heating"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.gas.consumption.heating"
+                }
+            ],
+            "class": [
+                "heating.gas.consumption.heating",
+                "feature"
+            ],
+            "properties": {
+                "day": {
+                    "value": [
+                        3.4,
+                        1.8,
+                        5.5,
+                        8.6,
+                        8.9,
+                        8.4,
+                        7.3,
+                        6.6
+                    ],
+                    "type": "array"
+                },
+                "week": {
+                    "value": [
+                        28.199999999999996,
+                        44.699999999999996,
+                        43.699999999999996,
+                        66.60000000000001
+                    ],
+                    "type": "array"
+                },
+                "month": {
+                    "value": [
+                        3.4,
+                        241.8,
+                        204.5,
+                        141.3,
+                        66.1,
+                        9.3,
+                        13.9,
+                        26.8,
+                        97.9,
+                        71.3,
+                        0,
+                        0,
+                        0
+                    ],
+                    "type": "array"
+                },
+                "year": {
+                    "value": [
+                        3.4,
+                        873.2
+                    ],
+                    "type": "array"
+                },
+                "unit": {
+                    "value": "cubicMeter",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.gas.consumption.heating",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.gas.consumption.heating",
+                        "timestamp": "2021-01-01T22:03:27.113Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.heating.curve"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.heating.curve"
+                }
+            ],
+            "class": [
+                "heating.circuits.2.heating.curve",
+                "feature"
+            ],
+            "properties": {
+                "shift": {
+                    "type": "number",
+                    "value": 0
+                },
+                "slope": {
+                    "type": "number",
+                    "value": 1.4
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.heating.curve",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.2.heating.curve",
+                        "timestamp": "2021-01-01T16:03:22.502Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "method": "POST",
+                    "isExecutable": true,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.heating.curve/setCurve",
+                    "name": "setCurve",
+                    "title": "setCurve",
+                    "fields": [
+                        {
+                            "name": "slope",
+                            "type": "number",
+                            "required": true,
+                            "min": 0.2,
+                            "max": 3.5,
+                            "stepping": 0.1
+                        },
+                        {
+                            "name": "shift",
+                            "type": "number",
+                            "required": true,
+                            "min": -13,
+                            "max": 40,
+                            "stepping": 1
+                        }
+                    ],
+                    "type": "application/json"
+                }
+            ]
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.sensors"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.sensors"
+                }
+            ],
+            "class": [
+                "heating.circuits.0.sensors",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.sensors",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.0.sensors",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#temperature",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-temperature",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.sensors.temperature"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "temperature"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.valves.diverter"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.valves.diverter"
+                }
+            ],
+            "class": [
+                "heating.valves.diverter",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.valves.diverter",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.valves.diverter",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#heatDhw",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-heatDhw",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.valves.diverter.heatDhw"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "heatDhw"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.configuration.multiFamilyHouse"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.configuration.multiFamilyHouse"
+                }
+            ],
+            "class": [
+                "heating.configuration.multiFamilyHouse",
+                "feature"
+            ],
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.configuration.multiFamilyHouse",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.configuration.multiFamilyHouse",
+                        "timestamp": "2021-01-01T16:03:22.491Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.flue"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.flue"
+                }
+            ],
+            "class": [
+                "heating.flue",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.flue",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.flue",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#sensors",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-sensors",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.flue.sensors"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "sensors"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.sensors.temperature"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.sensors.temperature"
+                }
+            ],
+            "class": [
+                "heating.circuits.3.sensors.temperature",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.sensors.temperature",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.3.sensors.temperature",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#room",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-room",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.sensors.temperature.room"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#supply",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-supply",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.sensors.temperature.supply"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "room",
+                            "supply"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.active"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.active"
+                }
+            ],
+            "class": [
+                "heating.circuits.2.operating.programs.active",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.active",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.2.operating.programs.active",
+                        "timestamp": "2021-01-01T16:03:22.322Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.temperature"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.temperature"
+                }
+            ],
+            "class": [
+                "heating.dhw.temperature",
+                "feature"
+            ],
+            "properties": {
+                "value": {
+                    "value": 55,
+                    "type": "number"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.temperature",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.dhw.temperature",
+                        "timestamp": "2021-01-01T16:03:22.272Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#main",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-main",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.temperature.main"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "main"
+                        ]
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "method": "POST",
+                    "isExecutable": true,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.temperature/setTargetTemperature",
+                    "name": "setTargetTemperature",
+                    "title": "setTargetTemperature",
+                    "fields": [
+                        {
+                            "name": "temperature",
+                            "type": "number",
+                            "required": true,
+                            "min": 10,
+                            "max": 60,
+                            "stepping": 1
+                        }
+                    ],
+                    "type": "application/json"
+                }
+            ]
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.frostprotection"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.frostprotection"
+                }
+            ],
+            "class": [
+                "heating.circuits.3.frostprotection",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.frostprotection",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.3.frostprotection",
+                        "timestamp": "2021-01-01T16:03:22.340Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.modes.standby"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.modes.standby"
+                }
+            ],
+            "class": [
+                "heating.circuits.1.operating.modes.standby",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.modes.standby",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.1.operating.modes.standby",
+                        "timestamp": "2021-01-01T16:03:22.415Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.circulation.pump"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.circulation.pump"
+                }
+            ],
+            "class": [
+                "heating.circuits.1.circulation.pump",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.circulation.pump",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.1.circulation.pump",
+                        "timestamp": "2021-01-01T16:03:22.328Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.modes"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.modes"
+                }
+            ],
+            "class": [
+                "heating.circuits.0.operating.modes",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.modes",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.0.operating.modes",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#active",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-active",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.modes.active"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#dhw",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-dhw",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.modes.dhw"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#dhwAndHeating",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-dhwAndHeating",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#heating",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-heating",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.modes.heating"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#standby",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-standby",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.modes.standby"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "active",
+                            "dhw",
+                            "dhwAndHeating",
+                            "heating",
+                            "standby"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.holiday"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.holiday"
+                }
+            ],
+            "class": [
+                "heating.circuits.2.operating.programs.holiday",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.operating.programs.holiday",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.2.operating.programs.holiday",
+                        "timestamp": "2021-01-01T16:03:22.380Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
+                }
+            ],
+            "class": [
+                "heating.dhw.sensors.temperature.hotWaterStorage",
+                "feature"
+            ],
+            "properties": {
+                "value": {
+                    "value": 20.1,
+                    "type": "number"
+                },
+                "status": {
+                    "value": "connected",
+                    "type": "string"
+                },
+                "unit": {
+                    "value": "celsius",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.dhw.sensors.temperature.hotWaterStorage",
+                        "timestamp": "2021-01-01T22:43:44.951Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.boiler.serial"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.boiler.serial"
+                }
+            ],
+            "class": [
+                "heating.boiler.serial",
+                "feature"
+            ],
+            "properties": {
+                "value": {
+                    "value": "xxxxxxxxxxxxxxxxx",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.boiler.serial",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.boiler.serial",
+                        "timestamp": "2021-01-01T16:03:21.939Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.errors"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.errors"
+                }
+            ],
+            "class": [
+                "heating.errors",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.errors",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.errors",
+                        "timestamp": "2021-01-01T16:03:21.717Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#active",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-active",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.errors.active"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#history",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-history",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.errors.history"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "active",
+                            "history"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.circulation"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.circulation"
+                }
+            ],
+            "class": [
+                "heating.circuits.3.circulation",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.circulation",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.3.circulation",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#pump",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-pump",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.circulation.pump"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "pump"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.modes.dhw"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.modes.dhw"
+                }
+            ],
+            "class": [
+                "heating.circuits.0.operating.modes.dhw",
+                "feature"
+            ],
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.modes.dhw",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.0.operating.modes.dhw",
+                        "timestamp": "2021-01-01T16:03:22.482Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.sensors.temperature"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.sensors.temperature"
+                }
+            ],
+            "class": [
+                "heating.circuits.2.sensors.temperature",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.sensors.temperature",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.2.sensors.temperature",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#room",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-room",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.sensors.temperature.room"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#supply",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-supply",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.sensors.temperature.supply"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "room",
+                            "supply"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.circulation.pump"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.circulation.pump"
+                }
+            ],
+            "class": [
+                "heating.circuits.2.circulation.pump",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.circulation.pump",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.2.circulation.pump",
+                        "timestamp": "2021-01-01T16:03:22.330Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.circulation"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.circulation"
+                }
+            ],
+            "class": [
+                "heating.circuits.1.circulation",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.circulation",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.1.circulation",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#pump",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-pump",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.circulation.pump"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "pump"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.modes.standby"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.modes.standby"
+                }
+            ],
+            "class": [
+                "heating.circuits.0.operating.modes.standby",
+                "feature"
+            ],
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.modes.standby",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.0.operating.modes.standby",
+                        "timestamp": "2021-01-01T16:03:22.413Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.heating"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.heating"
+                }
+            ],
+            "class": [
+                "heating.circuits.2.heating",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.heating",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.2.heating",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#curve",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-curve",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.heating.curve"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#schedule",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-schedule",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.heating.schedule"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "curve",
+                            "schedule"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.sensors"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.sensors"
+                }
+            ],
+            "class": [
+                "heating.circuits.1.sensors",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.sensors",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.1.sensors",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#temperature",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-temperature",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.sensors.temperature"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "temperature"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.heating.schedule"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.heating.schedule"
+                }
+            ],
+            "class": [
+                "heating.circuits.2.heating.schedule",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.heating.schedule",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.2.heating.schedule",
+                        "timestamp": "2021-01-01T16:03:22.488Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.device.time.offset"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.device.time.offset"
+                }
+            ],
+            "class": [
+                "heating.device.time.offset",
+                "feature"
+            ],
+            "properties": {
+                "value": {
+                    "value": 57,
+                    "type": "number"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.device.time.offset",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.device.time.offset",
+                        "timestamp": "2021-01-01T16:03:26.468Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.heating.schedule"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.heating.schedule"
+                }
+            ],
+            "class": [
+                "heating.circuits.0.heating.schedule",
+                "feature"
+            ],
+            "properties": {
+                "active": {
+                    "value": true,
+                    "type": "boolean"
+                },
+                "entries": {
+                    "value": {
+                        "mon": [
+                            {
+                                "mode": "normal",
+                                "start": "00:00",
+                                "end": "24:00",
+                                "position": 0
+                            }
+                        ],
+                        "tue": [
+                            {
+                                "mode": "normal",
+                                "start": "00:00",
+                                "end": "24:00",
+                                "position": 0
+                            }
+                        ],
+                        "wed": [
+                            {
+                                "mode": "normal",
+                                "start": "00:00",
+                                "end": "24:00",
+                                "position": 0
+                            }
+                        ],
+                        "thu": [
+                            {
+                                "mode": "normal",
+                                "start": "00:00",
+                                "end": "24:00",
+                                "position": 0
+                            }
+                        ],
+                        "fri": [
+                            {
+                                "mode": "normal",
+                                "start": "00:00",
+                                "end": "24:00",
+                                "position": 0
+                            }
+                        ],
+                        "sat": [
+                            {
+                                "mode": "normal",
+                                "start": "00:00",
+                                "end": "24:00",
+                                "position": 0
+                            }
+                        ],
+                        "sun": [
+                            {
+                                "mode": "normal",
+                                "start": "00:00",
+                                "end": "24:00",
+                                "position": 0
+                            }
+                        ]
+                    },
+                    "type": "Schedule"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.heating.schedule",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.0.heating.schedule",
+                        "timestamp": "2021-01-01T16:03:22.453Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "method": "POST",
+                    "isExecutable": true,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.heating.schedule/setSchedule",
+                    "name": "setSchedule",
+                    "title": "setSchedule",
+                    "fields": [
+                        {
+                            "name": "newSchedule",
+                            "type": "Schedule",
+                            "required": true,
+                            "modes": [
+                                "normal",
+                                "comfort"
+                            ],
+                            "maxEntries": 4,
+                            "resolution": 10,
+                            "defaultMode": "reduced",
+                            "overlapAllowed": false
+                        }
+                    ],
+                    "type": "application/json"
+                }
+            ]
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.power"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.power"
+                }
+            ],
+            "class": [
+                "heating.power",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.power",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.power",
+                        "timestamp": "2021-01-01T16:03:21.717Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#consumption",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-consumption",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.power.consumption"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "consumption"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.modes.heating"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.modes.heating"
+                }
+            ],
+            "class": [
+                "heating.circuits.1.operating.modes.heating",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.modes.heating",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.1.operating.modes.heating",
+                        "timestamp": "2021-01-01T16:03:22.447Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.modes.active"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.modes.active"
+                }
+            ],
+            "class": [
+                "heating.circuits.0.operating.modes.active",
+                "feature"
+            ],
+            "properties": {
+                "value": {
+                    "value": "heating",
+                    "type": "string"
+                }
+            },
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.modes.active",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.0.operating.modes.active",
+                        "timestamp": "2021-01-01T16:03:22.427Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "method": "POST",
+                    "isExecutable": true,
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.operating.modes.active/setMode",
+                    "name": "setMode",
+                    "title": "setMode",
+                    "fields": [
+                        {
+                            "name": "mode",
+                            "type": "string",
+                            "required": true,
+                            "enum": [
+                                "standby",
+                                "heating",
+                                "dhw",
+                                "dhwAndHeating"
+                            ]
+                        }
+                    ],
+                    "type": "application/json"
+                }
+            ]
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.modes.standby"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.modes.standby"
+                }
+            ],
+            "class": [
+                "heating.circuits.3.operating.modes.standby",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.operating.modes.standby",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.3.operating.modes.standby",
+                        "timestamp": "2021-01-01T16:03:22.418Z",
+                        "isEnabled": false,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating"
+                }
+            ],
+            "class": [
+                "heating.circuits.1.operating",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.1.operating",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#modes",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-modes",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.modes"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#programs",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-programs",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.operating.programs"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "modes",
+                            "programs"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.flue.sensors"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.flue.sensors"
+                }
+            ],
+            "class": [
+                "heating.flue.sensors",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.flue.sensors",
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.flue.sensors",
+                        "timestamp": "2021-01-01T16:03:21.718Z",
+                        "isEnabled": true,
+                        "isReady": true,
+                        "deviceId": "0"
+                    }
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#temperature",
+                        "http://schema.viessmann.com/link-relations#feature-component",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-temperature",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.flue.sensors.temperature"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-components",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "components": [
+                            "temperature"
+                        ]
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.geofencing"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.geofencing"
+                }
+            ],
+            "class": [
+                "heating.circuits.0.geofencing",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "isEnabled": false,
+                        "isReady": true,
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.0.geofencing",
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.0.geofencing",
+                        "deviceId": "0",
+                        "timestamp": "2021-01-01T22:43:52.139Z"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.geofencing"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.geofencing"
+                }
+            ],
+            "class": [
+                "heating.circuits.1.geofencing",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "isEnabled": false,
+                        "isReady": true,
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.1.geofencing",
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.1.geofencing",
+                        "deviceId": "0",
+                        "timestamp": "2021-01-01T22:43:52.139Z"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.geofencing"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.geofencing"
+                }
+            ],
+            "class": [
+                "heating.circuits.2.geofencing",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "isEnabled": false,
+                        "isReady": true,
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.2.geofencing",
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.2.geofencing",
+                        "deviceId": "0",
+                        "timestamp": "2021-01-01T22:43:52.139Z"
+                    }
+                }
+            ],
+            "actions": []
+        },
+        {
+            "rel": [
+                "http://schema.viessmann.com/link-relations#feature",
+                "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature",
+                "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-collection"
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.geofencing"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "https://api.viessmann-platform.io/operational-data/v1/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features"
+                },
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#live-updates",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-live-updates"
+                    ],
+                    "href": "/operational-data/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.geofencing"
+                }
+            ],
+            "class": [
+                "heating.circuits.3.geofencing",
+                "feature"
+            ],
+            "properties": {},
+            "entities": [
+                {
+                    "rel": [
+                        "http://schema.viessmann.com/link-relations#feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Relations#Relations-feature-meta-information",
+                        "https://wiki.viessmann.com/display/VPL/Amounts#Amounts-unique"
+                    ],
+                    "properties": {
+                        "apiVersion": 1,
+                        "isEnabled": false,
+                        "isReady": true,
+                        "gatewayId": "xxxxxxxxxxxxxxxxx",
+                        "feature": "heating.circuits.3.geofencing",
+                        "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/xxxxxx/gateways/xxxxxxxxxxxxxxxxx/devices/0/features/heating.circuits.3.geofencing",
+                        "deviceId": "0",
+                        "timestamp": "2021-01-01T22:43:52.139Z"
+                    }
+                }
+            ],
+            "actions": []
+        }
+    ],
+    "actions": []
+}

--- a/tests/test_Vitodens222F_notarget.py
+++ b/tests/test_Vitodens222F_notarget.py
@@ -1,0 +1,15 @@
+import unittest
+from tests.ViCareServiceMock import ViCareServiceMock
+from PyViCare.PyViCareGazBoiler import GazBoiler
+from PyViCare.PyViCare import PyViCareNotSupportedFeatureError
+import PyViCare.Feature
+
+class Vitodens222F_NoTarget(unittest.TestCase):
+    def setUp(self):
+        self.service = ViCareServiceMock('response_Vitodens222F_notarget.json', 0)
+        self.gaz = GazBoiler(None, None, None, 0, 0, self.service)
+        PyViCare.Feature.raise_exception_on_not_supported_device_feature = True
+
+    def test_getTargetSupplyTemperature(self):
+        self.assertAlmostEqual(self.gaz.getTargetSupplyTemperature(), None)
+        


### PR DESCRIPTION
This PR adds a method `isSupported` to check if a feature is supported. It also uses that method to check for required fields in `getTargetSupplyTemperature`. This is required as otherwise it would result in a type error on some calculations.