### PR TITLE
Enable Python 3.9 in build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: ["3.4.10", "3.6", "3.8"]
+        python-version: ["3.4.10", "3.6", "3.8", "3.9"]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
HA uses Python 3.9