### PR TITLE
Add support for V2 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ token.bin
 PyViCare/__init__.py
 
 .DS_Store
+.vscode/settings.json

--- a/PyViCare/PyViCareCachedServiceV2.py
+++ b/PyViCare/PyViCareCachedServiceV2.py
@@ -1,0 +1,45 @@
+from datetime import datetime
+import threading
+from PyViCare.PyViCareServiceV2 import apiURLBase, ViCareServiceV2, readFeature
+
+class ViCareCachedServiceV2(ViCareServiceV2):
+    
+    def __init__(self, username, password, cacheDuration, client_id, token_file=None,circuit=0):
+        ViCareServiceV2.__init__(self, username, password, client_id, token_file, circuit)
+        self.cacheDuration = cacheDuration
+        self.cache = None
+        self.cacheTime = None
+        self.lock = threading.Lock()
+
+
+    def getProperty(self,property_name):
+        data = self.getOrUpdateCache()   
+        entities = data["data"]
+        return readFeature(entities, property_name)
+
+    def setProperty(self,property_name,action,data):
+        response = super().setProperty(property_name, action, data)
+        self.clearCache()
+        return response
+
+    def getOrUpdateCache(self):
+        self.lock.acquire()
+        try:
+            if self.isCacheInvalid():
+                url = apiURLBase + '/equipment/installations/' + str(self.id) + '/gateways/' + str(self.serial) + '/devices/0/features/'
+                self.cache = self.get(url)
+                self.cacheTime = datetime.now()
+            return self.cache
+        finally:
+            self.lock.release()
+
+    def isCacheInvalid(self):
+        return self.cache is None or self.cacheTime is None or (datetime.now() - self.cacheTime).seconds > self.cacheDuration
+
+    def clearCache(self):
+        self.lock.acquire()
+        try:
+            self.cache = None
+            self.cacheTime = None
+        finally:
+            self.lock.release()

--- a/PyViCare/PyViCareDevice.py
+++ b/PyViCare/PyViCareDevice.py
@@ -4,7 +4,9 @@ import os
 import logging
 from datetime import datetime, time
 from PyViCare.PyViCareService import ViCareService
+from PyViCare.PyViCareServiceV2 import ViCareServiceV2
 from PyViCare.PyViCareCachedService import ViCareCachedService
+from PyViCare.PyViCareCachedServiceV2 import ViCareCachedServiceV2
 from PyViCare.PyViCare import handleNotSupported
 
 import traceback
@@ -39,7 +41,7 @@ class Device:
     """
 
     # TODO cirtcuit management should move at method level
-    def __init__(self, username, password,token_file=None,circuit=0,cacheDuration=0,customService=None):
+    def __init__(self, username, password,token_file=None,circuit=0,cacheDuration=0,customService=None,useV2=False,client_id=None):
         """Init function. Create the necessary oAuth2 sessions
         Parameters
         ----------
@@ -55,9 +57,16 @@ class Device:
         if customService is not None:
             self.service = customService
         elif cacheDuration == 0:
-            self.service = ViCareService(username, password, token_file, circuit)
+            if useV2:
+                self.service = ViCareServiceV2(username, password, client_id, token_file, circuit)
+            else:
+                self.service = ViCareService(username, password, token_file, circuit)
         else:
