### PR TITLE
Add setting of dhw circulation schedule

### DIFF
--- a/PyViCare/PyViCareDevice.py
+++ b/PyViCare/PyViCareDevice.py
@@ -338,3 +338,10 @@ class Device:
     def activateOneTimeCharge(self):
         return self.service.setProperty("heating.dhw.oneTimeCharge","activate","{}")
 
+    def setDomesticHotWaterCirculationSchedule(self,schedule):
+        return self.service.setProperty("heating.dhw.pumps.circulation.schedule", "setSchedule","{\"newSchedule\":"+str(schedule)+"}")
+
+    @handleNotSupported
+    def getDomesticHotWaterCirculationSchedule(self):
+        return self.service.getProperty("heating.dhw.pumps.circulation.schedule")["commands"]["setSchedule"]["params"]["newSchedule"]["constraints"]["modes"]
+

--- a/tests/test_Vitodens200W.py
+++ b/tests/test_Vitodens200W.py
@@ -41,3 +41,8 @@ class Vitodens200W(unittest.TestCase):
 
     def test_getDomesticHotWaterOutletTemperature(self):
         self.assertEqual(self.device.getDomesticHotWaterOutletTemperature(), 58)
+
+    def test_getDomesticHotWaterCirculationSchedule(self):
+        self.assertEqual(self.device.getDomesticHotWaterCirculationSchedule(), ['on'])
+
+        


### PR DESCRIPTION
Adds the methods to set the schedule for the domestic hot water circulation.
Provides also a method to read available modes.

Fixes #79 and #73 