### PR TITLE
Refactor oauth relying on invalid schema exception

### DIFF
--- a/PyViCare/PyViCareOAuthManager.py
+++ b/PyViCare/PyViCareOAuthManager.py
@@ -125,46 +125,44 @@ class ViCareOAuthManager(AbstractViCareOAuthManager):
             self.client_id, redirect_uri=REDIRECT_URI, scope=VIESSMANN_SCOPE)
         base_authorization_url, _ = oauth.authorization_url(AUTHORIZE_URL)
 
-        # workaround until requests-oauthlib supports PKCE flow
         code_verifier, code_challenge = pkce.generate_pkce_pair()
         authorization_url = f'{base_authorization_url}&code_challenge={code_challenge}&code_challenge_method=S256'
         logger.debug(f"Auth URL is: {authorization_url}")
 
-        try:
-            header = {'Content-Type': 'application/x-www-form-urlencoded'}
-            response = requests.post(
-                authorization_url, headers=header, auth=(username, password))
-            logger.warning(
-                "Received an HTML answer from the server during auth, this is not normal:")
-            logger.debug(response.content)
-        except requests.exceptions.InvalidSchema as e:
-            # capture the error, which contains the code the authorization code and put this in to codestring
-            codestring = "{0}".format(str(e.args[0])).encode("utf-8")
-            codestring = str(codestring)
-            match = re.search("code=(.*)&", codestring)
-            codestring = match.group(1)
-            logger.debug(f"Codestring : {codestring}")
+        header = {'Content-Type': 'application/x-www-form-urlencoded'}
+        response = requests.post(
+            authorization_url, headers=header, auth=(username, password), allow_redirects=False)
 
-            # workaround until requests-oauthlib supports PKCE flow
-            resp = requests.post(url=TOKEN_URL, data={
-                'grant_type': 'authorization_code',
-                'client_id': self.client_id,
-                'redirect_uri': REDIRECT_URI,
-                'code': codestring,
-                'code_verifier': code_verifier
-            }
-            )
-            result = resp.json()
-            token_dict = {
-                'access_token': result['access_token'],
-                'token_type': 'bearer'
-            }
-            oauth = OAuth2Session(client_id=self.client_id, token=token_dict)
-            logger.debug(f"Token received: {oauth.token}")
-            self._serializeToken(oauth.token, token_file)
-            logger.info("New token created")
-            return oauth
-        raise PyViCareInvalidCredentialsError()
+        if 'Location' not in response.headers:
+            logger.debug(f'Response: {response}')
+            raise PyViCareInvalidCredentialsError()
+
+        redirect_location = response.headers['Location']
+        logger.debug(f"Redirect location is: {redirect_location}")
+        match = re.match(
+            r"(?P<uri>.+?)\?code=(?P<code>.+?)&state=", redirect_location)
+        if match is None or match.group('uri') != REDIRECT_URI:
+            raise PyViCareInvalidCredentialsError()
+
+        code = match.group('code')
+        result = requests.post(url=TOKEN_URL, data={
+            'grant_type': 'authorization_code',
+            'client_id': self.client_id,
+            'redirect_uri': REDIRECT_URI,
+            'code': code,
+            'code_verifier': code_verifier
+        }
+        ).json()
+
+        token_dict = {
+            'access_token': result['access_token'],
+            'token_type': 'bearer'
+        }
+        oauth = OAuth2Session(client_id=self.client_id, token=token_dict)
+        logger.debug(f"Token received: {oauth.token}")
+        self._serializeToken(oauth.token, token_file)
+        logger.info("New token created")
+        return oauth
 
     def renewToken(self):
         logger.info("Token expired, renewing")

--- a/PyViCare/PyViCareOAuthManager.py
+++ b/PyViCare/PyViCareOAuthManager.py
@@ -10,6 +10,7 @@ import pkce
 from pickle import UnpicklingError
 from requests_oauthlib import OAuth2Session
 import logging
+from contextlib import suppress
 
 logger = logging.getLogger('ViCare')
 logger.addHandler(logging.NullHandler())