-            self.service = ViCareCachedService(username, password, cacheDuration, token_file, circuit)
+            if useV2:
+                self.service = ViCareCachedServiceV2(username, password, cacheDuration, client_id, token_file, circuit)
+            else:
+                self.service = ViCareCachedService(username, password, cacheDuration, token_file, circuit)
+
 
     """ Set the active mode
     Parameters

--- a/PyViCare/PyViCareServiceV2.py
+++ b/PyViCare/PyViCareServiceV2.py
@@ -34,10 +34,10 @@ def readFeature(entities, property_name):
     return feature
 
 def buildSetPropertyUrl(id, serial, circuit, property_name, action):
-    return apiURLBase +'/operational-data/v1/installations/'+str(id)+'/gateways/'+str(serial)+'/devices/'+str(circuit)+'/features/'+property_name+'/'+action
+    return apiURLBase +'/equipment/installations/'+str(id)+'/gateways/'+str(serial)+'/devices/'+str(circuit)+'/features/'+property_name+'/'+action
 
 def buildGetPropertyUrl(id, serial, circuit, property_name):
-    return apiURLBase + '/operational-data/installations/'+str(id)+'/gateways/'+str(serial)+'/devices/'+str(circuit)+'/features/'+property_name   
+    return apiURLBase + '/equipment/installations/'+str(id)+'/gateways/'+str(serial)+'/devices/'+str(circuit)+'/features/'+property_name   
 
 # https://api.viessmann-platform.io/general-management/v1/installations/DDDDD gives the type like VitoconnectOptolink
 # entities / "deviceType": "heating"

--- a/PyViCare/PyViCareServiceV2.py
+++ b/PyViCare/PyViCareServiceV2.py
@@ -1,0 +1,292 @@
+from requests_oauthlib import OAuth2Session
+from oauthlib.oauth2 import TokenExpiredError 
+
+import requests
+import re
+import pickle
+import os
+import logging
+import datetime
+import pkce
+from pickle import UnpicklingError
+# This is required because "requests" uses simplejson if installed on the system 
+
+import simplejson as json
+from simplejson import JSONDecodeError
+from PyViCare.PyViCare import PyViCareNotSupportedFeatureError, PyViCareRateLimitError
+import PyViCare.Feature
+
+authorizeURL = 'https://iam.viessmann.com/idp/v2/authorize'
+token_url = 'https://iam.viessmann.com/idp/v2/token'
+apiURLBase = 'https://api.viessmann.com/iot/v1'
+redirect_uri = "vicare://oauth-callback/everest"
+viessmann_scope=["IoT User"]
+logger = logging.getLogger('ViCare')
+logger.addHandler(logging.NullHandler())
+
+
+def readFeature(entities, property_name):
+    feature = next((f for f in entities if f["feature"] == property_name), None)
+
+    if(feature is None):
+        raise PyViCareNotSupportedFeatureError(property_name)
+
+    return feature
+
+def buildSetPropertyUrl(id, serial, circuit, property_name, action):
+    return apiURLBase +'/operational-data/v1/installations/'+str(id)+'/gateways/'+str(serial)+'/devices/'+str(circuit)+'/features/'+property_name+'/'+action
+
+def buildGetPropertyUrl(id, serial, circuit, property_name):
+    return apiURLBase + '/operational-data/installations/'+str(id)+'/gateways/'+str(serial)+'/devices/'+str(circuit)+'/features/'+property_name   
+
+# https://api.viessmann-platform.io/general-management/v1/installations/DDDDD gives the type like VitoconnectOptolink
+# entities / "deviceType": "heating"
+# entities are connected devices
+# https://api.viessmann-platform.io/general-management/v1/installations/16011/gateways PUT and POST only
+
+# TODO handle multi install / multi devices
+
+""""Viessmann ViCare API Python tools"""
+
+class ViCareServiceV2:
+    """This class connects to the Viesmann ViCare API.
+    The authentication is done through OAuth2.
+    Note that currently, a new token is generate for each run.
+    """
+
+
+    def __init__(self, username, password, client_id, token_file=None,circuit=0):
+        """Init function. Create the necessary oAuth2 sessions
+        Parameters
+        ----------
+        username : str
+            e-mail address
+        password : str
+            password
+
+        Returns
+        -------
+        """
+
+        self.username= username
+        self.password= password
+        self.token_file=token_file
+        self.circuit=circuit
+        self.client_id = client_id
+        self.oauth=self.__restoreToken(token_file)
+        self._getInstallations()
+        logger.info("Initialisation successful !")
+
+    def __restoreToken(self,token_file=None):
+        """Create the necessary oAuth2 sessions
+        Restore it from token_file if existing (token dict)
+        Viessmann tokens expire after 3600s (60min)
+        Parameters
+        ----------
+        username : str
+            e-mail address
+        password : str
+            password
+        token_file: str
+            path to serialize the token (will restore if already existing)
+
+        Returns
+        -------
+        oauth:
+            oauth sessions object
+        """
+        if (token_file!=None) and os.path.isfile(token_file):
+            try:
+                logger.info("Token file exists")
+                oauth = OAuth2Session(self.client_id,token=self._deserializeToken(token_file))
+                logger.info("Token restored from file")
+            except UnpicklingError:
+                logger.warning("Could not restore token")
+                oauth = self.__getNewToken(self.username, self.password,token_file)
+        else:
+            logger.debug("Token file argument not provided or file does not exist")
+            oauth = self.__getNewToken(self.username, self.password,token_file)
+        return oauth
+
+    def __getNewToken(self, username, password,token_file=None):
+        """Create a new oAuth2 sessions
+        Viessmann tokens expire after 3600s (60min)
+        Parameters
+        ----------
+        username : str
+            e-mail address
+        password : str
+            password
+        token_file: str
+            path to serialize the token (will restore if already existing). No serialisation if not present
+
+        Returns
+        -------
+        oauth:
+            oauth sessions object
+        """
+        oauth = OAuth2Session(self.client_id, redirect_uri=redirect_uri,scope=viessmann_scope)
+        authorization_url, _ = oauth.authorization_url(authorizeURL)
+           
+        # workaround until requests-oauthlib supports PKCE flow
+        code_verifier, code_challenge = pkce.generate_pkce_pair()
+        authorization_url += '&code_challenge=' + code_challenge + '&code_challenge_method=S256'
+        logger.debug("Auth URL is: "+authorization_url)
+
+        try:
+            header = {'Content-Type': 'application/x-www-form-urlencoded'}
+            response = requests.post(authorization_url, headers=header,auth=(username,password))
+            logger.warning("Received an HTML answer from the server during auth, this is not normal:")
+            logger.debug(response.content)
+        except requests.exceptions.InvalidSchema as e:
+            #capture the error, which contains the code the authorization code and put this in to codestring
+            codestring = "{0}".format(str(e.args[0])).encode("utf-8")
+            codestring = str(codestring)
+            match = re.search("code=(.*)&",codestring)
+            codestring=match.group(1)
+            logger.debug("Codestring : "+codestring)
+
+            # workaround until requests-oauthlib supports PKCE flow
+            resp = requests.post(url=token_url,
+                    data={
+                        'grant_type': 'authorization_code',
+                        'client_id': self.client_id,
+                        'redirect_uri': redirect_uri,
+                        'code': codestring,
+                        'code_verifier': code_verifier
+                    }
+                )
+            result = resp.json()
+            token_dict = {
+                'access_token': result['access_token'],
+                'token_type': 'bearer'
+            }
+            oauth = OAuth2Session(client_id=self.client_id, token=token_dict)
+            # oauth.fetch_token(token_url, authorization_response=authorization_url,code=codestring)
+            logger.debug("Token received: ")
+            logger.debug(oauth)
+            logger.debug("Start serial")
+            if token_file != None:
+                self._serializeToken(oauth.token,token_file)
+                logger.info("Token serialized to "+token_file)
+            logger.info("New token created")
+            #TODO throw an exception if oauth is null and implement the auth required method
+            # RELLY TODO AttributeError
+            return oauth
+
+        # TODO tranform to exception
+        
+    def renewToken(self):
+        logger.info("Token expired, renewing")
+        self.oauth=self.__getNewToken(self.username,self.password,self.token_file)
+        logger.info("Token renewed successfully")
+            
+        
+    """Get URL using OAuth session. Automatically renew the token if needed
+    Parameters
+    ----------
+    url : str
+        URL to get
+
+    Returns
+    -------
+    result: json
+        json representation of the answer
+    """
+    def __get(self,url):
+        try:
+            #if(self.oauth==None):
+            #    self.renewToken()
+            logger.debug(self.oauth)
+            r=self.oauth.get(url).json()
+            logger.debug("Response to get request: "+str(r))
+            self.handleRateLimit(r)
+
+            if(r=={'error': 'EXPIRED TOKEN'}):
+                logger.warning("Abnormal token, renewing") # apparently forged tokens TODO investigate
+                self.renewToken()
+                r = self.oauth.get(url).json()
+            return r
+        except TokenExpiredError:
+            self.renewToken()
+            return self.__get(url)
+
+    def handleRateLimit(self, response):
+        if not PyViCare.Feature.raise_exception_on_rate_limit:
+            return
+
+        if("statusCode" in response and response["statusCode"] == 429):
+            raise PyViCareRateLimitError(response)
+            
+    """POST URL using OAuth session. Automatically renew the token if needed
+    Parameters
+    ----------
+    url : str
+        URL to get
+    data : str
+        Data to post
+
+    Returns
+    -------
+    result: json
+        json representation of the answer
+    """
+    def __post(self,url,data):
+        h = {"Content-Type":"application/json","Accept":"application/vnd.siren+json"}
+        try:
+            #if(self.oauth==None):
+            #    self.renewToken()
+            j=self.oauth.post(url,data,headers=h)
+            try:
+                r=j.json()
+                self.handleRateLimit(r)
+                return r
+            except JSONDecodeError:
+                if j.status_code == 204:
+                    return {"statusCode": 204, "error": "None", "message": "SUCCESS"}
+                else:
+                    return {"statusCode": j.status_code, "error": "Unknown", "message": "UNKNOWN"}
+        except TokenExpiredError:
+            self.renewToken()
+            return self.__post(url,data)
+
+    def _serializeToken(self,oauth,token_file):
+        binary_file = open(token_file,mode='wb')
+        try:
+            pickle.dump(oauth,binary_file)
+        finally:
+            binary_file.close()
+
+    def _deserializeToken(self,token_file):
+        binary_file = open(token_file,mode='rb')
+        try:  
+            s_token = pickle.load(binary_file)
+            return s_token
+        finally:
+            binary_file.close()
+
+    def _getInstallations(self):
+        self.installations = self.__get(apiURLBase+"/equipment/installations")
+        self.id = self.installations["data"][0]["id"]
+
+        self.gateways = self.__get(apiURLBase+"/equipment/installations/" + str(self.id) + "/gateways")
+        self.serial = self.gateways["data"][0]["serial"]
+        return self.installations
+
+    def getInstallations(self):
+        return self.installations
+
+    def get(self, url):
+        return self.__get(url)
+
+   #TODO should move to device after refactoring 
+    def getProperty(self,property_name):
+        url = buildGetPropertyUrl(self.id, self.serial, self.circuit, property_name)
+        j=self.__get(url)
+        return j
+
+    def setProperty(self,property_name,action,data):
+        url = buildSetPropertyUrl(self.id, self.serial, self.circuit, property_name, action)
+        return self.__post(url,data)
+
+    

--- a/PyViCare/__init__.py
+++ b/PyViCare/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ['PyViCareService','PyViCareDevice','PyViCareGazBoiler','PyViCareHeatPump','PyViCareCachedService','PyViCareOilBoiler']
+__all__ = ['PyViCareService','PyViCareDevice','PyViCareGazBoiler','PyViCareHeatPump','PyViCareCachedService','PyViCareOilBoiler', 'PyViCareServiceV2', 'PyViCareCachedServiceV2']

