### PR TITLE
Add browser based OAuth login without credentials

### DIFF
--- a/PyViCare/PyViCare.py
+++ b/PyViCare/PyViCare.py
@@ -1,3 +1,4 @@
+from PyViCare.PyViCareBrowserOAuthManager import ViCareBrowserOAuthManager
 from PyViCare.PyViCareDeviceConfig import PyViCareDeviceConfig
 from PyViCare.PyViCareOAuthManager import ViCareOAuthManager
 from PyViCare.PyViCareService import ViCareDeviceAccessor, ViCareService
@@ -24,6 +25,10 @@ class PyViCare:
 
     def initWithExternalOAuth(self, oauth_manager):
         self.oauth_manager = oauth_manager
+        self.__loadInstallations()
+
+    def initWithBrowserOAuth(self, client_id, token_file):
+        self.oauth_manager = ViCareBrowserOAuthManager(client_id, token_file)
         self.__loadInstallations()
 
     def __buildService(self, accessor):

--- a/PyViCare/PyViCareAbstractOAuthManager.py
+++ b/PyViCare/PyViCareAbstractOAuthManager.py
@@ -1,0 +1,69 @@
+from PyViCare import Feature
+from PyViCare.PyViCareUtils import PyViCareRateLimitError
+from abc import abstractclassmethod
+from oauthlib.oauth2 import TokenExpiredError
+import logging
+
+logger = logging.getLogger('ViCare')
+logger.addHandler(logging.NullHandler())
+
+API_BASE_URL = 'https://api.viessmann.com/iot/v1'
+
+class AbstractViCareOAuthManager:
+    def __init__(self):
+        self.oauth = None
+
+    @abstractclassmethod
+    def renewToken(self):
+        return
+
+    def get(self, url):
+        try:
+            logger.debug(self.oauth)
+            response = self.oauth.get(f"{API_BASE_URL}{url}").json()
+            logger.debug("Response to get request: "+str(response))
+            self.handleExpiredToken(response)
+            self.handleRateLimit(response)
+            return response
+        except TokenExpiredError:
+            self.renewToken()
+            return self.get(url)
+
+    def handleExpiredToken(self, response):
+        if("error" in response and response["error"] == "EXPIRED TOKEN"):
+            raise TokenExpiredError(response)
+
+    def handleRateLimit(self, response):
+        if not Feature.raise_exception_on_rate_limit:
+            return
+
+        if("statusCode" in response and response["statusCode"] == 429):
+            raise PyViCareRateLimitError(response)
+
+    """POST URL using OAuth session. Automatically renew the token if needed
+    Parameters
+    ----------
+    url : str
+        URL to get
+    data : str
+        Data to post
+
+    Returns
+    -------
+    result: json
+        json representation of the answer
+    """
+
+    def post(self, url, data):
+        headers = {"Content-Type": "application/json",
+                   "Accept": "application/vnd.siren+json"}
+        try:
+            response = self.oauth.post(
+                f"{API_BASE_URL}{url}", data, headers=headers).json()
+            self.handleExpiredToken(response)
+            self.handleRateLimit(response)
+            return response
+        except TokenExpiredError:
+            self.renewToken()
+            return self.post(url, data)
+

--- a/PyViCare/PyViCareAbstractOAuthManager.py
+++ b/PyViCare/PyViCareAbstractOAuthManager.py
@@ -9,6 +9,7 @@ logger.addHandler(logging.NullHandler())
 
 API_BASE_URL = 'https://api.viessmann.com/iot/v1'
 
+
 class AbstractViCareOAuthManager:
     def __init__(self):
         self.oauth = None
@@ -66,4 +67,3 @@ class AbstractViCareOAuthManager:
         except TokenExpiredError:
             self.renewToken()
             return self.post(url, data)
-

--- a/PyViCare/PyViCareBrowserOAuthManager.py
+++ b/PyViCare/PyViCareBrowserOAuthManager.py
@@ -18,6 +18,7 @@ TOKEN_URL = 'https://iam.viessmann.com/idp/v2/token'
 REDIRECT_PORT = 51125
 VIESSMANN_SCOPE = ["IoT User", "offline_access"]
 API_BASE_URL = 'https://api.viessmann.com/iot/v1'
+AUTH_TIMEOUT = 60 * 3
 
 
 class ViCareBrowserOAuthManager(AbstractViCareOAuthManager):
@@ -69,7 +70,7 @@ class ViCareBrowserOAuthManager(AbstractViCareOAuthManager):
 
         server = HTTPServer(('localhost', REDIRECT_PORT),
                             handlerWithCallbackWrapper)
