### PR TITLE
remove simplejson dependency, add pkce to setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 requests-oauthlib>=1.1.0
-simplejson
 pkce

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/somm15/PyViCare",
     packages=setuptools.find_packages(exclude=["tests"]),
-    install_requires=['requests-oauthlib>=1.1.0', 'simplejson'],
+    install_requires=['requests-oauthlib>=1.1.0', 'pkce'],
     setup_requires=['setuptools-git-versioning'],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,5 +1,5 @@
 import os
-import simplejson as json
+import json
 
 
 def readJson(fileName):


### PR DESCRIPTION
We only use `simplejson`  in the unit tests, we can remove that dependency. We also need to reference `pkce` as new dependency in setup.py