--- a/README.md
+++ b/README.md
@@ -90,3 +90,93 @@ Follow these steps to access the API in Postman:
 ## Rate Limits
 
 [Due to latest changes in the Viessmann API](https://www.viessmann-community.com/t5/Konnektivitaet/Q-amp-A-Viessmann-API/td-p/127660) rate limits can be hit. In that case a `PyViCareRateLimitError` is raised. You can read from the error (`limitResetDate`) when the rate limit is reset.
+
+# Viessmann V2 API
+
+On July 15th the current Viessmann V1 API will be turned off. This library supports the Viessmann V2 API but not all properties are available (yet).
+
+We need help testing the new V2 API. Please follow these steps to test the new API.
+
+1. Register and login in the new [Viessmann Developer Portal](https://developer.viessmann.com/).
+2. In the menu navigate to `API Keys`.
+3. Create a new OAuth client using following data:
+    * Name: PyViCare
+    * Google reCAPTCHA: Disabled
+    * Redirect URIs: `vicare://oauth-callback/everest`
+4. Copy the `Client ID` to use in your code. Pass it as constructor parameter to the device.
+
+## Basic Usage with V2:
+
+```python
+import sys
+import logging
+sys.path.insert(0, 'PyViCare')
+from PyViCare.PyViCareGazBoiler import GazBoiler
+
+client_id = "INSERT CLIENT ID"
+
+t=GazBoiler("email@domain","password","token.save", client_id=client_id, useV2=True)
+print(t.getDomesticHotWaterConfiguredTemperature()) 
+print(t.getDomesticHotWaterStorageTemperature())
+print(t.getOutsideTemperature())
+print(t.getRoomTemperature())
+print(t.getSupplyTemperature())
+print(t.getOutsideTemperature()) 
+print(t.getHeatingCurveShift()) 
+print(t.getHeatingCurveSlope()) 
+print(t.getBoilerTemperature())
+print(t.getActiveProgram())
+print(t.getPrograms())
+
+print(t.getCurrentDesiredTemperature())
+print(t.getMonthSinceLastService())
+print(t.getLastServiceDate())
+
+print(t.getDesiredTemperatureForProgram("comfort"))
+print(t.getActiveMode())
+
+print(t.getDesiredTemperatureForProgram("comfort"))
+print(t.setProgramTemperature("comfort",21))
+print(t.activateProgram("comfort"))
+print(t.setDomesticHotWaterTemperature(59))
+print(t.activateProgram("comfort"))
+print(t.deactivateComfort())
+```
+
+## API V2 Usage in Postman
+
+Follow these steps to access the V2 API in Postman:
+
+1. Create an access token in the `Authorization` tab with type `OAuth 2.0` and following inputs:
+
+    - Token Name: `PyViCare`
+    - Grant Type: `Authorization Code (With PKCE)`
+    - Callback URL: `vicare://oauth-callback/everest`
+    - Authorize using browser: Disabled
+    - Auth URL: `https://iam.viessmann.com/idp/v2/authorize`
+    - Access Token URL: `https://iam.viessmann.com/idp/v2/token`
+    - Client ID: Your personal Client ID created in the developer portal.
+    - Client Secret: Blank
+    - Code Challenge Method: `SHA-256`
+    - Code Veriefier: Blank
+    - Scope: `IoT User`
+    - State: Blank
+    - Client Authentication: `Send client credentials in body`.
+
+    A login popup will open. Enter your ViCare username and password.
+
+2. Use this URL to access your `installationId`: 
+
+    `https://api.viessmann.com/iot/v1/equipment/installations`
+
+    - `installationId` is `data[0].id`
+
+2. Use this URL to access your `gatewaySerial`. Replace `{installationId}` with the installation id above.
+
+    `https://api.viessmann.com/iot/v1/equipment/installations/{installationId}/gateways`
+
+    - `gatewaySerial` is `data[0].serial`
+
+3. Use above data to replace `{installationId}` and `{gatewaySerial}` in this URL to investigate the Viessmann API:
+
+    `https://api.viessmann.com/iot/v1/equipment/installations/{installationId}/gateways/{gatewaySerial}/devices/0/features`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests-oauthlib>=1.1.0
 simplejson
+pkce

--- a/tests/ViCareServiceMockV2.py
+++ b/tests/ViCareServiceMockV2.py
@@ -1,0 +1,27 @@
+from PyViCare.PyViCareServiceV2 import ViCareServiceV2, readFeature, buildSetPropertyUrl
+from tests.helper import readJson
+
+class ViCareServiceMockV2(ViCareServiceV2):
+    
+    def __init__(self, filename, circuit, rawInput = None):
+        if rawInput is None:
+            testData = readJson(filename)
+            self.testData = testData
+        else:
+            self.testData = rawInput
+
+        self.circuit = circuit
+        self.setPropertyData = []
+
+    def getProperty(self, property_name):
+        entities = self.testData["data"]
+        return readFeature(entities, property_name)
+
+    def setProperty(self, property_name, action, data):
+        self.setPropertyData.append({
+            "url" : buildSetPropertyUrl('[id]', '[serial]', 0, property_name, action),
+            "property_name": property_name,
+            "action" : action,
+            "data" : data
+        })
+        

--- a/tests/response_Vitocal200_V2.json
+++ b/tests/response_Vitocal200_V2.json
@@ -1,0 +1,3504 @@
+{
+    "data": [
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/ventilation.operating.modes.standard",
+            "gatewayId": "7571381818533105",
+            "feature": "ventilation.operating.modes.standard",
+            "timestamp": "2021-06-17T03:43:11.720Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                }
+            },
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.operating.programs.standby",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0.operating.programs.standby",
+            "timestamp": "2021-06-17T03:43:11.566Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2.operating.programs.normal",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2.operating.programs.normal",
+            "timestamp": "2021-06-17T03:43:11.556Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "active",
+                "comfort",
+                "eco",
+                "fixed",
+                "normal",
+                "reduced",
+                "standby"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.operating.programs",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0.operating.programs",
+            "timestamp": "2021-06-17T03:43:10.693Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "value": 50,
+                    "unit": "",
+                    "type": "number"
+                }
+            },
+            "commands": {
+                "setTargetTemperature": {
+                    "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature",
+                    "name": "setTargetTemperature",
+                    "isExecutable": true,
+                    "params": {
+                        "temperature": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": 10,
+                                "efficientLowerBorder": 10,
+                                "efficientUpperBorder": 60,
+                                "max": 60,
+                                "stepping": 1
+                            }
+                        }
+                    }
+                }
+            },
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.dhw.temperature.main",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.dhw.temperature.main",
+            "timestamp": "2021-06-17T03:43:11.057Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "unit": {
+                    "value": "celsius",
+                    "type": "string"
+                },
+                "value": {
+                    "type": "number",
+                    "value": 48.5,
+                    "unit": "celsius"
+                },
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                }
+            },
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.top",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.dhw.sensors.temperature.hotWaterStorage.top",
+            "timestamp": "2021-06-17T18:10:24.541Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "active",
+                "standard",
+                "standby",
+                "ventilation"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/ventilation.operating.modes",
+            "gatewayId": "7571381818533105",
+            "feature": "ventilation.operating.modes",
+            "timestamp": "2021-06-17T03:43:10.692Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.configuration.multiFamilyHouse",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.configuration.multiFamilyHouse",
+            "timestamp": "2021-06-17T03:43:11.245Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1.operating.programs.active",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1.operating.programs.active",
+            "timestamp": "2021-06-17T03:43:11.639Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2.operating.modes.standby",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2.operating.modes.standby",
+            "timestamp": "2021-06-17T03:43:11.548Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2.operating.modes.active",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2.operating.modes.active",
+            "timestamp": "2021-06-17T03:43:11.690Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.operating.modes.cooling",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0.operating.modes.cooling",
+            "timestamp": "2021-06-17T03:43:11.303Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "modes",
+                "programs"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2.operating",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2.operating",
+            "timestamp": "2021-06-17T03:43:10.693Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2.operating.programs.reduced",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2.operating.programs.reduced",
+            "timestamp": "2021-06-17T03:43:11.565Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "sensors"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.evaporators.0",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.evaporators.0",
+            "timestamp": "2021-06-17T03:43:10.695Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "value": true,
+                    "type": "boolean"
+                },
+                "entries": {
+                    "value": {
+                        "mon": [
+                            {
+                                "start": "00:00",
+                                "end": "24:00",
+                                "mode": "normal",
+                                "position": 0
+                            }
+                        ],
+                        "tue": [
+                            {
+                                "start": "00:00",
+                                "end": "24:00",
+                                "mode": "normal",
+                                "position": 0
+                            }
+                        ],
+                        "wed": [
+                            {
+                                "start": "00:00",
+                                "end": "24:00",
+                                "mode": "normal",
+                                "position": 0
+                            }
+                        ],
+                        "thu": [
+                            {
+                                "start": "00:00",
+                                "end": "24:00",
+                                "mode": "normal",
+                                "position": 0
+                            }
+                        ],
+                        "fri": [
+                            {
+                                "start": "00:00",
+                                "end": "24:00",
+                                "mode": "normal",
+                                "position": 0
+                            }
+                        ],
+                        "sat": [
+                            {
+                                "start": "00:00",
+                                "end": "24:00",
+                                "mode": "normal",
+                                "position": 0
+                            }
+                        ],
+                        "sun": [
+                            {
+                                "start": "00:00",
+                                "end": "24:00",
+                                "mode": "normal",
+                                "position": 0
+                            }
+                        ]
+                    },
+                    "type": "Schedule"
+                }
+            },
+            "commands": {
+                "setSchedule": {
+                    "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule",
+                    "name": "setSchedule",
+                    "isExecutable": true,
+                    "params": {
+                        "newSchedule": {
+                            "type": "Schedule",
+                            "required": true,
+                            "constraints": {
+                                "modes": [
+                                    "reduced",
+                                    "normal",
+                                    "fixed"
+                                ],
+                                "maxEntries": 8,
+                                "resolution": 10,
+                                "defaultMode": "standby",
+                                "overlapAllowed": true
+                            }
+                        }
+                    }
+                }
+            },
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.heating.schedule",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0.heating.schedule",
+            "timestamp": "2021-06-17T03:43:11.291Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "unit": {
+                    "value": "celsius",
+                    "type": "string"
+                },
+                "value": {
+                    "type": "number",
+                    "value": 27.2,
+                    "unit": "celsius"
+                },
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                }
+            },
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.sensors.temperature.return",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.sensors.temperature.return",
+            "timestamp": "2021-06-17T18:23:08.524Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "active",
+                "cooling",
+                "dhw",
+                "dhwAndHeating",
+                "dhwAndHeatingCooling",
+                "heating",
+                "heatingCooling",
+                "normalStandby",
+                "standby"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.operating.modes",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0.operating.modes",
+            "timestamp": "2021-06-17T03:43:10.693Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.operating.modes.standby",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0.operating.modes.standby",
+            "timestamp": "2021-06-17T03:43:11.543Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "modes",
+                "programs"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/ventilation.operating",
+            "gatewayId": "7571381818533105",
+            "feature": "ventilation.operating",
+            "timestamp": "2021-06-17T03:43:10.692Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "heatingRod",
+                "multiFamilyHouse",
+                "secondaryHeatGenerator"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.configuration",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.configuration",
+            "timestamp": "2021-06-17T03:43:10.692Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "0"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.evaporators",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.evaporators",
+            "timestamp": "2021-06-17T03:43:10.695Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "min": {
+                    "value": 15,
+                    "unit": "celsius",
+                    "type": "number"
+                },
+                "minUnit": {
+                    "value": "celsius",
+                    "type": "string"
+                },
+                "max": {
+                    "value": 45,
+                    "unit": "celsius",
+                    "type": "number"
+                },
+                "maxUnit": {
+                    "value": "celsius",
+                    "type": "string"
+                }
+            },
+            "commands": {
+                "setMin": {
+                    "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.temperature.levels/commands/setMin",
+                    "name": "setMin",
+                    "isExecutable": true,
+                    "params": {
+                        "temperature": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": 1,
+                                "max": 30,
+                                "stepping": 1
+                            }
+                        }
+                    }
+                },
+                "setMax": {
+                    "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.temperature.levels/commands/setMax",
+                    "name": "setMax",
+                    "isExecutable": true,
+                    "params": {
+                        "temperature": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": 10,
+                                "max": 70,
+                                "stepping": 1
+                            }
+                        }
+                    }
+                },
+                "setLevels": {
+                    "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.temperature.levels/commands/setLevels",
+                    "name": "setLevels",
+                    "isExecutable": true,
+                    "params": {
+                        "minTemperature": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": 1,
+                                "max": 30,
+                                "stepping": 1
+                            }
+                        },
+                        "maxTemperature": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": 10,
+                                "max": 70,
+                                "stepping": 1
+                            }
+                        }
+                    }
+                }
+            },
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.temperature.levels",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0.temperature.levels",
+            "timestamp": "2021-06-17T03:43:11.749Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "off"
+                }
+            },
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.circulation.pump",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0.circulation.pump",
+            "timestamp": "2021-06-17T03:43:11.635Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2.temperature.levels",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2.temperature.levels",
+            "timestamp": "2021-06-17T03:43:11.751Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "temperature"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.condensors.0.sensors",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.condensors.0.sensors",
+            "timestamp": "2021-06-17T03:43:10.695Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/ventilation.operating.modes.ventilation",
+            "gatewayId": "7571381818533105",
+            "feature": "ventilation.operating.modes.ventilation",
+            "timestamp": "2021-06-17T03:43:11.721Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                },
+                "demand": {
+                    "value": "unknown",
+                    "type": "string"
+                },
+                "temperature": {
+                    "value": 20,
+                    "unit": "",
+                    "type": "number"
+                }
+            },
+            "commands": {
+                "setTemperature": {
+                    "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/setTemperature",
+                    "name": "setTemperature",
+                    "isExecutable": true,
+                    "params": {
+                        "targetTemperature": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": 10,
+                                "max": 30,
+                                "stepping": 1
+                            }
+                        }
+                    }
+                },
+                "activate": {
+                    "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/activate",
+                    "name": "activate",
+                    "isExecutable": true,
+                    "params": {
+                        "temperature": {
+                            "type": "number",
+                            "required": false,
+                            "constraints": {
+                                "min": 10,
+                                "max": 30,
+                                "stepping": 1
+                            }
+                        }
+                    }
+                },
+                "deactivate": {
+                    "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/deactivate",
+                    "name": "deactivate",
+                    "isExecutable": false,
+                    "params": {}
+                }
+            },
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.operating.programs.comfort",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0.operating.programs.comfort",
+            "timestamp": "2021-06-17T03:43:11.130Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "pump"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.circulation",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0.circulation",
+            "timestamp": "2021-06-17T03:43:10.692Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/ventilation.operating.programs.reduced",
+            "gatewayId": "7571381818533105",
+            "feature": "ventilation.operating.programs.reduced",
+            "timestamp": "2021-06-17T03:43:11.727Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "unit": {
+                    "value": "celsius",
+                    "type": "string"
+                },
+                "value": {
+                    "type": "number",
+                    "value": 48.5,
+                    "unit": "celsius"
+                },
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                }
+            },
+            "commands": {},
+            "components": [
+                "bottom",
+                "top"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.dhw.sensors.temperature.hotWaterStorage",
+            "timestamp": "2021-06-17T18:10:24.536Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1.operating.modes.heating",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1.operating.modes.heating",
+            "timestamp": "2021-06-17T03:43:11.517Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeatingCooling",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2.operating.modes.dhwAndHeatingCooling",
+            "timestamp": "2021-06-17T03:43:11.352Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2.operating.programs.fixed",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2.operating.programs.fixed",
+            "timestamp": "2021-06-17T03:43:11.561Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "circuit"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.solar.pumps",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.solar.pumps",
+            "timestamp": "2021-06-17T03:43:10.695Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1.operating.programs.normal",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1.operating.programs.normal",
+            "timestamp": "2021-06-17T03:43:11.554Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "value": 60,
+                    "unit": "",
+                    "type": "number"
+                }
+            },
+            "commands": {
+                "setTargetTemperature": {
+                    "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.dhw.temperature.temp2/commands/setTargetTemperature",
+                    "name": "setTargetTemperature",
+                    "isExecutable": true,
+                    "params": {
+                        "temperature": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": 10,
+                                "max": 60,
+                                "stepping": 1
+                            }
+                        }
+                    }
+                }
+            },
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.dhw.temperature.temp2",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.dhw.temperature.temp2",
+            "timestamp": "2021-06-17T03:43:11.058Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/ventilation.operating.programs.standard",
+            "gatewayId": "7571381818533105",
+            "feature": "ventilation.operating.programs.standard",
+            "timestamp": "2021-06-17T03:43:11.728Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "enabled": {
+                    "value": [
+                        "0"
+                    ],
+                    "type": "array"
+                }
+            },
+            "commands": {},
+            "components": [
+                "0",
+                "1",
+                "2"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits",
+            "timestamp": "2021-06-17T03:43:11.261Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "pumps",
+                "sensors"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.solar",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.solar",
+            "timestamp": "2021-06-17T03:43:11.732Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2.heating.schedule",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2.heating.schedule",
+            "timestamp": "2021-06-17T03:43:11.294Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1.sensors.temperature.room",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1.sensors.temperature.room",
+            "timestamp": "2021-06-17T03:43:11.571Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.operating.modes.dhw",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0.operating.modes.dhw",
+            "timestamp": "2021-06-17T03:43:11.323Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "boiler",
+                "burner",
+                "burners",
+                "circuits",
+                "compressors",
+                "condensors",
+                "configuration",
+                "device",
+                "dhw",
+                "evaporators",
+                "operating",
+                "sensors",
+                "solar"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating",
+            "gatewayId": "7571381818533105",
+            "feature": "heating",
+            "timestamp": "2021-06-17T03:43:10.692Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1.operating.modes.normalStandby",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1.operating.modes.normalStandby",
+            "timestamp": "2021-06-17T03:43:11.318Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "sensors"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.condensors.0",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.condensors.0",
+            "timestamp": "2021-06-17T03:43:10.695Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "time"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.device",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.device",
+            "timestamp": "2021-06-17T03:43:10.692Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1.temperature.levels",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1.temperature.levels",
+            "timestamp": "2021-06-17T03:43:11.750Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "value": true,
+                    "type": "boolean"
+                },
+                "entries": {
+                    "value": {
+                        "mon": [
+                            {
+                                "start": "11:00",
+                                "end": "22:00",
+                                "mode": "top",
+                                "position": 0
+                            }
+                        ],
+                        "tue": [
+                            {
+                                "start": "11:00",
+                                "end": "22:00",
+                                "mode": "top",
+                                "position": 0
+                            }
+                        ],
+                        "wed": [
+                            {
+                                "start": "11:00",
+                                "end": "22:00",
+                                "mode": "top",
+                                "position": 0
+                            }
+                        ],
+                        "thu": [
+                            {
+                                "start": "11:00",
+                                "end": "22:00",
+                                "mode": "top",
+                                "position": 0
+                            }
+                        ],
+                        "fri": [
+                            {
+                                "start": "11:00",
+                                "end": "22:00",
+                                "mode": "top",
+                                "position": 0
+                            },
+                            {
+                                "start": "10:00",
+                                "end": "11:00",
+                                "mode": "temp-2",
+                                "position": 1
+                            }
+                        ],
+                        "sat": [
+                            {
+                                "start": "10:00",
+                                "end": "22:30",
+                                "mode": "top",
+                                "position": 0
+                            }
+                        ],
+                        "sun": [
+                            {
+                                "start": "10:00",
+                                "end": "22:30",
+                                "mode": "top",
+                                "position": 0
+                            }
+                        ]
+                    },
+                    "type": "Schedule"
+                }
+            },
+            "commands": {
+                "setSchedule": {
+                    "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.dhw.schedule/commands/setSchedule",
+                    "name": "setSchedule",
+                    "isExecutable": true,
+                    "params": {
+                        "newSchedule": {
+                            "type": "Schedule",
+                            "required": true,
+                            "constraints": {
+                                "modes": [
+                                    "top",
+                                    "normal",
+                                    "temp-2"
+                                ],
+                                "maxEntries": 8,
+                                "resolution": 10,
+                                "defaultMode": "off",
+                                "overlapAllowed": true
+                            }
+                        }
+                    }
+                }
+            },
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.dhw.schedule",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.dhw.schedule",
+            "timestamp": "2021-06-17T03:43:11.644Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeatingCooling",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0.operating.modes.dhwAndHeatingCooling",
+            "timestamp": "2021-06-17T03:43:11.339Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeatingCooling",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1.operating.modes.dhwAndHeatingCooling",
+            "timestamp": "2021-06-17T03:43:11.343Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "temperature"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.evaporators.0.sensors",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.evaporators.0.sensors",
+            "timestamp": "2021-06-17T03:43:10.695Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "active",
+                "comfort",
+                "eco",
+                "fixed",
+                "normal",
+                "reduced",
+                "standby"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2.operating.programs",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2.operating.programs",
+            "timestamp": "2021-06-17T03:43:10.693Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "offset"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.device.time",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.device.time",
+            "timestamp": "2021-06-17T03:43:10.695Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2.operating.modes.normalStandby",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2.operating.modes.normalStandby",
+            "timestamp": "2021-06-17T03:43:11.320Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1.operating.programs.reduced",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1.operating.programs.reduced",
+            "timestamp": "2021-06-17T03:43:11.563Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/ventilation.operating.modes.standby",
+            "gatewayId": "7571381818533105",
+            "feature": "ventilation.operating.modes.standby",
+            "timestamp": "2021-06-17T03:43:11.719Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.operating.modes.heatingCooling",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0.operating.modes.heatingCooling",
+            "timestamp": "2021-06-17T03:43:11.490Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2.operating.programs.comfort",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2.operating.programs.comfort",
+            "timestamp": "2021-06-17T03:43:11.134Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 0,
+                    "unit": ""
+                }
+            },
+            "commands": {},
+            "components": [
+                "levels"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1.temperature",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1.temperature",
+            "timestamp": "2021-06-17T03:43:11.747Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1.frostprotection",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1.frostprotection",
+            "timestamp": "2021-06-17T03:43:11.280Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.condensors.0.sensors.temperature",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.condensors.0.sensors.temperature",
+            "timestamp": "2021-06-17T03:43:10.695Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "holiday"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.operating.programs",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.operating.programs",
+            "timestamp": "2021-06-17T03:43:10.692Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1.operating.modes.heatingCooling",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1.operating.modes.heatingCooling",
+            "timestamp": "2021-06-17T03:43:11.501Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "value": 5,
+                    "unit": "",
+                    "type": "number"
+                }
+            },
+            "commands": {
+                "setHysteresis": {
+                    "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresis",
+                    "name": "setHysteresis",
+                    "isExecutable": true,
+                    "params": {
+                        "hysteresis": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": 1,
+                                "max": 10,
+                                "stepping": 0.5
+                            }
+                        }
+                    }
+                }
+            },
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.dhw.temperature.hysteresis",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.dhw.temperature.hysteresis",
+            "timestamp": "2021-06-17T03:43:11.632Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "7785226810473114"
+                }
+            },
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.controller.serial",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.controller.serial",
+            "timestamp": "2021-06-17T03:43:11.590Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "production"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.compressors.0.heat",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.compressors.0.heat",
+            "timestamp": "2021-06-17T03:43:10.694Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.compressors.0.heat.production",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.compressors.0.heat.production",
+            "timestamp": "2021-06-17T03:43:10.694Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.solar.sensors.temperature.collector",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.solar.sensors.temperature.collector",
+            "timestamp": "2021-06-17T03:43:11.733Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "unit": {
+                    "value": "celsius",
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string",
+                    "value": "notConnected"
+                }
+            },
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.dhw.sensors.temperature.outlet",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.dhw.sensors.temperature.outlet",
+            "timestamp": "2021-06-17T03:43:11.634Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "modes",
+                "programs"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.operating",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0.operating",
+            "timestamp": "2021-06-17T03:43:10.692Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "unit": {
+                    "value": "celsius",
+                    "type": "string"
+                },
+                "value": {
+                    "type": "number",
+                    "value": 27.2,
+                    "unit": "celsius"
+                },
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                }
+            },
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.secondaryCircuit.sensors.temperature.return",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.secondaryCircuit.sensors.temperature.return",
+            "timestamp": "2021-06-17T17:46:06.978Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "outside",
+                "return"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.sensors.temperature",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.sensors.temperature",
+            "timestamp": "2021-06-17T03:43:10.694Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "schedule"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.heating",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0.heating",
+            "timestamp": "2021-06-17T03:43:10.692Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "value": true,
+                    "type": "boolean"
+                },
+                "name": {
+                    "value": "",
+                    "type": "string"
+                },
+                "type": {
+                    "value": "heatingCircuit",
+                    "type": "string"
+                }
+            },
+            "commands": {
+                "setName": {
+                    "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0/commands/setName",
+                    "name": "setName",
+                    "isExecutable": true,
+                    "params": {
+                        "name": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "minLength": 1,
+                                "maxLength": 20
+                            }
+                        }
+                    }
+                }
+            },
+            "components": [
+                "circulation",
+                "frostprotection",
+                "heating",
+                "operating",
+                "sensors",
+                "temperature"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0",
+            "timestamp": "2021-06-17T03:43:11.255Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2.sensors.temperature.room",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2.sensors.temperature.room",
+            "timestamp": "2021-06-17T03:43:11.572Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "unit": {
+                    "value": "celsius",
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string",
+                    "value": "notConnected"
+                }
+            },
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.boiler.sensors.temperature.commonSupply",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.boiler.sensors.temperature.commonSupply",
+            "timestamp": "2021-06-17T03:43:11.218Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                }
+            },
+            "commands": {
+                "activate": {
+                    "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.dhw.oneTimeCharge/commands/activate",
+                    "name": "activate",
+                    "isExecutable": true,
+                    "params": {}
+                },
+                "deactivate": {
+                    "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate",
+                    "name": "deactivate",
+                    "isExecutable": false,
+                    "params": {}
+                }
+            },
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.dhw.oneTimeCharge",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.dhw.oneTimeCharge",
+            "timestamp": "2021-06-17T03:43:11.617Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "room",
+                "supply"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2.sensors.temperature",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2.sensors.temperature",
+            "timestamp": "2021-06-17T03:43:10.694Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2.operating.modes.dhw",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2.operating.modes.dhw",
+            "timestamp": "2021-06-17T03:43:11.328Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "7571447801104117"
+                }
+            },
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.boiler.serial",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.boiler.serial",
+            "timestamp": "2021-06-17T03:43:11.235Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "programs"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.operating",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.operating",
+            "timestamp": "2021-06-17T03:43:10.692Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2.operating.modes.cooling",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2.operating.modes.cooling",
+            "timestamp": "2021-06-17T03:43:11.311Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2.operating.modes.heatingCooling",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2.operating.modes.heatingCooling",
+            "timestamp": "2021-06-17T03:43:11.510Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "collector",
+                "dhw"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.solar.sensors.temperature",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.solar.sensors.temperature",
+            "timestamp": "2021-06-17T03:43:10.695Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "room",
+                "supply"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1.sensors.temperature",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1.sensors.temperature",
+            "timestamp": "2021-06-17T03:43:10.694Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeating",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2.operating.modes.dhwAndHeating",
+            "timestamp": "2021-06-17T03:43:11.418Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.sensors.valve",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.sensors.valve",
+            "timestamp": "2021-06-17T03:43:10.695Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/ventilation.operating.programs.active",
+            "gatewayId": "7571381818533105",
+            "feature": "ventilation.operating.programs.active",
+            "timestamp": "2021-06-17T03:43:11.722Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.boiler.sensors",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.boiler.sensors",
+            "timestamp": "2021-06-17T03:43:10.693Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1.sensors.temperature.supply",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1.sensors.temperature.supply",
+            "timestamp": "2021-06-17T03:43:11.574Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/ventilation.operating.programs.intensive",
+            "gatewayId": "7571381818533105",
+            "feature": "ventilation.operating.programs.intensive",
+            "timestamp": "2021-06-17T03:43:11.729Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.operating.programs.fixed",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0.operating.programs.fixed",
+            "timestamp": "2021-06-17T03:43:11.559Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "0"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.burners",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.burners",
+            "timestamp": "2021-06-17T03:43:10.694Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.compressors.1.heat.production",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.compressors.1.heat.production",
+            "timestamp": "2021-06-17T03:43:10.694Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "off"
+                }
+            },
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.dhw.pumps.primary",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.dhw.pumps.primary",
+            "timestamp": "2021-06-17T03:43:11.618Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 105,
+                    "unit": ""
+                }
+            },
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.device.time.offset",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.device.time.offset",
+            "timestamp": "2021-06-17T15:43:13.514Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.burner",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.burner",
+            "timestamp": "2021-06-17T03:43:11.252Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "pump"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1.circulation",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1.circulation",
+            "timestamp": "2021-06-17T03:43:10.695Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2.circulation.pump",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2.circulation.pump",
+            "timestamp": "2021-06-17T03:43:11.637Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "unit": {
+                    "value": "celsius",
+                    "type": "string"
+                },
+                "value": {
+                    "type": "number",
+                    "value": 25.3,
+                    "unit": "celsius"
+                },
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                }
+            },
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.sensors.temperature.room",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0.sensors.temperature.room",
+            "timestamp": "2021-06-17T14:39:45.293Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.dhw.sensors",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.dhw.sensors",
+            "timestamp": "2021-06-17T03:43:10.695Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.configuration.heatingRod",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.configuration.heatingRod",
+            "timestamp": "2021-06-17T03:43:10.692Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "normal"
+                }
+            },
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.operating.programs.active",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0.operating.programs.active",
+            "timestamp": "2021-06-17T03:43:11.638Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.dhw.charging",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.dhw.charging",
+            "timestamp": "2021-06-17T09:15:15.000Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "temperature"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.solar.sensors",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.solar.sensors",
+            "timestamp": "2021-06-17T03:43:10.695Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "heat"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.compressors.1",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.compressors.1",
+            "timestamp": "2021-06-17T03:43:11.088Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/device",
+            "gatewayId": "7571381818533105",
+            "feature": "device",
+            "timestamp": "2021-06-17T03:43:10.693Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/ventilation.operating.programs.standby",
+            "gatewayId": "7571381818533105",
+            "feature": "ventilation.operating.programs.standby",
+            "timestamp": "2021-06-17T03:43:11.725Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.configuration.secondaryHeatGenerator",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.configuration.secondaryHeatGenerator",
+            "timestamp": "2021-06-17T03:43:10.692Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.compressors.0.sensors.temperature",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.compressors.0.sensors.temperature",
+            "timestamp": "2021-06-17T03:43:10.694Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1.operating.programs.comfort",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1.operating.programs.comfort",
+            "timestamp": "2021-06-17T03:43:11.132Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "active",
+                "cooling",
+                "dhw",
+                "dhwAndHeating",
+                "dhwAndHeatingCooling",
+                "heating",
+                "heatingCooling",
+                "normalStandby",
+                "standby"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2.operating.modes",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2.operating.modes",
+            "timestamp": "2021-06-17T03:43:10.693Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "value": 50,
+                    "unit": "",
+                    "type": "number"
+                }
+            },
+            "commands": {
+                "setTargetTemperature": {
+                    "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.dhw.temperature/commands/setTargetTemperature",
+                    "name": "setTargetTemperature",
+                    "isExecutable": true,
+                    "params": {
+                        "temperature": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": 10,
+                                "max": 60,
+                                "stepping": 1
+                            }
+                        }
+                    }
+                }
+            },
+            "components": [
+                "hysteresis",
+                "main",
+                "temp2"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.dhw.temperature",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.dhw.temperature",
+            "timestamp": "2021-06-17T03:43:11.056Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                },
+                "demand": {
+                    "value": "unknown",
+                    "type": "string"
+                },
+                "temperature": {
+                    "value": 20,
+                    "unit": "",
+                    "type": "number"
+                }
+            },
+            "commands": {
+                "setTemperature": {
+                    "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.operating.programs.reduced/commands/setTemperature",
+                    "name": "setTemperature",
+                    "isExecutable": true,
+                    "params": {
+                        "targetTemperature": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": 10,
+                                "max": 30,
+                                "stepping": 1
+                            }
+                        }
+                    }
+                }
+            },
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.operating.programs.reduced",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0.operating.programs.reduced",
+            "timestamp": "2021-06-17T03:43:11.562Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1.operating.modes.active",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1.operating.modes.active",
+            "timestamp": "2021-06-17T03:43:11.669Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "enabled": {
+                    "value": [
+                        "0"
+                    ],
+                    "type": "array"
+                }
+            },
+            "commands": {},
+            "components": [
+                "0",
+                "1"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.compressors",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.compressors",
+            "timestamp": "2021-06-17T03:43:11.089Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.operating.modes.heating",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0.operating.modes.heating",
+            "timestamp": "2021-06-17T03:43:11.514Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1.operating.modes.dhwAndHeating",
+            "timestamp": "2021-06-17T03:43:11.368Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                },
+                "status": {
+                    "type": "string",
+                    "value": "on"
+                }
+            },
+            "commands": {},
+            "components": [
+                "charging",
+                "oneTimeCharge",
+                "schedule",
+                "sensors",
+                "temperature"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.dhw",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.dhw",
+            "timestamp": "2021-06-17T03:43:11.641Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "unit": {
+                    "value": "celsius",
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string",
+                    "value": "notConnected"
+                }
+            },
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.bottom",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.dhw.sensors.temperature.hotWaterStorage.bottom",
+            "timestamp": "2021-06-17T03:43:11.625Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "operating",
+                "schedule"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/ventilation",
+            "gatewayId": "7571381818533105",
+            "feature": "ventilation",
+            "timestamp": "2021-06-17T03:43:11.716Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.solar.pumps.circuit",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.solar.pumps.circuit",
+            "timestamp": "2021-06-17T03:43:11.738Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1.operating.programs.standby",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1.operating.programs.standby",
+            "timestamp": "2021-06-17T03:43:11.567Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "modes",
+                "programs"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1.operating",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1.operating",
+            "timestamp": "2021-06-17T03:43:10.693Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "off"
+                }
+            },
+            "commands": {},
+            "components": [
+                "schedule"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.dhw.pumps.circulation",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.dhw.pumps.circulation",
+            "timestamp": "2021-06-17T03:43:11.620Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "unit": {
+                    "value": "celsius",
+                    "type": "string"
+                },
+                "value": {
+                    "type": "number",
+                    "value": 27.1,
+                    "unit": "celsius"
+                },
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                }
+            },
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.sensors.temperature.supply",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0.sensors.temperature.supply",
+            "timestamp": "2021-06-17T18:20:13.047Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/ventilation.schedule",
+            "gatewayId": "7571381818533105",
+            "feature": "ventilation.schedule",
+            "timestamp": "2021-06-17T03:43:11.717Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "value": "dhwAndHeatingCooling",
+                    "type": "string"
+                }
+            },
+            "commands": {
+                "setMode": {
+                    "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode",
+                    "name": "setMode",
+                    "isExecutable": true,
+                    "params": {
+                        "mode": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "enum": [
+                                    "standby",
+                                    "dhw",
+                                    "dhwAndHeatingCooling"
+                                ]
+                            }
+                        }
+                    }
+                }
+            },
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.operating.modes.active",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0.operating.modes.active",
+            "timestamp": "2021-06-17T03:43:11.649Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2.frostprotection",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2.frostprotection",
+            "timestamp": "2021-06-17T03:43:11.283Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1.operating.modes.cooling",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1.operating.modes.cooling",
+            "timestamp": "2021-06-17T03:43:11.307Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.burners.0",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.burners.0",
+            "timestamp": "2021-06-17T03:43:10.694Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1.operating.programs.eco",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1.operating.programs.eco",
+            "timestamp": "2021-06-17T03:43:11.555Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1.operating.modes.standby",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1.operating.modes.standby",
+            "timestamp": "2021-06-17T03:43:11.546Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "unit": {
+                    "value": "celsius",
+                    "type": "string"
+                },
+                "value": {
+                    "type": "number",
+                    "value": 33.3,
+                    "unit": "celsius"
+                },
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                }
+            },
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.secondaryCircuit.sensors.temperature.supply",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.secondaryCircuit.sensors.temperature.supply",
+            "timestamp": "2021-06-17T18:19:51.668Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "room",
+                "supply"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.sensors.temperature",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0.sensors.temperature",
+            "timestamp": "2021-06-17T03:43:10.694Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2.operating.programs.active",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2.operating.programs.active",
+            "timestamp": "2021-06-17T03:43:11.640Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "unit": {
+                    "value": "celsius",
+                    "type": "string"
+                },
+                "value": {
+                    "type": "number",
+                    "value": 29,
+                    "unit": "celsius"
+                },
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                }
+            },
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.primaryCircuit.sensors.temperature.supply",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.primaryCircuit.sensors.temperature.supply",
+            "timestamp": "2021-06-17T18:22:30.220Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2.operating.programs.eco",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2.operating.programs.eco",
+            "timestamp": "2021-06-17T03:43:11.557Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "circulation",
+                "frostprotection",
+                "heating",
+                "operating",
+                "sensors",
+                "temperature"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1",
+            "timestamp": "2021-06-17T03:43:11.257Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1.operating.programs.fixed",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1.operating.programs.fixed",
+            "timestamp": "2021-06-17T03:43:11.560Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "active",
+                "basic",
+                "intensive",
+                "reduced",
+                "standard",
+                "standby"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/ventilation.operating.programs",
+            "gatewayId": "7571381818533105",
+            "feature": "ventilation.operating.programs",
+            "timestamp": "2021-06-17T03:43:10.692Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                },
+                "temperature": {
+                    "value": 20,
+                    "unit": "",
+                    "type": "number"
+                }
+            },
+            "commands": {
+                "activate": {
+                    "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.operating.programs.eco/commands/activate",
+                    "name": "activate",
+                    "isExecutable": true,
+                    "params": {}
+                },
+                "deactivate": {
+                    "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.operating.programs.eco/commands/deactivate",
+                    "name": "deactivate",
+                    "isExecutable": false,
+                    "params": {}
+                }
+            },
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.operating.programs.eco",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0.operating.programs.eco",
+            "timestamp": "2021-06-17T03:43:11.552Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                },
+                "start": {
+                    "value": "",
+                    "type": "string"
+                },
+                "end": {
+                    "value": "",
+                    "type": "string"
+                }
+            },
+            "commands": {
+                "changeEndDate": {
+                    "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate",
+                    "name": "changeEndDate",
+                    "isExecutable": false,
+                    "params": {
+                        "end": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
+                                "sameDayAllowed": false
+                            }
+                        }
+                    }
+                },
+                "schedule": {
+                    "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.operating.programs.holiday/commands/schedule",
+                    "name": "schedule",
+                    "isExecutable": true,
+                    "params": {
+                        "start": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$"
+                            }
+                        },
+                        "end": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
+                                "sameDayAllowed": false
+                            }
+                        }
+                    }
+                },
+                "unschedule": {
+                    "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.operating.programs.holiday/commands/unschedule",
+                    "name": "unschedule",
+                    "isExecutable": true,
+                    "params": {}
+                }
+            },
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.operating.programs.holiday",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.operating.programs.holiday",
+            "timestamp": "2021-06-17T03:43:11.740Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 22.1,
+                    "unit": ""
+                }
+            },
+            "commands": {},
+            "components": [
+                "levels"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.temperature",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0.temperature",
+            "timestamp": "2021-06-17T18:20:03.418Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "pump"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2.circulation",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2.circulation",
+            "timestamp": "2021-06-17T03:43:10.695Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1.circulation.pump",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1.circulation.pump",
+            "timestamp": "2021-06-17T03:43:11.636Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/ventilation.operating.programs.basic",
+            "gatewayId": "7571381818533105",
+            "feature": "ventilation.operating.programs.basic",
+            "timestamp": "2021-06-17T03:43:11.726Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "unit": {
+                    "value": "celsius",
+                    "type": "string"
+                },
+                "value": {
+                    "type": "number",
+                    "value": 28.3,
+                    "unit": "celsius"
+                },
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                }
+            },
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.sensors.temperature.outside",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.sensors.temperature.outside",
+            "timestamp": "2021-06-17T18:22:30.226Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.evaporators.0.sensors.temperature",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.evaporators.0.sensors.temperature",
+            "timestamp": "2021-06-17T03:43:10.695Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "sensors",
+                "serial"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.boiler",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.boiler",
+            "timestamp": "2021-06-17T03:43:10.693Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "temperature"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1.sensors",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1.sensors",
+            "timestamp": "2021-06-17T03:43:10.694Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.operating.modes.normalStandby",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0.operating.modes.normalStandby",
+            "timestamp": "2021-06-17T03:43:11.314Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "schedule"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1.heating",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1.heating",
+            "timestamp": "2021-06-17T03:43:10.692Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1.operating.modes.dhw",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1.operating.modes.dhw",
+            "timestamp": "2021-06-17T03:43:11.325Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "temperature"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.compressors.0.sensors",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.compressors.0.sensors",
+            "timestamp": "2021-06-17T03:43:10.693Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "active",
+                "comfort",
+                "eco",
+                "fixed",
+                "normal",
+                "reduced",
+                "standby"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1.operating.programs",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1.operating.programs",
+            "timestamp": "2021-06-17T03:43:10.693Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/ventilation.operating.modes.active",
+            "gatewayId": "7571381818533105",
+            "feature": "ventilation.operating.modes.active",
+            "timestamp": "2021-06-17T03:43:11.718Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "active",
+                "cooling",
+                "dhw",
+                "dhwAndHeating",
+                "dhwAndHeatingCooling",
+                "heating",
+                "heatingCooling",
+                "normalStandby",
+                "standby"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1.operating.modes",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1.operating.modes",
+            "timestamp": "2021-06-17T03:43:10.693Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "unit": {
+                    "value": "celsius",
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string",
+                    "value": "notConnected"
+                }
+            },
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.primaryCircuit.sensors.temperature.return",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.primaryCircuit.sensors.temperature.return",
+            "timestamp": "2021-06-17T03:43:11.578Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.solar.sensors.temperature.dhw",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.solar.sensors.temperature.dhw",
+            "timestamp": "2021-06-17T03:43:11.714Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "circulation",
+                "frostprotection",
+                "heating",
+                "operating",
+                "sensors",
+                "temperature"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2",
+            "timestamp": "2021-06-17T03:43:11.260Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2.operating.programs.standby",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2.operating.programs.standby",
+            "timestamp": "2021-06-17T03:43:11.568Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "value": true,
+                    "type": "boolean"
+                },
+                "demand": {
+                    "value": "unknown",
+                    "type": "string"
+                },
+                "temperature": {
+                    "value": 20,
+                    "unit": "",
+                    "type": "number"
+                }
+            },
+            "commands": {
+                "setTemperature": {
+                    "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature",
+                    "name": "setTemperature",
+                    "isExecutable": true,
+                    "params": {
+                        "targetTemperature": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": 10,
+                                "max": 30,
+                                "stepping": 1
+                            }
+                        }
+                    }
+                }
+            },
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.operating.programs.normal",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0.operating.programs.normal",
+            "timestamp": "2021-06-17T03:43:11.551Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "production"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.compressors.1.heat",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.compressors.1.heat",
+            "timestamp": "2021-06-17T03:43:10.694Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0.operating.modes.dhwAndHeating",
+            "timestamp": "2021-06-17T03:43:11.359Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 0,
+                    "unit": ""
+                }
+            },
+            "commands": {},
+            "components": [
+                "levels"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2.temperature",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2.temperature",
+            "timestamp": "2021-06-17T03:43:11.748Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "0"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.condensors",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.condensors",
+            "timestamp": "2021-06-17T03:43:10.694Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "temperature"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.sensors",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0.sensors",
+            "timestamp": "2021-06-17T03:43:10.694Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                },
+                "phase": {
+                    "type": "string",
+                    "value": "off"
+                }
+            },
+            "commands": {},
+            "components": [
+                "heat",
+                "sensors"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.compressors.0",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.compressors.0",
+            "timestamp": "2021-06-17T09:25:08.187Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.1.heating.schedule",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.1.heating.schedule",
+            "timestamp": "2021-06-17T03:43:11.292Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "schedule"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2.heating",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2.heating",
+            "timestamp": "2021-06-17T03:43:10.692Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2.sensors.temperature.supply",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2.sensors.temperature.supply",
+            "timestamp": "2021-06-17T03:43:11.575Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "off"
+                }
+            },
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.0.frostprotection",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.0.frostprotection",
+            "timestamp": "2021-06-17T03:43:11.278Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "temperature",
+                "valve"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.sensors",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.sensors",
+            "timestamp": "2021-06-17T03:43:10.694Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2.operating.modes.heating",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2.operating.modes.heating",
+            "timestamp": "2021-06-17T03:43:11.522Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "components": [
+                "temperature"
+            ],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.circuits.2.sensors",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.circuits.2.sensors",
+            "timestamp": "2021-06-17T03:43:10.694Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "value": true,
+                    "type": "boolean"
+                },
+                "entries": {
+                    "value": {
+                        "mon": [],
+                        "tue": [],
+                        "wed": [],
+                        "thu": [],
+                        "fri": [],
+                        "sat": [],
+                        "sun": []
+                    },
+                    "type": "Schedule"
+                }
+            },
+            "commands": {
+                "setSchedule": {
+                    "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/setSchedule",
+                    "name": "setSchedule",
+                    "isExecutable": true,
+                    "params": {
+                        "newSchedule": {
+                            "type": "Schedule",
+                            "required": true,
+                            "constraints": {
+                                "modes": [
+                                    "5/25-cycles",
+                                    "5/10-cycles",
+                                    "on"
+                                ],
+                                "maxEntries": 8,
+                                "resolution": 10,
+                                "defaultMode": "off",
+                                "overlapAllowed": true
+                            }
+                        }
+                    }
+                }
+            },
+            "components": [],
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/154905/gateways/7571381818533105/devices/0/features/heating.dhw.pumps.circulation.schedule",
+            "gatewayId": "7571381818533105",
+            "feature": "heating.dhw.pumps.circulation.schedule",
+            "timestamp": "2021-06-17T03:43:11.642Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        }
+    ]
+}

