### PR TITLE
Refactor circuits for auto detection and easier usage

### DIFF
--- a/PyViCare/PyViCare.py
+++ b/PyViCare/PyViCare.py
@@ -54,6 +54,6 @@ class PyViCare:
                         installation_id, gateway_serial, device_id)
                     service = self.__buildService(accessor)
 
-                    logger.info("Device found: %s" % device_model)
+                    logger.info(f"Device found: {device_model}")
 
                     yield PyViCareDeviceConfig(service, device_model, status)

--- a/PyViCare/PyViCare.py
+++ b/PyViCare/PyViCare.py
@@ -6,6 +6,8 @@ import logging
 
 logger = logging.getLogger('ViCare')
 logger.addHandler(logging.NullHandler())
+
+""""Viessmann ViCare API Python tools"""
 class PyViCare:
     def __init__(self):
         self.cacheDuration = 60

--- a/PyViCare/PyViCareCachedService.py
+++ b/PyViCare/PyViCareCachedService.py
@@ -25,10 +25,7 @@ class ViCareCachedService(ViCareService):
         self.lock.acquire()
         try:
             if self.isCacheInvalid():
-                url = '/equipment/installations/' + \
-                    str(self.accessor.id) + '/gateways/' + \
-                    str(self.accessor.serial) + '/devices/' + \
-                    str(self.accessor.device_id) + '/features/'
+                url = f'/equipment/installations/{self.accessor.id}/gateways/{self.accessor.serial}/devices/{self.accessor.device_id}/features/'
                 self.cache = self.oauth_manager.get(url)
                 self.cacheTime = datetime.now()
             return self.cache

--- a/PyViCare/PyViCareCachedService.py
+++ b/PyViCare/PyViCareCachedService.py
@@ -1,8 +1,6 @@
 from datetime import datetime
 import threading
 from PyViCare.PyViCareService import ViCareService, readFeature
-import json
-
 
 class ViCareCachedService(ViCareService):
 
@@ -19,8 +17,7 @@ class ViCareCachedService(ViCareService):
         return readFeature(entities, property_name)
 
     def setProperty(self, property_name, action, data):
-        strData = data if isinstance(data, str) else json.dump(data)
-        response = super().setProperty(property_name, action, strData)
+        response = super().setProperty(property_name, action, data)
         self.clearCache()
         return response
 

--- a/PyViCare/PyViCareCachedService.py
+++ b/PyViCare/PyViCareCachedService.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import threading
 from PyViCare.PyViCareService import ViCareService, readFeature
+import json
 
 
 class ViCareCachedService(ViCareService):
@@ -18,7 +19,8 @@ class ViCareCachedService(ViCareService):
         return readFeature(entities, property_name)
 
     def setProperty(self, property_name, action, data):
-        response = super().setProperty(property_name, action, data)
+        strData = data if isinstance(data, str) else json.dump(data)
+        response = super().setProperty(property_name, action, strData)
         self.clearCache()
         return response
 

--- a/PyViCare/PyViCareDevice.py
+++ b/PyViCare/PyViCareDevice.py
@@ -8,15 +8,6 @@ logger.addHandler(logging.NullHandler())
 VICARE_DAYS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
 VICARE_DHW_TEMP2 = "temp-2"
 
-# TODO Holiday program can still be used (parameters are there) heating.circuits." + str(self.circuit) + ".operating.programs.holiday
-# TODO heating.dhw.schedule/setSchedule
-# https://api.viessmann-platform.io/operational-data/installations/16011/gateways/7571381681420106/devices/0/features
-# could be used for auto-generation
-# a method to list all features
-# another one to use them
-# this can tell me if it's heating pump or gaz
-
-""""Viessmann ViCare API Python tools"""
 
 def isSupported(method):
     try:
@@ -25,144 +16,22 @@ def isSupported(method):
     except:
         return False
 
+
 class Device:
     """This class connects to the Viesmann ViCare API.
     The authentication is done through OAuth2.
     Note that currently, a new token is generate for each run.
     """
 
-    # TODO cirtcuit management should move at method level
     def __init__(self, service):
         self.service = service
-        self.circuit = 0
 
-    
-    def setCircuit(self, circuit):
-        self.circuit = circuit
-        
-    """ Set the active mode
-    Parameters
-    ----------
-    mode : str
-        Valid mode can be obtained using getModes()
-
-    Returns
-    -------
-    result: json
-        json representation of the answer
-    """
-    def setMode(self,mode):
-        r=self.service.setProperty("heating.circuits." + str(self.circuit) + ".operating.modes.active","setMode","{\"mode\":\""+mode+"\"}")
-        return r
-
-    # Works for normal, reduced, comfort
-    # active has no action
-    # external, standby no action
-    # holiday, sheculde and unscheduled
-    # activate, decativate comfort, eco
-    """ Set the target temperature for the target program
-    Parameters
-    ----------
-    program : str
-        Can be normal, reduced or comfort
-    temperature: int
-        target temperature
-
-    Returns
-    -------
-    result: json
-        json representation of the answer
-    """
-    def setProgramTemperature(self,program: str,temperature :int):
-        return self.service.setProperty("heating.circuits." + str(self.circuit) + ".operating.programs."+program,"setTemperature","{\"targetTemperature\":"+str(temperature)+"}")
-
-    def setReducedTemperature(self,temperature):
-        return self.setProgramTemperature("reduced",temperature)
-
-    def setComfortTemperature(self,temperature):
-        return self.setProgramTemperature("comfort",temperature)
-
-    def setNormalTemperature(self,temperature):
-        return self.setProgramTemperature("normal",temperature)
-
-    """ Activate a program
-        NOTE
-        DEVICE_COMMUNICATION_ERROR can just mean that the program is already on
-    Parameters
-    ----------
-    program : str
-        Appears to work only for comfort
-
-    Returns
-    -------
-    result: json
-        json representation of the answer
-    """
-    # optional temperature parameter could be passed (but not done)
-    def activateProgram(self,program):
-        return self.service.setProperty("heating.circuits." + str(self.circuit) + ".operating.programs."+program,"activate","{}")
-
-    def activateComfort(self):
-        return self.activateProgram("comfort")
-    """ Deactivate a program
-    Parameters
-    ----------
-    program : str
-        Appears to work only for comfort and eco (coming from normal, can be reached only by deactivating another state)
-
-    Returns
-    -------
-    result: json
-        json representation of the answer
-    """
-    def deactivateProgram(self,program):
-        return self.service.setProperty("heating.circuits." + str(self.circuit) + ".operating.programs."+program,"deactivate","{}")
-    def deactivateComfort(self):
-        return self.deactivateProgram("comfort")
+    def circuit(self, circuit):
+        return DeviceWithCircuit(self.service, circuit)
 
     @handleNotSupported
     def getOutsideTemperature(self):
         return self.service.getProperty("heating.sensors.temperature.outside")["properties"]["value"]["value"]