-        server.timeout = 60*3
+        server.timeout = AUTH_TIMEOUT
         server.handle_request()
 
         if code is None:

--- a/PyViCare/PyViCareBrowserOAuthManager.py
+++ b/PyViCare/PyViCareBrowserOAuthManager.py
@@ -57,12 +57,10 @@ class ViCareBrowserOAuthManager(AbstractViCareOAuthManager):
 
         webbrowser.open(authorization_url)
 
-        server = None
         code = None
 
         def callback(path):
             nonlocal code
-            nonlocal server
             match = re.match(r"(?P<uri>.+?)\?code=(?P<code>[^&]+)", path)
             code = match.group('code')
 

--- a/PyViCare/PyViCareBrowserOAuthManager.py
+++ b/PyViCare/PyViCareBrowserOAuthManager.py
@@ -40,9 +40,11 @@ class ViCareBrowserOAuthManager(AbstractViCareOAuthManager):
                 "Success. You can close this browser window now.".encode("utf-8"))
 
     def __init__(self, client_id, token_file):
+        super().__init__()
         self.token_file = token_file
         self.client_id = client_id
         self.token = None
+        self.oauth = None
         self.__loadOrCreateNewSession()
 
     def __loadOrCreateNewSession(self):
@@ -103,6 +105,7 @@ class ViCareBrowserOAuthManager(AbstractViCareOAuthManager):
         with open(self.token_file, mode='r') as json_file:
             token = json.load(json_file)
             logger.info("Token restored from file")
+            self.__set_oauth(token)
             self.token = token
 
     def __set_oauth(self, result):

--- a/PyViCare/PyViCareBrowserOAuthManager.py
+++ b/PyViCare/PyViCareBrowserOAuthManager.py
@@ -40,7 +40,12 @@ class ViCareBrowserOAuthManager(AbstractViCareOAuthManager):
     def __init__(self, client_id, token_file):
         self.token_file = token_file
         self.client_id = client_id
-        self.__createNewSession()
+        self.__loadOrCreateNewSession()
+
+    def __loadOrCreateNewSession(self):
+        self.__restoreToken()
+        if(self.token is None):
+            self.__createNewSession()
 
     def __createNewSession(self):
         redirect_uri = f"http://localhost:{REDIRECT_PORT}"
@@ -87,10 +92,13 @@ class ViCareBrowserOAuthManager(AbstractViCareOAuthManager):
             return token
 
     def __restoreToken(self):
+        if (self.token_file == None) or not os.path.isfile(self.token_file):
+            return None
+
         with open(self.token_file, mode='r') as json_file:
             token = json.load(json_file)
             logger.info("Token restored from file")
-            return token
+            self.token = token
     
     def __set_oauth(self, result):
         if 'access_token' not in result and 'refresh_token' not in result:

--- a/PyViCare/PyViCareBrowserOAuthManager.py
+++ b/PyViCare/PyViCareBrowserOAuthManager.py
@@ -19,7 +19,7 @@ logger.addHandler(logging.NullHandler())
 
 AUTHORIZE_URL = 'https://iam.viessmann.com/idp/v2/authorize'
 TOKEN_URL = 'https://iam.viessmann.com/idp/v2/token'
-REDIRECT_URI = "http://localhost:5125"
+REDIRECT_PORT = 51125
 VIESSMANN_SCOPE = ["IoT User", "offline_access"]
 API_BASE_URL = 'https://api.viessmann.com/iot/v1'
 
@@ -42,9 +42,9 @@ class ViCareBrowserOAuthManager(AbstractViCareOAuthManager):
         self.abc = self.__createNewSession()
 
     def __createNewSession(self):
-
+        redirect_uri = f"http://localhost:{REDIRECT_PORT}"
         oauth = OAuth2Session(
-            self.client_id, redirect_uri=REDIRECT_URI, scope=VIESSMANN_SCOPE)
+            self.client_id, redirect_uri=redirect_uri, scope=VIESSMANN_SCOPE)
         base_authorization_url, _ = oauth.authorization_url(AUTHORIZE_URL)
         code_verifier, code_challenge = pkce.generate_pkce_pair()
         authorization_url = f'{base_authorization_url}&code_challenge={code_challenge}&code_challenge_method=S256'
@@ -63,13 +63,11 @@ class ViCareBrowserOAuthManager(AbstractViCareOAuthManager):
         def handlerWithCallbackWrapper(*args):
             ViCareBrowserOAuthManager.Serv(callback, *args)
 