--- a/tests/test_Vitocal200_V2.py
+++ b/tests/test_Vitocal200_V2.py
@@ -1,37 +1,45 @@
 import unittest
-from tests.ViCareServiceMock import ViCareServiceMock
+from tests.ViCareServiceMockV2 import ViCareServiceMockV2
 from PyViCare.PyViCareHeatPump import HeatPump
 from PyViCare.PyViCare import PyViCareNotSupportedFeatureError
 import PyViCare.Feature
 
-class Vitocal200(unittest.TestCase):
+class Vitocal200V2(unittest.TestCase):
     def setUp(self):
-        self.service = ViCareServiceMock('response_Vitocal200.json', 0)
+        self.service = ViCareServiceMockV2('response_Vitocal200_V2.json', 0)
         self.heat = HeatPump(None, None, None, 0, 0, self.service)
         PyViCare.Feature.raise_exception_on_not_supported_device_feature = True
         
     def test_getCompressorActive(self):
         self.assertEqual(self.heat.getCompressorActive(), False)
 
+    @unittest.skip("Not available in V2 yet")
     def test_getCompressorHours(self):
         self.assertAlmostEqual(self.heat.getCompressorHours(), 8541)
 
+
+    @unittest.skip("Not available in V2 yet")
     def test_getHeatingRodStatusOverall(self):
         self.assertEqual(self.heat.getHeatingRodStatusOverall(), False)
 