-
-    @handleNotSupported
-    def getSupplyTemperature(self):
-        return self.service.getProperty("heating.circuits." + str(self.circuit) + ".sensors.temperature.supply")["properties"]["value"]["value"]
-
-    @handleNotSupported
-    def getRoomTemperature(self):
-        return self.service.getProperty("heating.circuits." + str(self.circuit) + ".sensors.temperature.room")["properties"]["value"]["value"]
-
-    @handleNotSupported
-    def getModes(self):
-        return self.service.getProperty("heating.circuits." + str(self.circuit) + ".operating.modes.active")["commands"]["setMode"]["params"]["mode"]["constraints"]["enum"]
-
-    @handleNotSupported
-    def getActiveMode(self):
-        return self.service.getProperty("heating.circuits." + str(self.circuit) + ".operating.modes.active")["properties"]["value"]["value"]
-
-    @handleNotSupported
-    def getHeatingCurveShift(self):
-        return self.service.getProperty("heating.circuits." + str(self.circuit) + ".heating.curve")["properties"]["shift"]["value"]
-
-    @handleNotSupported
-    def getHeatingCurveSlope(self):
-        return self.service.getProperty("heating.circuits." + str(self.circuit) + ".heating.curve")["properties"]["slope"]["value"]
-
-    @handleNotSupported
-    def getActiveProgram(self):
-        return self.service.getProperty("heating.circuits." + str(self.circuit) + ".operating.programs.active")["properties"]["value"]["value"]
-
-    @handleNotSupported
-    def getPrograms(self):
-        return self.service.getProperty("heating.circuits." + str(self.circuit) + ".operating.programs")["components"]
-
-    @handleNotSupported
-    def getDesiredTemperatureForProgram(self , program):
-        return self.service.getProperty("heating.circuits." + str(self.circuit) + ".operating.programs."+program)["properties"]["temperature"]["value"]
-
-    @handleNotSupported
-    def getCurrentDesiredTemperature(self):
-        return self.service.getProperty("heating.circuits." + str(self.circuit) + ".operating.programs."+self.getActiveProgram())["properties"]["temperature"]["value"]
 
     @handleNotSupported
     def getDomesticHotWaterConfiguredTemperature(self):
@@ -182,7 +51,7 @@ class Device:
 
         try:
             daySchedule = schedule[VICARE_DAYS[currentDateTime.weekday()]]
-        except KeyError: # no schedule for day configured 
+        except KeyError:  # no schedule for day configured
             return None
 
         mode = None
@@ -190,13 +59,13 @@ class Device:
             startTime = time.fromisoformat(s["start"])
             endTime = time.fromisoformat(s["end"])
             if startTime <= currentTime and currentTime <= endTime:
-                if s["mode"] == VICARE_DHW_TEMP2: # temp-2 overrides all other modes
+                if s["mode"] == VICARE_DHW_TEMP2:  # temp-2 overrides all other modes
                     return s["mode"]
                 else:
                     mode = s["mode"]
         return mode
 
-    def getDomesticHotWaterDesiredTemperature(self): 
+    def getDomesticHotWaterDesiredTemperature(self):
         mode = self.getDomesticHotWaterActiveMode()
 
         if mode != None:
@@ -204,8 +73,8 @@ class Device:
                 return self.getDomesticHotWaterConfiguredTemperature2()
             else:
                 return self.getDomesticHotWaterConfiguredTemperature()
-        
-        return None   
+
+        return None
 
     @handleNotSupported
     def getDomesticHotWaterStorageTemperature(self):
@@ -217,12 +86,12 @@ class Device:
 
     @handleNotSupported
     def getDomesticHotWaterPumpActive(self):
-        status =  self.service.getProperty("heating.dhw.pumps.primary")["properties"]["status"]["value"]
+        status = self.service.getProperty("heating.dhw.pumps.primary")["properties"]["status"]["value"]
         return status == 'on'
 
     @handleNotSupported
     def getDomesticHotWaterCirculationPumpActive(self):
-        status =  self.service.getProperty("heating.dhw.pumps.circulation")["properties"]["status"]["value"]
+        status = self.service.getProperty("heating.dhw.pumps.circulation")["properties"]["status"]["value"]
         return status == 'on'
 
     @handleNotSupported
@@ -236,7 +105,7 @@ class Device:
     @handleNotSupported
     def getDomesticHotWaterChargingActive(self):
         return self.service.getProperty("heating.dhw.charging")["properties"]["active"]["value"]
-    
+
     """ Set the target temperature for domestic host water
     Parameters
     ----------
@@ -248,9 +117,10 @@ class Device:
     result: json
         json representation of the answer
     """
-    def setDomesticHotWaterTemperature(self,temperature):
-        return self.service.setProperty("heating.dhw.temperature","setTargetTemperature","{\"temperature\":"+str(temperature)+"}")
-        
+
+    def setDomesticHotWaterTemperature(self, temperature):
+        return self.service.setProperty("heating.dhw.temperature", "setTargetTemperature", {'temperature':temperature})
+
     """ Set the target temperature 2 for domestic host water
     Parameters
     ----------
@@ -262,17 +132,14 @@ class Device:
     result: json
         json representation of the answer
     """
-    def setDomesticHotWaterTemperature2(self,temperature):
-        return self.service.setProperty("heating.dhw.temperature.temp2","setTargetTemperature","{\"temperature\":"+str(temperature)+"}")
+
+    def setDomesticHotWaterTemperature2(self, temperature):
+        return self.service.setProperty("heating.dhw.temperature.temp2", "setTargetTemperature", "{\"temperature\":"+str(temperature)+"}")
 
     @handleNotSupported
-    def getCirculationPumpActive(self):
-        status =  self.service.getProperty("heating.circuits." + str(self.circuit) + ".circulation.pump")["properties"]["status"]["value"]
-        return status == 'on'
-
-    @handleNotSupported
-    def getHeatingSchedule(self):
-        properties = self.service.getProperty("heating.circuits." + str(self.circuit) + ".heating.schedule")["properties"]
+    def getDomesticHotWaterSchedule(self):
+        properties = self.service.getProperty(
+            "heating.dhw.schedule")["properties"]
         return {
             "active": properties["active"]["value"],
             "mon": properties["entries"]["value"]["mon"],
@@ -285,8 +152,181 @@ class Device:
         }
 
     @handleNotSupported
