### PR TITLE
Fixes device_id as circuit_id usage

### DIFF
--- a/PyViCare/PyViCareCachedService.py
+++ b/PyViCare/PyViCareCachedService.py
@@ -29,7 +29,7 @@ class ViCareCachedService(ViCareService):
                 url = '/equipment/installations/' + \
                     str(self.accessor.id) + '/gateways/' + \
                     str(self.accessor.serial) + '/devices/' + \
-                    str(self.accessor.circuit) + '/features/'
+                    str(self.accessor.device_id) + '/features/'
                 self.cache = self.oauth_manager.get(url)
                 self.cacheTime = datetime.now()
             return self.cache

--- a/PyViCare/PyViCareDevice.py
+++ b/PyViCare/PyViCareDevice.py
@@ -34,10 +34,11 @@ class Device:
     # TODO cirtcuit management should move at method level
     def __init__(self, service):
         self.service = service
+        self.circuit = 0
 
-    @property
-    def circuit(self):
-        return self.service.accessor.circuit
+    
+    def setCircuit(self, circuit):
+        self.circuit = circuit
         
     """ Set the active mode
     Parameters
@@ -337,4 +338,8 @@ class Device:
 
     def activateOneTimeCharge(self):
         return self.service.setProperty("heating.dhw.oneTimeCharge","activate","{}")
+
+    @handleNotSupported
+    def getAvailableCircuits(self):
+        return self.service.getProperty("heating.circuits")["properties"]["enabled"]["value"]
 

--- a/PyViCare/PyViCareService.py
+++ b/PyViCare/PyViCareService.py
@@ -16,18 +16,18 @@ def readFeature(entities, property_name):
     return feature
 
 
-def buildSetPropertyUrl(id, serial, circuit, property_name, action):
-    return '/equipment/installations/'+str(id)+'/gateways/'+str(serial)+'/devices/'+str(circuit)+'/features/'+property_name+'/'+action
+def buildSetPropertyUrl(accessor, property_name, action):
+    return '/equipment/installations/'+str(accessor.id)+'/gateways/'+str(accessor.serial)+'/devices/'+str(accessor.device_id)+'/features/'+property_name+'/'+action
 
 
-def buildGetPropertyUrl(id, serial, circuit, property_name):
-    return '/equipment/installations/'+str(id)+'/gateways/'+str(serial)+'/devices/'+str(circuit)+'/features/'+property_name
+def buildGetPropertyUrl(accessor, property_name):
+    return '/equipment/installations/'+str(accessor.id)+'/gateways/'+str(accessor.serial)+'/devices/'+str(accessor.device_id)+'/features/'+property_name
 
 class ViCareDeviceAccessor:
-    def __init__(self, id, serial, circuit):
+    def __init__(self, id, serial, device_id):
         self.id = id
         self.serial = serial
-        self.circuit = circuit
+        self.device_id = device_id
 
 
 class ViCareService:
@@ -37,11 +37,11 @@ class ViCareService:
 
     def getProperty(self, property_name):
         url = buildGetPropertyUrl(
-            self.accessor.id, self.accessor.serial, self.accessor.circuit, property_name)
+            self.accessor, property_name)
         j = self.oauth_manager.get(url)
         return j
 
     def setProperty(self, property_name, action, data):
         url = buildSetPropertyUrl(
-            self.accessor.id, self.accessor.serial, self.accessor.circuit, property_name, action)
+            self.accessor, property_name, action)
         return self.oauth_manager.post(url, data)

--- a/tests/ViCareServiceMock.py
+++ b/tests/ViCareServiceMock.py
@@ -3,7 +3,7 @@ from tests.helper import readJson
 
 class ViCareServiceMock:
     
-    def __init__(self, filename, circuit, rawInput = None):
+    def __init__(self, filename, rawInput = None):
         if rawInput is None:
             testData = readJson(filename)
             self.testData = testData
@@ -11,7 +11,7 @@ class ViCareServiceMock:
             self.testData = rawInput
 
         self.accessor = ViCareDeviceAccessor(
-                        '[id]', '[serial]', circuit)
+                        '[id]', '[serial]', '[deviceid]')
         self.setPropertyData = []
 
     def getProperty(self, property_name):
@@ -20,7 +20,7 @@ class ViCareServiceMock:
 
     def setProperty(self, property_name, action, data):
         self.setPropertyData.append({
-            "url" : buildSetPropertyUrl(self.accessor.id, self.accessor.serial, self.accessor.circuit, property_name, action),
+            "url" : buildSetPropertyUrl(self.accessor, property_name, action),
             "property_name": property_name,
             "action" : action,
             "data" : data

--- a/tests/test_GenericDevice.py
+++ b/tests/test_GenericDevice.py
@@ -4,7 +4,7 @@ from PyViCare.PyViCareDevice import Device
 
 class GenericDevice(unittest.TestCase):
     def setUp(self):
-        self.service = ViCareServiceMock(None, 0, {})
+        self.service = ViCareServiceMock(None, {})
         self.device = Device(self.service)
         
     def test_activateComfort(self):

--- a/tests/test_Integration.py
+++ b/tests/test_Integration.py
@@ -61,14 +61,20 @@ class Integration(unittest.TestCase):
 
                 if expected_device_type != '':
                     self.assertEqual(auto_type_name, expected_device_type)
+
+
+                for circuit in device.getAvailableCircuits():
+                    device.setCircuit(circuit)
+                    print(f"{'Use circuit':<45}{circuit}")
+                    print()
                 
-                for (name, method) in allGetterMethods(device):
-                    result = None
-                    try:
-                        result = prettyPrintResults(method())
-                    except TypeError:  # skip methods which have more than one argument
-                        result = "Skipped"
-                    except PyViCareNotSupportedFeatureError:
-                        result = "Not Supported"
-                    print(f"{name:<45}{result}")
+                    for (name, method) in allGetterMethods(device):
+                        result = None
+                        try:
+                            result = prettyPrintResults(method())
+                        except TypeError:  # skip methods which have more than one argument
+                            result = "Skipped"
+                        except PyViCareNotSupportedFeatureError:
+                            result = "Not Supported"
+                        print(f"{name:<45}{result}")
             print()

--- a/tests/test_Vitocal200.py
+++ b/tests/test_Vitocal200.py
@@ -6,7 +6,7 @@ import PyViCare.Feature
 
 class Vitocal200(unittest.TestCase):
     def setUp(self):
-        self.service = ViCareServiceMock('response_Vitocal200.json', 0)
+        self.service = ViCareServiceMock('response_Vitocal200.json')
         self.device = HeatPump(self.service)
         PyViCare.Feature.raise_exception_on_not_supported_device_feature = True
         

--- a/tests/test_Vitodens200W.py
+++ b/tests/test_Vitodens200W.py
@@ -5,7 +5,7 @@ import PyViCare.Feature
 
 class Vitodens200W(unittest.TestCase):
     def setUp(self):
-        self.service = ViCareServiceMock('response_Vitodens200W.json', 0)
+        self.service = ViCareServiceMock('response_Vitodens200W.json')
         self.device = GazBoiler(self.service)
         PyViCare.Feature.raise_exception_on_not_supported_device_feature = True
 


### PR DESCRIPTION
This PR fixes a confusion between device_id and circuit_id. 

Before the detection of devices, only the first device has been used. During that refactoring, mistakenly, the device_id has been used as the circuit id. 

I added the methods `getAvailableCircuits` and `setCircuit` on the device level to detect all available and change the circuit. for method calls.