### PR TITLE
Flip feature flags to raise exceptions on certain errors

### DIFF
--- a/PyViCare/Feature.py
+++ b/PyViCare/Feature.py
@@ -1,7 +1,7 @@
 # Feature flag to raise an exception in case of a non existing device feature.
 # The flag should be fully removed in a later release.
 # It allows dependend libraries to gracefully migrate to the new behaviour
-raise_exception_on_not_supported_device_feature = False
+raise_exception_on_not_supported_device_feature = True
 
 # Feature flag to raise exception if rate limit of the API is hit
-raise_exception_on_rate_limit = False
+raise_exception_on_rate_limit = True

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This library implements access to Viessmann devices by using the official API fr
 ## Breaking changes in version 1.x
 
 * The versions prior to 1.x used an inofficial API which stopped working on July, 15th 2021. All users need to migrate to version 1.0.0 to continue using the API.
-* Exception is raised if the library runs into a API rate limit.  (Can be disabld via feature flag `raise_exception_on_rate_limit`)
-* Exception is raised if an unsupported device feature is used. (Can be disabld via feature flag `raise_exception_on_not_supported_device_feature`)
+* Exception is raised if the library runs into a API rate limit.  (See feature flag `raise_exception_on_rate_limit`)
+* Exception is raised if an unsupported device feature is used. (See feature flag `raise_exception_on_not_supported_device_feature`)
 * Python 3.4 is no longer supported.
 * Python 3.9 is now supported.
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This library implements access to Viessmann devices by using the official API fr
 ## Breaking changes in version 1.x
 
 * The versions prior to 1.x used an inofficial API which stopped working on July, 15th 2021. All users need to migrate to version 1.0.0 to continue using the API.
-* Exception is raised if the library runs into a API rate limit.  (Can be disabld via feature flag)
-* Exception is raised if an unsupported device feature is used. (Can be disabld via feature flag)
+* Exception is raised if the library runs into a API rate limit.  (Can be disabld via feature flag `raise_exception_on_rate_limit`)
+* Exception is raised if an unsupported device feature is used. (Can be disabld via feature flag `raise_exception_on_not_supported_device_feature`)
 * Python 3.4 is no longer supported.
 * Python 3.9 is now supported.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This library implements access to Viessmann devices by using the official API fr
 ## Breaking changes in version 1.x
 
 * The versions prior to 1.x used an inofficial API which stopped working on July, 15th 2021. All users need to migrate to version 1.0.0 to continue using the API.
+* Exception is raised if the library runs into a API rate limit.  (Can be disabld via feature flag)
+* Exception is raised if an unsupported device feature is used. (Can be disabld via feature flag)
 * Python 3.4 is no longer supported.
 * Python 3.9 is now supported.
 


### PR DESCRIPTION
As we flip the major version, this PR flips the feature flags. We should still keep them there so that dependent libraries can flip it back.