@@ -192,12 +193,10 @@ class ViCareOAuthManager(AbstractViCareOAuthManager):
             return None
 
         logger.info("Token file exists")
-        try:
+        with suppress(UnpicklingError):
             with open(token_file, mode='rb') as binary_file:
                 s_token = pickle.load(binary_file)
                 logger.info("Token restored from file")
                 return s_token
-        except UnpicklingError:
-            pass
         logger.warning("Could not restore token")
         return None

--- a/PyViCare/PyViCareOAuthManager.py
+++ b/PyViCare/PyViCareOAuthManager.py
@@ -140,7 +140,7 @@ class ViCareOAuthManager(AbstractViCareOAuthManager):
         redirect_location = response.headers['Location']
         logger.debug(f"Redirect location is: {redirect_location}")
         match = re.match(
-            r"(?P<uri>.+?)\?code=(?P<code>.+?)&state=", redirect_location)
+            r"(?P<uri>.+?)\?code=(?P<code>[^&]+)", redirect_location)
         if match is None or match.group('uri') != REDIRECT_URI:
             raise PyViCareInvalidCredentialsError()
 
@@ -153,6 +153,10 @@ class ViCareOAuthManager(AbstractViCareOAuthManager):
             'code_verifier': code_verifier
         }
         ).json()
+
+        if 'access_token' not in result:
+            logger.debug(f"Invalid result after redirect {result}")
+            raise PyViCareInvalidCredentialsError()
 
         token_dict = {
             'access_token': result['access_token'],

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Please not that not all previous properties are available in the new API. Missin
 [Due to latest changes in the Viessmann API](https://www.viessmann-community.com/t5/Konnektivitaet/Q-amp-A-Viessmann-API/td-p/127660) rate limits can be hit. In that case a `PyViCareRateLimitError` is raised. You can read from the error (`limitResetDate`) when the rate limit is reset.
 
 ## More different devices for test cases needed
+
 In order to help ensuring making it easier to create more test cases you can run this code and make a pull request with the new test of your device type added. Your test shoudl be commited into [tests/response](tests/response) and named <family><model>.
 
 The code to run to make this happen is below. Notice how it removes "sensitive" information like installation id and serial numbers.
@@ -154,7 +155,7 @@ t = device.asAutoDetectDevice()
 
 # Extract install id and serial which we want to anonymize for test datasets
 config = device.getConfig()
-(installId, serial, deviceId)  = (config.id, config.serial, config.device_id) 
+(installId, serial, deviceId)  = (config.id, config.serial, config.device_id)
 
 # Extract heating.controller.serial
 controllerSerial = t.getControllerSerial()

--- a/tests/test_ViCareOAuthManager.py
+++ b/tests/test_ViCareOAuthManager.py
@@ -29,7 +29,9 @@ class PyViCareServiceTest(unittest.TestCase):
         self.manager = OAuthManagerWithMock(self.oauth_mock)
 
     def test_get_raiseratelimit_ifthatreponse(self):
-        self.oauth_mock.get.return_value = FakeResponse('response/rate_limit.json')
+        self.oauth_mock.get.return_value = FakeResponse(
+            'response/rate_limit.json')
+
         def func(): return self.manager.get("/")
         self.assertRaises(PyViCareRateLimitError, func)
 
@@ -42,7 +44,9 @@ class PyViCareServiceTest(unittest.TestCase):
         self.oauth_mock.renewToken.assert_called_once()
 
     def test_post_raiseratelimit_ifthatreponse(self):
-        self.oauth_mock.post.return_value = FakeResponse('response/rate_limit.json')
+        self.oauth_mock.post.return_value = FakeResponse(
+            'response/rate_limit.json')
+
         def func(): return self.manager.post("/", "some")
         self.assertRaises(PyViCareRateLimitError, func)
 


### PR DESCRIPTION
As mentioned in #142 the current implementation of receiving the OAuth token relies on an invalid schema exception.

This is changed by preventing a redirect and reading the code directly out of the response header. 

This alone will likely not resolve the issue solely. After moving the authentication for Home Assistant out of the application into the browser, this should be solved completely.