-        server = HTTPServer(('localhost',5125), handlerWithCallbackWrapper)
+        server = HTTPServer(('localhost', REDIRECT_PORT), handlerWithCallbackWrapper)
         server.serve_forever()
         print(f"Code: {code}")
 
     def renewToken(self):
-
-        offline_access
 
         # todo: move this class to Home Assistant and implement the oauth flow
         return super().renewToken()

--- a/PyViCare/PyViCareBrowserOAuthManager.py
+++ b/PyViCare/PyViCareBrowserOAuthManager.py
@@ -1,0 +1,75 @@
+from PyViCare.PyViCareAbstractOAuthManager import AbstractViCareOAuthManager
+from PyViCare import Feature
+from PyViCare.PyViCareUtils import PyViCareInvalidCredentialsError, PyViCareRateLimitError
+from abc import abstractclassmethod
+from oauthlib.oauth2 import TokenExpiredError
+import requests
+import re
+import pickle
+import threading
+import os
+import pkce
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import logging
+from requests_oauthlib import OAuth2Session
+import webbrowser
+
+logger = logging.getLogger('ViCare')
+logger.addHandler(logging.NullHandler())
+
+AUTHORIZE_URL = 'https://iam.viessmann.com/idp/v2/authorize'
+TOKEN_URL = 'https://iam.viessmann.com/idp/v2/token'
+REDIRECT_URI = "http://localhost:5125"
+VIESSMANN_SCOPE = ["IoT User", "offline_access"]
+API_BASE_URL = 'https://api.viessmann.com/iot/v1'
+
+class ViCareBrowserOAuthManager(AbstractViCareOAuthManager):
+    class Serv(BaseHTTPRequestHandler):
+        def __init__(self, callback, *args):
+            self.callback = callback
+            BaseHTTPRequestHandler.__init__(self, *args)
+
+        def do_GET(self):
+            self.callback(self.path)
+            self.send_response(200)
+            self.send_header("Content-type", "text/plain")
+            self.end_headers()
+            self.wfile.write("Success. You can close this browser window now.".encode("utf-8"))
+            
+    def __init__(self, client_id, token_file):
+        self.token_file = token_file
+        self.client_id = client_id
+        self.abc = self.__createNewSession()
+
+    def __createNewSession(self):
+
+        oauth = OAuth2Session(
+            self.client_id, redirect_uri=REDIRECT_URI, scope=VIESSMANN_SCOPE)
+        base_authorization_url, _ = oauth.authorization_url(AUTHORIZE_URL)
+        code_verifier, code_challenge = pkce.generate_pkce_pair()
+        authorization_url = f'{base_authorization_url}&code_challenge={code_challenge}&code_challenge_method=S256'
+        
+        webbrowser.open(authorization_url)
+
+        server = None
+        code = None
+        def callback(path):
+            nonlocal code
+            nonlocal server
+            match = re.match(r"(?P<uri>.+?)\?code=(?P<code>[^&]+)", path)
+            code = match.group('code')
+            threading.Thread(target=server.shutdown, daemon=True).start()
+
+        def handlerWithCallbackWrapper(*args):
+            ViCareBrowserOAuthManager.Serv(callback, *args)
+
+        server = HTTPServer(('localhost',5125), handlerWithCallbackWrapper)
+        server.serve_forever()
+        print(f"Code: {code}")
+
+    def renewToken(self):
+
+        offline_access
+
+        # todo: move this class to Home Assistant and implement the oauth flow
+        return super().renewToken()

--- a/PyViCare/PyViCareOAuthManager.py
+++ b/PyViCare/PyViCareOAuthManager.py
@@ -1,14 +1,10 @@
-from PyViCare import Feature
-from PyViCare.PyViCareUtils import PyViCareInvalidCredentialsError, PyViCareRateLimitError
-from abc import abstractclassmethod
-from oauthlib.oauth2 import TokenExpiredError
+from PyViCare.PyViCareAbstractOAuthManager import AbstractViCareOAuthManager
+from PyViCare.PyViCareUtils import PyViCareInvalidCredentialsError
 import requests
 import re
 import pickle
-import threading
 import os
 import pkce
-from http.server import BaseHTTPRequestHandler, HTTPServer
 from pickle import UnpicklingError
 from requests_oauthlib import OAuth2Session
 import logging