-    def getDomesticHotWaterSchedule(self):
-        properties = self.service.getProperty("heating.dhw.schedule")["properties"]
+    def getSolarCollectorTemperature(self):
+        return self.service.getProperty("heating.solar.sensors.temperature.collector")["properties"]["value"]["value"]
+
+    @handleNotSupported
+    def getSolarPumpActive(self):
+        status = self.service.getProperty("heating.solar.pumps.circuit")["properties"]["status"]["value"]
+        return status == 'on'
+
+    @handleNotSupported
+    def getOneTimeCharge(self):
+        return self.service.getProperty("heating.dhw.oneTimeCharge")["properties"]["active"]["value"]
+
+    def deactivateOneTimeCharge(self):
+        return self.service.setProperty("heating.dhw.oneTimeCharge", "deactivate", {})
+
+    def activateOneTimeCharge(self):
+        return self.service.setProperty("heating.dhw.oneTimeCharge", "activate", {})
+
+    def setDomesticHotWaterCirculationSchedule(self, schedule):
+        return self.service.setProperty("heating.dhw.pumps.circulation.schedule", "setSchedule", {'newSchedule': schedule})
+
+    @handleNotSupported
+    def getDomesticHotWaterCirculationSchedule(self):
+        return self.service.getProperty("heating.dhw.pumps.circulation.schedule")["commands"]["setSchedule"]["params"]["newSchedule"]["constraints"]["modes"]
+
+    @handleNotSupported
+    def getAvailableCircuits(self):
+        return self.service.getProperty("heating.circuits")["properties"]["enabled"]["value"]
+
+class DeviceWithCircuit:
+    def __init__(self, service, circuit):
+        self.service = service
+        self.circuit = circuit
+
+    """ Set the active mode
+    Parameters
+    ----------
+    mode : str
+        Valid mode can be obtained using getModes()
+
+    Returns
+    -------
+    result: json
+        json representation of the answer
+    """
+
+    def setMode(self, mode):
+        r = self.service.setProperty(f"heating.circuits.{self.circuit}.operating.modes.active", "setMode", {'mode': mode})
+        return r
+
+    # Works for normal, reduced, comfort
+    # active has no action
+    # external, standby no action
+    # holiday, scheduled and unscheduled
+    # activate, decativate comfort, eco
+    """ Set the target temperature for the target program
+    Parameters
+    ----------
+    program : str
+        Can be normal, reduced or comfort
+    temperature: int
+        target temperature
+
+    Returns
+    -------
+    result: json
+        json representation of the answer
+    """
+
+    def setProgramTemperature(self, program: str, temperature: int):
+        return self.service.setProperty(f"heating.circuits.{self.circuit}.operating.programs.{program}", "setTemperature", {'targetTemperature': temperature})
+
+    def setReducedTemperature(self, temperature):
+        return self.setProgramTemperature("reduced", temperature)
+
+    def setComfortTemperature(self, temperature):
+        return self.setProgramTemperature("comfort", temperature)
+
+    def setNormalTemperature(self, temperature):
+        return self.setProgramTemperature("normal", temperature)
+
+    """ Activate a program
+        NOTE
+        DEVICE_COMMUNICATION_ERROR can just mean that the program is already on
+    Parameters
+    ----------
+    program : str
+        Appears to work only for comfort
+
+    Returns
+    -------
+    result: json
+        json representation of the answer
+    """
+    # optional temperature parameter could be passed (but not done)
+
+    def activateProgram(self, program):
+        return self.service.setProperty(f"heating.circuits.{self.circuit}.operating.programs.{program}", "activate", {})
+
+    def activateComfort(self):
+        return self.activateProgram("comfort")
+
+
+    """ Deactivate a program
+    Parameters
+    ----------
+    program : str
+        Appears to work only for comfort and eco (coming from normal, can be reached only by deactivating another state)
+
+    Returns
+    -------
+    result: json
+        json representation of the answer
+    """
+
+    def deactivateProgram(self, program):
+        return self.service.setProperty(f"heating.circuits.{self.circuit}.operating.programs.{program}", "deactivate", {})
+
+    def deactivateComfort(self):
+        return self.deactivateProgram("comfort")
+
+    @handleNotSupported
+    def getSupplyTemperature(self):
+        return self.service.getProperty(f"heating.circuits.{self.circuit}.sensors.temperature.supply")["properties"]["value"]["value"]
+
+    @handleNotSupported
+    def getRoomTemperature(self):
+        return self.service.getProperty(f"heating.circuits.{self.circuit}.sensors.temperature.room")["properties"]["value"]["value"]
+
+    @handleNotSupported
+    def getModes(self):
+        return self.service.getProperty(f"heating.circuits.{self.circuit}.operating.modes.active")["commands"]["setMode"]["params"]["mode"]["constraints"]["enum"]
+
+    @handleNotSupported
+    def getActiveMode(self):
+        return self.service.getProperty(f"heating.circuits.{self.circuit}.operating.modes.active")["properties"]["value"]["value"]
+
+    @handleNotSupported
+    def getHeatingCurveShift(self):
+        return self.service.getProperty(f"heating.circuits.{self.circuit}.heating.curve")["properties"]["shift"]["value"]
+
+    @handleNotSupported
+    def getHeatingCurveSlope(self):
+        return self.service.getProperty(f"heating.circuits.{self.circuit}.heating.curve")["properties"]["slope"]["value"]
+
+    @handleNotSupported
+    def getActiveProgram(self):
+        return self.service.getProperty(f"heating.circuits.{self.circuit}.operating.programs.active")["properties"]["value"]["value"]
+
+    @handleNotSupported
+    def getPrograms(self):
+        return self.service.getProperty(f"heating.circuits.{self.circuit}.operating.programs")["components"]
+
+    @handleNotSupported
+    def getDesiredTemperatureForProgram(self, program):
+        return self.service.getProperty(f"heating.circuits.{self.circuit}.operating.programs."+program)["properties"]["temperature"]["value"]
+
+    @handleNotSupported
+    def getCurrentDesiredTemperature(self):
+        return self.service.getProperty(f"heating.circuits.{self.circuit}.operating.programs."+self.getActiveProgram())["properties"]["temperature"]["value"]
+
+
+    @handleNotSupported
+    def getFrostProtectionActive(self):
+        status = self.service.getProperty(f"heating.circuits.{self.circuit}.frostprotection")["properties"]["status"]["value"]
+        return status == 'on'
+
+    @handleNotSupported
+    def getCirculationPumpActive(self):
+        status = self.service.getProperty(f"heating.circuits.{self.circuit}.circulation.pump")["properties"]["status"]["value"]
+        return status == 'on'
+
+    @handleNotSupported
+    def getHeatingSchedule(self):
+        properties = self.service.getProperty(f"heating.circuits.{self.circuit}.heating.schedule")["properties"]
         return {
             "active": properties["active"]["value"],
             "mon": properties["entries"]["value"]["mon"],
@@ -301,10 +341,10 @@ class Device:
     # Calculates target supply temperature based on data from Viessmann
     # See: https://www.viessmann-community.com/t5/Gas/Mathematische-Formel-fuer-Vorlauftemperatur-aus-den-vier/m-p/68890#M27556
     def getTargetSupplyTemperature(self):
-        if(not isSupported(self.getCurrentDesiredTemperature) 
-            or not isSupported(self.getOutsideTemperature)
-            or not isSupported(self.getHeatingCurveShift)
-            or not isSupported(self.getHeatingCurveSlope)):
+        if(not isSupported(self.getCurrentDesiredTemperature)
+                or not isSupported(self.getOutsideTemperature)
+                or not isSupported(self.getHeatingCurveShift)
+                or not isSupported(self.getHeatingCurveSlope)):
             return None
 
         inside = self.getCurrentDesiredTemperature()
@@ -312,41 +352,7 @@ class Device:
         delta_outside_inside = (outside - inside)
         shift = self.getHeatingCurveShift()
         slope = self.getHeatingCurveSlope()
-        targetSupply = inside + shift - slope * delta_outside_inside * (1.4347 + 0.021 * delta_outside_inside + 247.9 * pow(10, -6) * pow(delta_outside_inside, 2))
+        targetSupply = inside + shift - slope * delta_outside_inside * \
+            (1.4347 + 0.021 * delta_outside_inside + 247.9 *
+             pow(10, -6) * pow(delta_outside_inside, 2))
         return round(targetSupply, 1)
-
-    @handleNotSupported
-    def getSolarCollectorTemperature(self):
-        return self.service.getProperty("heating.solar.sensors.temperature.collector")["properties"]["value"]["value"]
-
-    @handleNotSupported
-    def getSolarPumpActive(self):
-        status = self.service.getProperty("heating.solar.pumps.circuit")["properties"]["status"]["value"]
-        return status == 'on'
-
-    @handleNotSupported
-    def getFrostProtectionActive(self):
-        status = self.service.getProperty("heating.circuits." + str(self.circuit) + ".frostprotection")["properties"]["status"]["value"]
-        return status == 'on'
-
-    @handleNotSupported
-    def getOneTimeCharge(self):
-        return self.service.getProperty("heating.dhw.oneTimeCharge")["properties"]["active"]["value"]
-
-    def deactivateOneTimeCharge(self):
-        return self.service.setProperty("heating.dhw.oneTimeCharge","deactivate","{}")
-
-    def activateOneTimeCharge(self):
-        return self.service.setProperty("heating.dhw.oneTimeCharge","activate","{}")
-
-    def setDomesticHotWaterCirculationSchedule(self,schedule):
-        return self.service.setProperty("heating.dhw.pumps.circulation.schedule", "setSchedule","{\"newSchedule\":"+str(schedule)+"}")
-
-    @handleNotSupported
-    def getDomesticHotWaterCirculationSchedule(self):
-        return self.service.getProperty("heating.dhw.pumps.circulation.schedule")["commands"]["setSchedule"]["params"]["newSchedule"]["constraints"]["modes"]
-      
-    @handleNotSupported
-    def getAvailableCircuits(self):
-        return self.service.getProperty("heating.circuits")["properties"]["enabled"]["value"]
-

--- a/PyViCare/PyViCareDevice.py
+++ b/PyViCare/PyViCareDevice.py
@@ -26,7 +26,11 @@ class Device:
     def __init__(self, service):
         self.service = service
 
-    def circuit(self, circuit):
+    @property
+    def circuits(self):
+        return list([self.getCircuit(x) for x in self.getAvailableCircuits()])
+
+    def getCircuit(self, circuit):
         return DeviceWithCircuit(self.service, circuit)
 
     @handleNotSupported
@@ -185,6 +189,10 @@ class DeviceWithCircuit:
     def __init__(self, service, circuit):
         self.service = service
         self.circuit = circuit
+
+    @property
+    def id(self):
+        return self.circuit
 
     """ Set the active mode
     Parameters

--- a/PyViCare/PyViCareDeviceConfig.py
+++ b/PyViCare/PyViCareDeviceConfig.py
@@ -59,6 +59,5 @@ class PyViCareDeviceConfig:
                             (self.device_model, creator_method.__name__))
                 return creator_method()
 
-        logger.info("Could not auto detect %s. Use generic device." %
-                    self.device_model)
+        logger.info(f"Could not auto detect {self.device_model}. Use generic device.")
         return self.asGeneric()

--- a/PyViCare/PyViCareGazBoiler.py
+++ b/PyViCare/PyViCareGazBoiler.py
@@ -3,7 +3,7 @@ from PyViCare.PyViCareUtils import handleNotSupported
 
 class GazBoiler(Device):
 
-    def circuit(self, circuit):
+    def getCircuit(self, circuit):
         return GazBoilerWithCircuit(self.service, circuit)
 
     @handleNotSupported

--- a/PyViCare/PyViCareGazBoiler.py
+++ b/PyViCare/PyViCareGazBoiler.py
@@ -4,7 +4,7 @@ from PyViCare.PyViCareUtils import handleNotSupported
 class GazBoiler(Device):
 
     def getCircuit(self, circuit):
-        return GazBoilerWithCircuit(self.service, circuit)
+        return GazBoilerWithCircuit(self, circuit)
 
     @handleNotSupported
     def getBurnerActive(self):

--- a/PyViCare/PyViCareGazBoiler.py
+++ b/PyViCare/PyViCareGazBoiler.py
@@ -1,7 +1,10 @@
-from PyViCare.PyViCareDevice import Device
+from PyViCare.PyViCareDevice import Device, DeviceWithCircuit
 from PyViCare.PyViCareUtils import handleNotSupported
 
 class GazBoiler(Device):
+
+    def circuit(self, circuit):
+        return GazBoilerWithCircuit(self.service, circuit)
 
     @handleNotSupported
     def getBurnerActive(self):
@@ -107,18 +110,19 @@ class GazBoiler(Device):
     def getPowerConsumptionThisYear(self):
         return self.service.getProperty("heating.power.consumption")["properties"]["year"]["value"][0]
 
+class GazBoilerWithCircuit(DeviceWithCircuit):
+
     @handleNotSupported
     def getBurnerHours(self):
-        return self.service.getProperty("heating.burners." + str(self.circuit) + ".statistics")["properties"]["hours"]["value"]
+        return self.service.getProperty(f"heating.burners.{self.circuit}.statistics")["properties"]["hours"]["value"]
 
     @handleNotSupported
     def getBurnerStarts(self):
-        return self.service.getProperty("heating.burners." + str(self.circuit) + ".statistics")["properties"]["starts"]["value"]
+        return self.service.getProperty(f"heating.burners.{self.circuit}.statistics")["properties"]["starts"]["value"]
 
     @handleNotSupported
     def getBurnerModulation(self):
-        return self.service.getProperty("heating.burners." + str(self.circuit) + ".modulation")["properties"]["value"]["value"]
+        return self.service.getProperty(f"heating.burners.{self.circuit}.modulation")["properties"]["value"]["value"]
 
 
-    
 

--- a/PyViCare/PyViCareHeatPump.py
+++ b/PyViCare/PyViCareHeatPump.py
@@ -3,7 +3,7 @@ from PyViCare.PyViCareUtils import handleNotSupported
 
 class HeatPump(Device):
 
-    def circuit(self, circuit):
+    def getCircuit(self, circuit):
         return HeatPumpWithCircuit(self.service, circuit)
 
     @handleNotSupported

--- a/PyViCare/PyViCareHeatPump.py
+++ b/PyViCare/PyViCareHeatPump.py
@@ -1,43 +1,14 @@
-from PyViCare.PyViCareDevice import Device
+from PyViCare.PyViCareDevice import Device, DeviceWithCircuit
 from PyViCare.PyViCareUtils import handleNotSupported
 
 class HeatPump(Device):
-    
-    @handleNotSupported
-    def getCompressorActive(self):
-        return self.service.getProperty("heating.compressors." + str(self.circuit))["properties"]["active"]["value"]
+
+    def circuit(self, circuit):
+        return HeatPumpWithCircuit(self.service, circuit)
 
     @handleNotSupported
     def getReturnTemperature(self):
         return self.service.getProperty("heating.sensors.temperature.return")["properties"]["value"]["value"]
-
-    @handleNotSupported
-    def getCompressorStarts(self):
-        return self.service.getProperty("heating.compressors." + str(self.circuit) + ".statistics")["properties"]["starts"]["value"] 
-
-    @handleNotSupported
-    def getCompressorHours(self):
-        return self.service.getProperty("heating.compressors." + str(self.circuit) + ".statistics")["properties"]["hours"]["value"]
-
-    @handleNotSupported
-    def getCompressorHoursLoadClass1(self):
-        return self.service.getProperty("heating.compressors." + str(self.circuit) + ".statistics")["properties"]["hoursLoadClassOne"]["value"]
-
-    @handleNotSupported
-    def getCompressorHoursLoadClass2(self):
-        return self.service.getProperty("heating.compressors." + str(self.circuit) + ".statistics")["properties"]["hoursLoadClassTwo"]["value"]
-
-    @handleNotSupported
-    def getCompressorHoursLoadClass3(self):
-        return self.service.getProperty("heating.compressors." + str(self.circuit) + ".statistics")["properties"]["hoursLoadClassThree"]["value"]
-
-    @handleNotSupported
-    def getCompressorHoursLoadClass4(self):
-        return self.service.getProperty("heating.compressors." + str(self.circuit) + ".statistics")["properties"]["hoursLoadClassFour"]["value"]
-
-    @handleNotSupported
-    def getCompressorHoursLoadClass5(self):
-        return self.service.getProperty("heating.compressors." + str(self.circuit) + ".statistics")["properties"]["hoursLoadClassFive"]["value"]
 
     @handleNotSupported
     def getSupplyTemperaturePrimaryCircuit(self):
@@ -46,3 +17,37 @@ class HeatPump(Device):
     @handleNotSupported
     def getReturnTemperaturePrimaryCircuit(self):
         return self.service.getProperty("heating.primaryCircuit.sensors.temperature.return")["properties"]["value"]["value"]
+
+class HeatPumpWithCircuit(DeviceWithCircuit):
+
+    @handleNotSupported
+    def getCompressorStarts(self):
+        return self.service.getProperty(f"heating.compressors.{self.circuit}.statistics")["properties"]["starts"]["value"] 
+
+    @handleNotSupported
+    def getCompressorHours(self):
+        return self.service.getProperty(f"heating.compressors.{self.circuit}.statistics")["properties"]["hours"]["value"]
+
+    @handleNotSupported
+    def getCompressorHoursLoadClass1(self):
+        return self.service.getProperty(f"heating.compressors.{self.circuit}.statistics")["properties"]["hoursLoadClassOne"]["value"]
+
+    @handleNotSupported
+    def getCompressorHoursLoadClass2(self):
+        return self.service.getProperty(f"heating.compressors.{self.circuit}.statistics")["properties"]["hoursLoadClassTwo"]["value"]
+
+    @handleNotSupported
+    def getCompressorHoursLoadClass3(self):
+        return self.service.getProperty(f"heating.compressors.{self.circuit}.statistics")["properties"]["hoursLoadClassThree"]["value"]
+
+    @handleNotSupported
+    def getCompressorHoursLoadClass4(self):
+        return self.service.getProperty(f"heating.compressors.{self.circuit}.statistics")["properties"]["hoursLoadClassFour"]["value"]
+
+    @handleNotSupported
+    def getCompressorHoursLoadClass5(self):
+        return self.service.getProperty(f"heating.compressors.{self.circuit}.statistics")["properties"]["hoursLoadClassFive"]["value"]
+
+    @handleNotSupported
+    def getCompressorActive(self):
+        return self.service.getProperty(f"heating.compressors.{self.circuit}")["properties"]["active"]["value"]

--- a/PyViCare/PyViCareHeatPump.py
+++ b/PyViCare/PyViCareHeatPump.py
@@ -4,7 +4,7 @@ from PyViCare.PyViCareUtils import handleNotSupported
 class HeatPump(Device):
 
     def getCircuit(self, circuit):
-        return HeatPumpWithCircuit(self.service, circuit)
+        return HeatPumpWithCircuit(self, circuit)
 
     @handleNotSupported
     def getReturnTemperature(self):

--- a/PyViCare/PyViCareOAuthManager.py
+++ b/PyViCare/PyViCareOAuthManager.py
@@ -123,13 +123,12 @@ class ViCareOAuthManager(AbstractViCareOAuthManager):
         """
         oauth = OAuth2Session(
             self.client_id, redirect_uri=redirect_uri, scope=viessmann_scope)
-        authorization_url, _ = oauth.authorization_url(authorizeURL)
+        base_authorization_url, _ = oauth.authorization_url(authorizeURL)
 
         # workaround until requests-oauthlib supports PKCE flow
         code_verifier, code_challenge = pkce.generate_pkce_pair()
-        authorization_url += '&code_challenge=' + \
-            code_challenge + '&code_challenge_method=S256'
-        logger.debug("Auth URL is: "+authorization_url)
+        authorization_url = f'{base_authorization_url}&code_challenge={code_challenge}&code_challenge_method=S256'
+        logger.debug(f"Auth URL is: {authorization_url}")
 
         try:
             header = {'Content-Type': 'application/x-www-form-urlencoded'}
@@ -144,7 +143,7 @@ class ViCareOAuthManager(AbstractViCareOAuthManager):
             codestring = str(codestring)
             match = re.search("code=(.*)&", codestring)
             codestring = match.group(1)
-            logger.debug("Codestring : %s" % codestring)
+            logger.debug(f"Codestring : {codestring}")
 
             # workaround until requests-oauthlib supports PKCE flow
             resp = requests.post(url=token_url, data={
@@ -161,7 +160,7 @@ class ViCareOAuthManager(AbstractViCareOAuthManager):
                 'token_type': 'bearer'
             }
             oauth = OAuth2Session(client_id=self.client_id, token=token_dict)
-            logger.debug("Token received: %s" % oauth.token)
+            logger.debug(f"Token received: {oauth.token}")
             self._serializeToken(oauth.token, token_file)    
             logger.info("New token created")
             return oauth

--- a/PyViCare/PyViCareService.py
+++ b/PyViCare/PyViCareService.py
@@ -1,5 +1,5 @@
 import logging
-
+import json
 from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
 
 logger = logging.getLogger('ViCare')
@@ -44,4 +44,6 @@ class ViCareService:
     def setProperty(self, property_name, action, data):
         url = buildSetPropertyUrl(
             self.accessor, property_name, action)
-        return self.oauth_manager.post(url, data)
+
+        post_data = data if isinstance(data, str) else json.dump(data)
+        return self.oauth_manager.post(url, post_data)

--- a/PyViCare/PyViCareService.py
+++ b/PyViCare/PyViCareService.py
@@ -17,11 +17,11 @@ def readFeature(entities, property_name):
 
 
 def buildSetPropertyUrl(accessor, property_name, action):
-    return '/equipment/installations/'+str(accessor.id)+'/gateways/'+str(accessor.serial)+'/devices/'+str(accessor.device_id)+'/features/'+property_name+'/'+action
+    return f'/equipment/installations/{accessor.id}/gateways/{accessor.serial}/devices/{accessor.device_id}/features/{property_name}/{action}'
 
 
 def buildGetPropertyUrl(accessor, property_name):
-    return '/equipment/installations/'+str(accessor.id)+'/gateways/'+str(accessor.serial)+'/devices/'+str(accessor.device_id)+'/features/'+property_name
+    return f'/equipment/installations/{accessor.id}/gateways/{accessor.serial}/devices/{accessor.device_id}/features/{property_name}'
 
 class ViCareDeviceAccessor:
     def __init__(self, id, serial, device_id):

--- a/PyViCare/PyViCareUtils.py
+++ b/PyViCare/PyViCareUtils.py
@@ -40,7 +40,7 @@ class PyViCareRateLimitError(Exception):
         limitReset = extended_payload["limitReset"]
         limitResetDate = datetime.datetime.utcfromtimestamp(limitReset/1000)
 
-        msg = 'API rate limit '+name+' exceeded. Max '+str(requestCountLimit)+' calls in timewindow. Limit reset at '+limitResetDate.isoformat()+'.'
+        msg = f'API rate limit {name} exceeded. Max {requestCountLimit} calls in timewindow. Limit reset at {limitResetDate.isoformat()}.'
 
         super().__init__(self, msg)
         self.message = msg

--- a/tests/ViCareServiceMock.py
+++ b/tests/ViCareServiceMock.py
@@ -1,9 +1,21 @@
 from PyViCare.PyViCareService import ViCareDeviceAccessor, readFeature, buildSetPropertyUrl
 from tests.helper import readJson
 
+
+def MockCircuitsData(circuits):
+    return {
+        "properties": {
+            "enabled": {
+                "value": circuits
+            }
+        },
+        "feature": "heating.circuits",
+    }
+
+
 class ViCareServiceMock:
-    
-    def __init__(self, filename, rawInput = None):
+
+    def __init__(self, filename, rawInput=None):
         if rawInput is None:
             testData = readJson(filename)
             self.testData = testData
@@ -11,7 +23,7 @@ class ViCareServiceMock:
             self.testData = rawInput
 
         self.accessor = ViCareDeviceAccessor(
-                        '[id]', '[serial]', '[deviceid]')
+            '[id]', '[serial]', '[deviceid]')
         self.setPropertyData = []
 
     def getProperty(self, property_name):
@@ -20,9 +32,8 @@ class ViCareServiceMock:
 
     def setProperty(self, property_name, action, data):
         self.setPropertyData.append({
-            "url" : buildSetPropertyUrl(self.accessor, property_name, action),
+            "url": buildSetPropertyUrl(self.accessor, property_name, action),
             "property_name": property_name,
-            "action" : action,
-            "data" : data
+            "action": action,
+            "data": data
         })
-        

--- a/tests/test_GenericDevice.py
+++ b/tests/test_GenericDevice.py
@@ -8,13 +8,13 @@ class GenericDevice(unittest.TestCase):
         self.device = Device(self.service)
         
     def test_activateComfort(self):
-        self.device.activateComfort()
+        self.device.circuit(0).activateComfort()
         self.assertEqual(len(self.service.setPropertyData), 1)
         self.assertEqual(self.service.setPropertyData[0]['action'], 'activate')
         self.assertEqual(self.service.setPropertyData[0]['property_name'], 'heating.circuits.0.operating.programs.comfort')
 
     def test_deactivateComfort(self):
-        self.device.deactivateComfort()
+        self.device.circuit(0).deactivateComfort()
         self.assertEqual(len(self.service.setPropertyData), 1)
         self.assertEqual(self.service.setPropertyData[0]['action'], 'deactivate')
         self.assertEqual(self.service.setPropertyData[0]['property_name'], 'heating.circuits.0.operating.programs.comfort')
@@ -24,13 +24,13 @@ class GenericDevice(unittest.TestCase):
         self.assertEqual(len(self.service.setPropertyData), 1)
         self.assertEqual(self.service.setPropertyData[0]['property_name'], 'heating.dhw.temperature')
         self.assertEqual(self.service.setPropertyData[0]['action'], 'setTargetTemperature')
-        self.assertEqual(self.service.setPropertyData[0]['data'], '{"temperature":50}')
+        self.assertEqual(self.service.setPropertyData[0]['data'], {'temperature':50})
 
     def test_setMode(self):
-        self.device.setMode('dhw')
+        self.device.circuit(0).setMode('dhw')
         self.assertEqual(len(self.service.setPropertyData), 1)
         self.assertEqual(self.service.setPropertyData[0]['property_name'], 'heating.circuits.0.operating.modes.active')
         self.assertEqual(self.service.setPropertyData[0]['action'], 'setMode')
-        self.assertEqual(self.service.setPropertyData[0]['data'], '{"mode":"dhw"}')
+        self.assertEqual(self.service.setPropertyData[0]['data'], {'mode':'dhw'})
 
     

--- a/tests/test_GenericDevice.py
+++ b/tests/test_GenericDevice.py
@@ -1,20 +1,20 @@
 import unittest
-from tests.ViCareServiceMock import ViCareServiceMock
+from tests.ViCareServiceMock import ViCareServiceMock, MockCircuitsData
 from PyViCare.PyViCareDevice import Device
 
 class GenericDevice(unittest.TestCase):
     def setUp(self):
-        self.service = ViCareServiceMock(None, {})
+        self.service = ViCareServiceMock(None, {'data': [MockCircuitsData([0])]})
         self.device = Device(self.service)
         
     def test_activateComfort(self):
-        self.device.circuit(0).activateComfort()
+        self.device.circuits[0].activateComfort()
         self.assertEqual(len(self.service.setPropertyData), 1)
         self.assertEqual(self.service.setPropertyData[0]['action'], 'activate')
         self.assertEqual(self.service.setPropertyData[0]['property_name'], 'heating.circuits.0.operating.programs.comfort')
 
     def test_deactivateComfort(self):
-        self.device.circuit(0).deactivateComfort()
+        self.device.circuits[0].deactivateComfort()
         self.assertEqual(len(self.service.setPropertyData), 1)
         self.assertEqual(self.service.setPropertyData[0]['action'], 'deactivate')
         self.assertEqual(self.service.setPropertyData[0]['property_name'], 'heating.circuits.0.operating.programs.comfort')
@@ -27,7 +27,7 @@ class GenericDevice(unittest.TestCase):
         self.assertEqual(self.service.setPropertyData[0]['data'], {'temperature':50})
 
     def test_setMode(self):
-        self.device.circuit(0).setMode('dhw')
+        self.device.circuits[0].setMode('dhw')
         self.assertEqual(len(self.service.setPropertyData), 1)
         self.assertEqual(self.service.setPropertyData[0]['property_name'], 'heating.circuits.0.operating.modes.active')
         self.assertEqual(self.service.setPropertyData[0]['action'], 'setMode')

--- a/tests/test_Integration.py
+++ b/tests/test_Integration.py
@@ -28,6 +28,17 @@ def prettyPrintResults(result):
 def enablePrintStatementsForTest(test_case):
     return test_case.capsys.disabled()
 
+def dumpResults(vicare_device):
+    for (name, method) in allGetterMethods(vicare_device):
+        result = None
+        try:
+            result = prettyPrintResults(method())
+        except TypeError:  # skip methods which have more than one argument
+            result = "Skipped"
+        except PyViCareNotSupportedFeatureError:
+            result = "Not Supported"
+        print(f"{name:<45}{result}")
+
 class Integration(unittest.TestCase):
     @pytest.fixture(autouse=True)
     def capsys(self, capsys):
@@ -62,19 +73,15 @@ class Integration(unittest.TestCase):
                 if expected_device_type != '':
                     self.assertEqual(auto_type_name, expected_device_type)
 
+                dumpResults(device)
+                print()
 
                 for circuit in device.getAvailableCircuits():
-                    device.setCircuit(circuit)
+                    
                     print(f"{'Use circuit':<45}{circuit}")
+                    circuit_device = device.circuit(circuit)
+                    dumpResults(circuit_device)
                     print()
                 
-                    for (name, method) in allGetterMethods(device):
-                        result = None
-                        try:
-                            result = prettyPrintResults(method())
-                        except TypeError:  # skip methods which have more than one argument
-                            result = "Skipped"
-                        except PyViCareNotSupportedFeatureError:
-                            result = "Not Supported"
-                        print(f"{name:<45}{result}")
+                    
             print()

--- a/tests/test_Integration.py
+++ b/tests/test_Integration.py
@@ -76,11 +76,9 @@ class Integration(unittest.TestCase):
                 dumpResults(device)
                 print()
 
-                for circuit in device.getAvailableCircuits():
-                    
-                    print(f"{'Use circuit':<45}{circuit}")
-                    circuit_device = device.circuit(circuit)
-                    dumpResults(circuit_device)
+                for circuit in device.circuits:
+                    print(f"{'Use circuit':<45}{circuit.id}")
+                    dumpResults(circuit)
                     print()
                 
                     

--- a/tests/test_Vitocal200.py
+++ b/tests/test_Vitocal200.py
@@ -11,34 +11,34 @@ class Vitocal200(unittest.TestCase):
         PyViCare.Feature.raise_exception_on_not_supported_device_feature = True
         
     def test_getCompressorActive(self):
-        self.assertEqual(self.device.getCompressorActive(), False)
+        self.assertEqual(self.device.circuit(0).getCompressorActive(), False)
 
     def test_getCompressorHours(self):
-        self.assertAlmostEqual(self.device.getCompressorHours(), 8583.2)
+        self.assertAlmostEqual(self.device.circuit(0).getCompressorHours(), 8583.2)
 
     def test_getCompressorStarts(self):
-        self.assertAlmostEqual(self.device.getCompressorStarts(), 3180)
+        self.assertAlmostEqual(self.device.circuit(0).getCompressorStarts(), 3180)
 
     def test_getCompressorHoursLoadClass1(self):
-        self.assertAlmostEqual(self.device.getCompressorHoursLoadClass1(), 227)
+        self.assertAlmostEqual(self.device.circuit(0).getCompressorHoursLoadClass1(), 227)
 
     def test_getCompressorHoursLoadClass2(self):
-        self.assertAlmostEqual(self.device.getCompressorHoursLoadClass2(), 3294)
+        self.assertAlmostEqual(self.device.circuit(0).getCompressorHoursLoadClass2(), 3294)
 
     def test_getCompressorHoursLoadClass3(self):
-        self.assertAlmostEqual(self.device.getCompressorHoursLoadClass3(), 3903)
+        self.assertAlmostEqual(self.device.circuit(0).getCompressorHoursLoadClass3(), 3903)
 
     def test_getCompressorHoursLoadClass4(self):
-        self.assertAlmostEqual(self.device.getCompressorHoursLoadClass4(), 506)
+        self.assertAlmostEqual(self.device.circuit(0).getCompressorHoursLoadClass4(), 506)
 
     def test_getCompressorHoursLoadClass5(self):
-        self.assertAlmostEqual(self.device.getCompressorHoursLoadClass5(), 461)
+        self.assertAlmostEqual(self.device.circuit(0).getCompressorHoursLoadClass5(), 461)
 
     def test_getHeatingCurveSlope(self):
-        self.assertAlmostEqual(self.device.getHeatingCurveSlope(), 0.3)
+        self.assertAlmostEqual(self.device.circuit(0).getHeatingCurveSlope(), 0.3)
 
     def test_getHeatingCurveShift(self):
-        self.assertAlmostEqual(self.device.getHeatingCurveShift(), -5)
+        self.assertAlmostEqual(self.device.circuit(0).getHeatingCurveShift(), -5)
 
     def test_getReturnTemperature(self):
         self.assertAlmostEqual(self.device.getReturnTemperature(), 27.5)
@@ -51,11 +51,11 @@ class Vitocal200(unittest.TestCase):
 
     def test_getPrograms(self):
         expected_programs = ['active', 'comfort', 'eco', 'fixed', 'normal', 'reduced', 'standby']
-        self.assertListEqual(self.device.getPrograms(), expected_programs)
+        self.assertListEqual(self.device.circuit(0).getPrograms(), expected_programs)
 
     def test_getModes(self):
         expected_modes = ['standby', 'dhw', 'dhwAndHeatingCooling']
-        self.assertListEqual(self.device.getModes(), expected_modes)
+        self.assertListEqual(self.device.circuit(0).getModes(), expected_modes)
 
     def test_getDomesticHotWaterCirculationPumpActive(self):
         self.assertEqual(self.device.getDomesticHotWaterCirculationPumpActive(), False)

--- a/tests/test_Vitocal200.py
+++ b/tests/test_Vitocal200.py
@@ -11,34 +11,34 @@ class Vitocal200(unittest.TestCase):
         PyViCare.Feature.raise_exception_on_not_supported_device_feature = True
         
     def test_getCompressorActive(self):
-        self.assertEqual(self.device.circuit(0).getCompressorActive(), False)
+        self.assertEqual(self.device.circuits[0].getCompressorActive(), False)
 
     def test_getCompressorHours(self):
-        self.assertAlmostEqual(self.device.circuit(0).getCompressorHours(), 8583.2)
+        self.assertAlmostEqual(self.device.circuits[0].getCompressorHours(), 8583.2)
 
     def test_getCompressorStarts(self):
-        self.assertAlmostEqual(self.device.circuit(0).getCompressorStarts(), 3180)
+        self.assertAlmostEqual(self.device.circuits[0].getCompressorStarts(), 3180)
 
     def test_getCompressorHoursLoadClass1(self):
-        self.assertAlmostEqual(self.device.circuit(0).getCompressorHoursLoadClass1(), 227)
+        self.assertAlmostEqual(self.device.circuits[0].getCompressorHoursLoadClass1(), 227)
 
     def test_getCompressorHoursLoadClass2(self):
-        self.assertAlmostEqual(self.device.circuit(0).getCompressorHoursLoadClass2(), 3294)
+        self.assertAlmostEqual(self.device.circuits[0].getCompressorHoursLoadClass2(), 3294)
 
     def test_getCompressorHoursLoadClass3(self):
-        self.assertAlmostEqual(self.device.circuit(0).getCompressorHoursLoadClass3(), 3903)
+        self.assertAlmostEqual(self.device.circuits[0].getCompressorHoursLoadClass3(), 3903)
 
     def test_getCompressorHoursLoadClass4(self):
-        self.assertAlmostEqual(self.device.circuit(0).getCompressorHoursLoadClass4(), 506)
+        self.assertAlmostEqual(self.device.circuits[0].getCompressorHoursLoadClass4(), 506)
 
     def test_getCompressorHoursLoadClass5(self):
-        self.assertAlmostEqual(self.device.circuit(0).getCompressorHoursLoadClass5(), 461)
+        self.assertAlmostEqual(self.device.circuits[0].getCompressorHoursLoadClass5(), 461)
 
     def test_getHeatingCurveSlope(self):
-        self.assertAlmostEqual(self.device.circuit(0).getHeatingCurveSlope(), 0.3)
+        self.assertAlmostEqual(self.device.circuits[0].getHeatingCurveSlope(), 0.3)
 
     def test_getHeatingCurveShift(self):
-        self.assertAlmostEqual(self.device.circuit(0).getHeatingCurveShift(), -5)
+        self.assertAlmostEqual(self.device.circuits[0].getHeatingCurveShift(), -5)
 
     def test_getReturnTemperature(self):
         self.assertAlmostEqual(self.device.getReturnTemperature(), 27.5)
@@ -51,11 +51,11 @@ class Vitocal200(unittest.TestCase):
 
     def test_getPrograms(self):
         expected_programs = ['active', 'comfort', 'eco', 'fixed', 'normal', 'reduced', 'standby']
-        self.assertListEqual(self.device.circuit(0).getPrograms(), expected_programs)
+        self.assertListEqual(self.device.circuits[0].getPrograms(), expected_programs)
 
     def test_getModes(self):
         expected_modes = ['standby', 'dhw', 'dhwAndHeatingCooling']
-        self.assertListEqual(self.device.circuit(0).getModes(), expected_modes)
+        self.assertListEqual(self.device.circuits[0].getModes(), expected_modes)
 
     def test_getDomesticHotWaterCirculationPumpActive(self):
         self.assertEqual(self.device.getDomesticHotWaterCirculationPumpActive(), False)

--- a/tests/test_Vitodens200W.py
+++ b/tests/test_Vitodens200W.py
@@ -13,28 +13,28 @@ class Vitodens200W(unittest.TestCase):
         self.assertEqual(self.device.getBurnerActive(), True)
 
     def test_getBurnerStarts(self):
-        self.assertEqual(self.device.circuit(0).getBurnerStarts(), 8028)
+        self.assertEqual(self.device.circuits[0].getBurnerStarts(), 8028)
 
     def test_getBurnerHours(self):
-        self.assertEqual(self.device.circuit(0).getBurnerHours(), 5570)
+        self.assertEqual(self.device.circuits[0].getBurnerHours(), 5570)
 
     def test_getBurnerModulation(self):
-        self.assertEqual(self.device.circuit(0).getBurnerModulation(), 11.1)
+        self.assertEqual(self.device.circuits[0].getBurnerModulation(), 11.1)
 
     def test_getPrograms(self):
         expected_programs = ['active', 'comfort', 'forcedLastFromSchedule', 'normal', 'reduced', 'standby']
-        self.assertListEqual(self.device.circuit(0).getPrograms(), expected_programs)
+        self.assertListEqual(self.device.circuits[0].getPrograms(), expected_programs)
 
     def test_getModes(self):
         expected_modes =  ['standby', 'heating', 'dhw', 'dhwAndHeating']
-        self.assertListEqual(self.device.circuit(0).getModes(), expected_modes)
+        self.assertListEqual(self.device.circuits[0].getModes(), expected_modes)
 
     def test_getPowerConsumptionDays(self):
         expected_consumption = [0, 0.1, 0.2, 0.1, 0.2, 0.2, 0.2, 0.2]
         self.assertEqual(self.device.getPowerConsumptionDays(), expected_consumption)
 
     def test_getFrostProtectionActive(self):
-        self.assertEqual(self.device.circuit(0).getFrostProtectionActive(), False)
+        self.assertEqual(self.device.circuits[0].getFrostProtectionActive(), False)
 
     def test_getDomesticHotWaterCirculationPumpActive(self):
         self.assertEqual(self.device.getDomesticHotWaterCirculationPumpActive(), True)

--- a/tests/test_Vitodens200W.py
+++ b/tests/test_Vitodens200W.py
@@ -13,28 +13,28 @@ class Vitodens200W(unittest.TestCase):
         self.assertEqual(self.device.getBurnerActive(), True)
 
     def test_getBurnerStarts(self):
-        self.assertEqual(self.device.getBurnerStarts(), 8028)
+        self.assertEqual(self.device.circuit(0).getBurnerStarts(), 8028)
 
     def test_getBurnerHours(self):
-        self.assertEqual(self.device.getBurnerHours(), 5570)
+        self.assertEqual(self.device.circuit(0).getBurnerHours(), 5570)
 
     def test_getBurnerModulation(self):
-        self.assertEqual(self.device.getBurnerModulation(), 11.1)
+        self.assertEqual(self.device.circuit(0).getBurnerModulation(), 11.1)
 
     def test_getPrograms(self):
         expected_programs = ['active', 'comfort', 'forcedLastFromSchedule', 'normal', 'reduced', 'standby']
-        self.assertListEqual(self.device.getPrograms(), expected_programs)
+        self.assertListEqual(self.device.circuit(0).getPrograms(), expected_programs)
 
     def test_getModes(self):
         expected_modes =  ['standby', 'heating', 'dhw', 'dhwAndHeating']
-        self.assertListEqual(self.device.getModes(), expected_modes)
+        self.assertListEqual(self.device.circuit(0).getModes(), expected_modes)
 
     def test_getPowerConsumptionDays(self):
         expected_consumption = [0, 0.1, 0.2, 0.1, 0.2, 0.2, 0.2, 0.2]
         self.assertEqual(self.device.getPowerConsumptionDays(), expected_consumption)
 
     def test_getFrostProtectionActive(self):
-        self.assertEqual(self.device.getFrostProtectionActive(), False)
+        self.assertEqual(self.device.circuit(0).getFrostProtectionActive(), False)
 
     def test_getDomesticHotWaterCirculationPumpActive(self):
         self.assertEqual(self.device.getDomesticHotWaterCirculationPumpActive(), True)


### PR DESCRIPTION
This PR is another breaking change. But it allows a much easier usage of all the circuits.

Changes:
1. Split up of the device in non-circuit and circuit dependent properties
2. Access the circuit properties via `device.circuits[0].getAbc()`

This allows iteration of all existing circuits via the new `.circuits` property. Circuits are accessed via an indexer.