### PR TITLE
Run on latest ubuntu and import lint errors to annotations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.6", "3.8", "3.9"]
@@ -26,6 +26,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install flake8 pytest
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Setup flake8 annotations
+        uses: rbialon/flake8-annotations@v1
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names


### PR DESCRIPTION
Use `ubuntu-latest` and also import flake8 warnings as GitHub annotations.