@@ -21,115 +17,6 @@ AUTHORIZE_URL = 'https://iam.viessmann.com/idp/v2/authorize'
 TOKEN_URL = 'https://iam.viessmann.com/idp/v2/token'
 REDIRECT_URI = "vicare://oauth-callback/everest"
 VIESSMANN_SCOPE = ["IoT User"]
-API_BASE_URL = 'https://api.viessmann.com/iot/v1'
-
-
-class AbstractViCareOAuthManager:
-    def __init__(self):
-        self.oauth = None
-
-    @abstractclassmethod
-    def renewToken(self):
-        return
-
-    def get(self, url):
-        try:
-            logger.debug(self.oauth)
-            response = self.oauth.get(f"{API_BASE_URL}{url}").json()
-            logger.debug("Response to get request: "+str(response))
-            self.handleExpiredToken(response)
-            self.handleRateLimit(response)
-            return response
-        except TokenExpiredError:
-            self.renewToken()
-            return self.get(url)
-
-    def handleExpiredToken(self, response):
-        if("error" in response and response["error"] == "EXPIRED TOKEN"):
-            raise TokenExpiredError(response)
-
-    def handleRateLimit(self, response):
-        if not Feature.raise_exception_on_rate_limit:
-            return
-
-        if("statusCode" in response and response["statusCode"] == 429):
-            raise PyViCareRateLimitError(response)
-
-    """POST URL using OAuth session. Automatically renew the token if needed
-    Parameters
-    ----------
-    url : str
-        URL to get
-    data : str
-        Data to post
-
-    Returns
-    -------
-    result: json
-        json representation of the answer
-    """
-
-    def post(self, url, data):
-        headers = {"Content-Type": "application/json",
-                   "Accept": "application/vnd.siren+json"}
-        try:
-            response = self.oauth.post(
-                f"{API_BASE_URL}{url}", data, headers=headers).json()
-            self.handleExpiredToken(response)
-            self.handleRateLimit(response)
-            return response
-        except TokenExpiredError:
-            self.renewToken()
-            return self.post(url, data)
-
-
-class ViCareHomeAssistantOAuthManager(AbstractViCareOAuthManager):
-    def __init__(self, oauth):
-        self.oauth = oauth
-
-    def renewToken(self):
-        # todo: move this class to Home Assistant and implement the oauth flow
-        return super().renewToken()
-
-class ViCareBrowserOAuthManager(AbstractViCareOAuthManager):
-    class Serv(BaseHTTPRequestHandler):
-        def __init__(self, callback, *args):
-            self.callback = callback
-            BaseHTTPRequestHandler.__init__(self, *args)
-
-        def do_GET(self):
-            self.callback(self.path)
-            self.send_response(200)
-            self.send_header("Content-type", "text/plain")
-            self.end_headers()
-            self.wfile.write("Success. You can close this browser window now.".encode("utf-8"))
-            
-    def __init__(self, client_id, token_file):
-        self.token_file = token_file
-        self.client_id = client_id
-        self.abc = self.__createNewSession()
-
-    def __createNewSession(self):
-        server = None
-        code = None
-        def callback(path):
-            nonlocal code
-            nonlocal server
-            match = re.match(r"(?P<uri>.+?)\?code=(?P<code>[^&]+)", path)
-            code = match.group('code')
-            threading.Thread(target=server.shutdown, daemon=True).start()
-
-        def handlerWithCallbackWrapper(*args):
-            ViCareBrowserOAuthManager.Serv(callback, *args)
-
-        server = HTTPServer(('localhost',5125), handlerWithCallbackWrapper)
-        server.serve_forever()
-        print(f"Code: {code}")
-
-    def renewToken(self):
-        # todo: move this class to Home Assistant and implement the oauth flow
-        return super().renewToken()
-
 
 class ViCareOAuthManager(AbstractViCareOAuthManager):
     def __init__(self, username, password, client_id, token_file):

--- a/PyViCare/PyViCareOAuthManager.py
+++ b/PyViCare/PyViCareOAuthManager.py
@@ -18,6 +18,7 @@ TOKEN_URL = 'https://iam.viessmann.com/idp/v2/token'
 REDIRECT_URI = "vicare://oauth-callback/everest"
 VIESSMANN_SCOPE = ["IoT User"]
 
+
 class ViCareOAuthManager(AbstractViCareOAuthManager):
     def __init__(self, username, password, client_id, token_file):
         self.username = username

--- a/PyViCare/PyViCareUtils.py
+++ b/PyViCare/PyViCareUtils.py
@@ -35,6 +35,9 @@ class PyViCareNotSupportedFeatureError(Exception):
 class PyViCareInvalidCredentialsError(Exception):
     pass
 