+    @unittest.skip("Not available in V2 yet")
     def test_getHeatingRodStatusLevel1(self):
         self.assertEqual(self.heat.getHeatingRodStatusLevel1(), False)
 
     def test_getReturnTemperature(self):
-        self.assertAlmostEqual(self.heat.getReturnTemperature(), 23.3)
+        self.assertAlmostEqual(self.heat.getReturnTemperature(), 27.2)
 
+    @unittest.skip("Not available in V2 yet")
     def test_getMonthSinceLastService_fails(self):
         self.assertRaises(PyViCareNotSupportedFeatureError, self.heat.getMonthSinceLastService)
 
+
+    @unittest.skip("Not available in V2 yet")
     def test_getPrograms_fails(self):
         expected_programs = ['active', 'comfort', 'eco', 'fixed', 'normal', 'reduced', 'screedDrying', 'standby']
         self.assertListEqual(self.heat.getPrograms(), expected_programs)
-    
+
+    @unittest.skip("Not available in V2 yet")    
     def test_getModes(self):
         expected_modes = ['standby', 'dhw', 'dhwAndHeatingCooling']
         self.assertListEqual(self.heat.getModes(), expected_modes)


### PR DESCRIPTION
This PR adds support for the Viessmann V2 API. Instructions how to use the new API are in the readme.

The most important part is that every user has to create an account in the viessmann developer portal and use their personal client id.