+class PyViCareBrowserOAuthTimeoutReachedError(Exception):
+    pass
+
 
 class PyViCareRateLimitError(Exception):
 

--- a/PyViCare/PyViCareUtils.py
+++ b/PyViCare/PyViCareUtils.py
@@ -35,6 +35,7 @@ class PyViCareNotSupportedFeatureError(Exception):
 class PyViCareInvalidCredentialsError(Exception):
     pass
 
+
 class PyViCareBrowserOAuthTimeoutReachedError(Exception):
     pass
 

--- a/tests/test_Integration.py
+++ b/tests/test_Integration.py
@@ -1,4 +1,4 @@
-from PyViCare.PyViCareOAuthManager import ViCareBrowserOAuthManager
+from PyViCare.PyViCareBrowserOAuthManager import ViCareBrowserOAuthManager
 import unittest
 import os
 import pytest
@@ -52,7 +52,8 @@ class Integration(unittest.TestCase):
 
     def test_abc(self):
         with enablePrintStatementsForTest(self):
-            ViCareBrowserOAuthManager("id", "some.save")
+            client_id = os.getenv('PYVICARE_CLIENT_ID', '')
+            ViCareBrowserOAuthManager(client_id, "some.save")
 
     @unittest.skipIf(not EXEC_INTEGRATION_TEST, "environments needed")
     def test_PyViCare(self):

--- a/tests/test_Integration.py
+++ b/tests/test_Integration.py
@@ -49,11 +49,11 @@ class Integration(unittest.TestCase):
     def capsys(self, capsys):
         self.capsys = capsys
 
-
-    def test_abc(self):
+    @unittest.skipIf(not EXEC_INTEGRATION_TEST, "environments needed")
+    def test_BrowserBasedLogin(self):
         with enablePrintStatementsForTest(self):
             client_id = os.getenv('PYVICARE_CLIENT_ID', '')
-            ViCareBrowserOAuthManager(client_id, "some.save")
+            ViCareBrowserOAuthManager(client_id, "browser.save")
 
     @unittest.skipIf(not EXEC_INTEGRATION_TEST, "environments needed")
     def test_PyViCare(self):

--- a/tests/test_Integration.py
+++ b/tests/test_Integration.py
@@ -58,7 +58,7 @@ class Integration(unittest.TestCase):
             vicare = PyViCare()
             vicare.initWithBrowserOAuth(client_id, token_file)
 
-            self.assertIsNotNone(vicare.oauth_manager.token)
+            self.assertIsNotNone(vicare.oauth_manager.oauth)
 
     @unittest.skipIf(not EXEC_INTEGRATION_TEST, "environments needed")
     def test_PyViCare(self):

--- a/tests/test_Integration.py
+++ b/tests/test_Integration.py
@@ -53,7 +53,12 @@ class Integration(unittest.TestCase):
     def test_BrowserBasedLogin(self):
         with enablePrintStatementsForTest(self):
             client_id = os.getenv('PYVICARE_CLIENT_ID', '')
-            ViCareBrowserOAuthManager(client_id, "browser.save")
+            token_file = "browser.save"
+
+            vicare = PyViCare()
+            vicare.initWithBrowserOAuth(client_id, token_file)
+
+            self.assertIsNotNone(vicare.oauth_manager.token)
 
     @unittest.skipIf(not EXEC_INTEGRATION_TEST, "environments needed")
     def test_PyViCare(self):

--- a/tests/test_Integration.py
+++ b/tests/test_Integration.py
@@ -1,3 +1,4 @@
+from PyViCare.PyViCareOAuthManager import ViCareBrowserOAuthManager
 import unittest
 import os
 import pytest
@@ -47,6 +48,11 @@ class Integration(unittest.TestCase):
     @pytest.fixture(autouse=True)
     def capsys(self, capsys):
         self.capsys = capsys
+
+
+    def test_abc(self):
+        with enablePrintStatementsForTest(self):
+            ViCareBrowserOAuthManager("id", "some.save")
 
     @unittest.skipIf(not EXEC_INTEGRATION_TEST, "environments needed")
     def test_PyViCare(self):


### PR DESCRIPTION
This PR is currently work in progress. It adds a browser based OAuth login, so you don't need to store your credentials in a local file. Fixes #142 .

You need to add `http://localhost:51125` as additional redirect uri in the Viessmann Developer Portal.

Todo:
* [x] Add timeout to webserver creation