### PR TITLE
Added isort to format and typing

### DIFF
--- a/PyViCare/PyViCare.py
+++ b/PyViCare/PyViCare.py
@@ -1,9 +1,10 @@
+import logging
+
 from PyViCare.PyViCareBrowserOAuthManager import ViCareBrowserOAuthManager
+from PyViCare.PyViCareCachedService import ViCareCachedService
 from PyViCare.PyViCareDeviceConfig import PyViCareDeviceConfig
 from PyViCare.PyViCareOAuthManager import ViCareOAuthManager
 from PyViCare.PyViCareService import ViCareDeviceAccessor, ViCareService
-from PyViCare.PyViCareCachedService import ViCareCachedService
-import logging
 
 logger = logging.getLogger('ViCare')
 logger.addHandler(logging.NullHandler())

--- a/PyViCare/PyViCare.py
+++ b/PyViCare/PyViCare.py
@@ -1,5 +1,6 @@
 import logging
 
+from PyViCare.PyViCareAbstractOAuthManager import AbstractViCareOAuthManager
 from PyViCare.PyViCareBrowserOAuthManager import ViCareBrowserOAuthManager
 from PyViCare.PyViCareCachedService import ViCareCachedService
 from PyViCare.PyViCareDeviceConfig import PyViCareDeviceConfig
@@ -13,24 +14,22 @@ logger.addHandler(logging.NullHandler())
 
 
 class PyViCare:
-    def __init__(self):
+    def __init__(self) -> None:
         self.cacheDuration = 60
 
     def setCacheDuration(self, cache_duration):
         self.cacheDuration = cache_duration
 
-    def initWithCredentials(self, username, password, client_id, token_file):
-        self.oauth_manager = ViCareOAuthManager(
-            username, password, client_id, token_file)
-        self.__loadInstallations()
+    def initWithCredentials(self, username: str, password: str, client_id: str, token_file: str):
+        self.initWithExternalOAuth(ViCareOAuthManager(
+            username, password, client_id, token_file))
 
-    def initWithExternalOAuth(self, oauth_manager):
+    def initWithExternalOAuth(self, oauth_manager: AbstractViCareOAuthManager) -> None:
         self.oauth_manager = oauth_manager
         self.__loadInstallations()
 
-    def initWithBrowserOAuth(self, client_id, token_file):
-        self.oauth_manager = ViCareBrowserOAuthManager(client_id, token_file)
-        self.__loadInstallations()
+    def initWithBrowserOAuth(self, client_id: str, token_file: str) -> None:
+        self.initWithExternalOAuth(ViCareBrowserOAuthManager(client_id, token_file))
 
     def __buildService(self, accessor):
         if self.cacheDuration > 0:

--- a/PyViCare/PyViCareAbstractOAuthManager.py
+++ b/PyViCare/PyViCareAbstractOAuthManager.py
@@ -1,7 +1,9 @@
 import logging
 from abc import abstractclassmethod
+from typing import Any
 
-from oauthlib.oauth2 import TokenExpiredError
+from oauthlib.oauth2 import TokenExpiredError  # type: ignore
+from requests_oauthlib.oauth2_session import OAuth2Session
 
 from PyViCare import Feature
 from PyViCare.PyViCareUtils import PyViCareCommandError, PyViCareRateLimitError
@@ -13,21 +15,21 @@ API_BASE_URL = 'https://api.viessmann.com/iot/v1'
 
 
 class AbstractViCareOAuthManager:
-    def __init__(self, oauth_session):
+    def __init__(self, oauth_session: OAuth2Session) -> None:
         self.__oauth = oauth_session
 
     @property
-    def oauth_session(self):
+    def oauth_session(self) -> OAuth2Session:
         return self.__oauth
 
-    def replace_session(self, new_session):
+    def replace_session(self, new_session: OAuth2Session) -> None:
         self.__oauth = new_session
 
     @abstractclassmethod
     def renewToken(self):
         return
 
-    def get(self, url):
+    def get(self, url: str) -> Any:
         try:
             logger.debug(self.__oauth)
             response = self.__oauth.get(f"{API_BASE_URL}{url}").json()
@@ -71,7 +73,7 @@ class AbstractViCareOAuthManager:
         json representation of the answer
     """
 
-    def post(self, url, data):
+    def post(self, url, data) -> Any:
         headers = {"Content-Type": "application/json",
                    "Accept": "application/vnd.siren+json"}
         try:

--- a/PyViCare/PyViCareAbstractOAuthManager.py
+++ b/PyViCare/PyViCareAbstractOAuthManager.py
@@ -1,8 +1,10 @@
-from PyViCare import Feature
-from PyViCare.PyViCareUtils import PyViCareRateLimitError, PyViCareCommandError
-from abc import abstractclassmethod
-from oauthlib.oauth2 import TokenExpiredError
 import logging
+from abc import abstractclassmethod
+
+from oauthlib.oauth2 import TokenExpiredError
+
+from PyViCare import Feature
+from PyViCare.PyViCareUtils import PyViCareCommandError, PyViCareRateLimitError
 
 logger = logging.getLogger('ViCare')
 logger.addHandler(logging.NullHandler())

--- a/PyViCare/PyViCareBrowserOAuthManager.py
+++ b/PyViCare/PyViCareBrowserOAuthManager.py
@@ -37,7 +37,7 @@ class ViCareBrowserOAuthManager(AbstractViCareOAuthManager):
             self.end_headers()
             self.wfile.write(text.encode("utf-8"))
 
-    def __init__(self, client_id, token_file):
+    def __init__(self, client_id: str, token_file: str) -> None:
 
         self.token_file = token_file
         self.client_id = client_id
@@ -127,7 +127,7 @@ class ViCareBrowserOAuthManager(AbstractViCareOAuthManager):
         self.__storeToken(result)
         return OAuth2Session(client_id=self.client_id, token=result)
 
-    def renewToken(self):
+    def renewToken(self) -> None:
         token = self.oauth_session.token
         result = requests.post(url=TOKEN_URL, data={
             'grant_type': 'refresh_token',

--- a/PyViCare/PyViCareBrowserOAuthManager.py
+++ b/PyViCare/PyViCareBrowserOAuthManager.py
@@ -1,14 +1,17 @@
-from PyViCare.PyViCareAbstractOAuthManager import AbstractViCareOAuthManager
-from PyViCare.PyViCareUtils import PyViCareBrowserOAuthTimeoutReachedError, PyViCareInvalidCredentialsError
-import requests
-import re
 import json
-import os
-import pkce
-from http.server import BaseHTTPRequestHandler, HTTPServer
 import logging
-from requests_oauthlib import OAuth2Session
+import os
+import re
 import webbrowser
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pkce
+import requests
+from requests_oauthlib import OAuth2Session
+
+from PyViCare.PyViCareAbstractOAuthManager import AbstractViCareOAuthManager
+from PyViCare.PyViCareUtils import (PyViCareBrowserOAuthTimeoutReachedError,
+                                    PyViCareInvalidCredentialsError)
 
 logger = logging.getLogger('ViCare')
 logger.addHandler(logging.NullHandler())

--- a/PyViCare/PyViCareCachedService.py
+++ b/PyViCare/PyViCareCachedService.py
@@ -1,25 +1,28 @@
 import threading
 from datetime import datetime
+from typing import Any
 
-from PyViCare.PyViCareService import ViCareService, readFeature
+from PyViCare.PyViCareAbstractOAuthManager import AbstractViCareOAuthManager
+from PyViCare.PyViCareService import (ViCareDeviceAccessor, ViCareService,
+                                      readFeature)
 
 
 class ViCareTimer:
     # class is used to replace logic in unittest
-    def now(self):
+    def now(self) -> datetime:
         return datetime.now()
 
 
 class ViCareCachedService(ViCareService):
 
-    def __init__(self, oauth_manager, accessor, cacheDuration):
+    def __init__(self, oauth_manager: AbstractViCareOAuthManager, accessor: ViCareDeviceAccessor, cacheDuration: int) -> None:
         ViCareService.__init__(self, oauth_manager, accessor)
         self.__cacheDuration = cacheDuration
         self.__cache = None
         self.__cacheTime = None
         self.__lock = threading.Lock()
 
-    def getProperty(self, property_name):
+    def getProperty(self, property_name: str) -> Any:
         data = self.__get_or_update_cache()
         entities = data["data"]
         return readFeature(entities, property_name)
@@ -36,7 +39,7 @@ class ViCareCachedService(ViCareService):
                 self.__cacheTime = ViCareTimer().now()
             return self.__cache
 
-    def is_cache_invalid(self):
+    def is_cache_invalid(self) -> bool:
         return self.__cache is None or self.__cacheTime is None or (ViCareTimer().now() - self.__cacheTime).seconds > self.__cacheDuration
 
     def clear_cache(self):

--- a/PyViCare/PyViCareCachedService.py
+++ b/PyViCare/PyViCareCachedService.py
@@ -1,5 +1,6 @@
-from datetime import datetime
 import threading
+from datetime import datetime
+
 from PyViCare.PyViCareService import ViCareService, readFeature
 
 

--- a/PyViCare/PyViCareDevice.py
+++ b/PyViCare/PyViCareDevice.py
@@ -1,6 +1,8 @@
 import logging
 from datetime import datetime, time
-from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError, handleNotSupported, handleAPICommandErrors
+
+from PyViCare.PyViCareUtils import (PyViCareNotSupportedFeatureError,
+                                    handleAPICommandErrors, handleNotSupported)
 
 logger = logging.getLogger('ViCare')
 logger.addHandler(logging.NullHandler())

--- a/PyViCare/PyViCareDeviceConfig.py
+++ b/PyViCare/PyViCareDeviceConfig.py
@@ -1,12 +1,14 @@
+import json
+import logging
+import re
+
 from PyViCare.PyViCareDevice import Device
-from PyViCare.PyViCareGazBoiler import GazBoiler
 from PyViCare.PyViCareFuelCell import FuelCell
+from PyViCare.PyViCareGazBoiler import GazBoiler
 from PyViCare.PyViCareHeatPump import HeatPump
 from PyViCare.PyViCareOilBoiler import OilBoiler
 from PyViCare.PyViCarePelletsBoiler import PelletsBoiler
-import re
-import logging
-import json
+
 logger = logging.getLogger('ViCare')
 logger.addHandler(logging.NullHandler())
 

--- a/PyViCare/PyViCareOAuthManager.py
+++ b/PyViCare/PyViCareOAuthManager.py
@@ -1,14 +1,16 @@
+import logging
+import os
+import pickle
+import re
+from contextlib import suppress
+from pickle import UnpicklingError
+
+import pkce
+import requests
+from requests_oauthlib import OAuth2Session
+
 from PyViCare.PyViCareAbstractOAuthManager import AbstractViCareOAuthManager
 from PyViCare.PyViCareUtils import PyViCareInvalidCredentialsError
-import requests
-import re
-import pickle
-import os
-import pkce
-from pickle import UnpicklingError
-from requests_oauthlib import OAuth2Session
-import logging
-from contextlib import suppress
 
 logger = logging.getLogger('ViCare')
 logger.addHandler(logging.NullHandler())

--- a/PyViCare/PyViCareService.py
+++ b/PyViCare/PyViCareService.py
@@ -1,5 +1,6 @@
-import logging
 import json
+import logging
+
 from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
 
 logger = logging.getLogger('ViCare')

--- a/PyViCare/PyViCareService.py
+++ b/PyViCare/PyViCareService.py
@@ -1,6 +1,8 @@
 import json
 import logging
+from typing import Any
 
+from PyViCare.PyViCareAbstractOAuthManager import AbstractViCareOAuthManager
 from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
 
 logger = logging.getLogger('ViCare')
@@ -26,29 +28,29 @@ def buildGetPropertyUrl(accessor, property_name):
 
 
 class ViCareDeviceAccessor:
-    def __init__(self, id, serial, device_id):
+    def __init__(self, id: int, serial: str, device_id: str) -> None:
         self.id = id
         self.serial = serial
         self.device_id = device_id
 
 
 class ViCareService:
-    def __init__(self, oauth_manager, accessor):
+    def __init__(self, oauth_manager: AbstractViCareOAuthManager, accessor: ViCareDeviceAccessor) -> None:
         self.oauth_manager = oauth_manager
         self.accessor = accessor
 
-    def getProperty(self, property_name):
+    def getProperty(self, property_name: str) -> Any:
         url = buildGetPropertyUrl(
             self.accessor, property_name)
         return self.oauth_manager.get(url)
 
-    def setProperty(self, property_name, action, data):
+    def setProperty(self, property_name: str, action: str, data: Any) -> Any:
         url = buildSetPropertyUrl(
             self.accessor, property_name, action)
 
         post_data = data if isinstance(data, str) else json.dumps(data)
         return self.oauth_manager.post(url, post_data)
 
-    def fetch_all_features(self):
+    def fetch_all_features(self) -> Any:
         url = f'/equipment/installations/{self.accessor.id}/gateways/{self.accessor.serial}/devices/{self.accessor.device_id}/features/'
         return self.oauth_manager.get(url)

--- a/PyViCare/PyViCareUtils.py
+++ b/PyViCare/PyViCareUtils.py
@@ -1,6 +1,7 @@
-from PyViCare import Feature
 import datetime
 from functools import wraps
+
+from PyViCare import Feature
 
 # This decorator handles access to underlying JSON properties.
 # If the property is not found (KeyError) or the index does not

--- a/PyViCare/PyViCareUtils.py
+++ b/PyViCare/PyViCareUtils.py
@@ -1,5 +1,6 @@
 import datetime
 from functools import wraps
+from typing import Callable
 
 from PyViCare import Feature
 
@@ -9,7 +10,7 @@ from PyViCare import Feature
 # the device.
 
 
-def handleNotSupported(func):
+def handleNotSupported(func: Callable) -> Callable:
     @wraps(func)
     def wrapper(*args, **kwargs):
         try:
@@ -29,7 +30,7 @@ def handleNotSupported(func):
     return feature_flag_wrapper
 
 
-def handleAPICommandErrors(func):
+def handleAPICommandErrors(func: Callable) -> Callable:
     @wraps(func)
     def wrapper(*args, **kwargs):
         try:

--- a/format.sh
+++ b/format.sh
@@ -2,4 +2,3 @@
 isort .
 autopep8 --in-place --recursive .
 npx prettier --write {**.md,**.yml,**.json}
-flake8

--- a/format.sh
+++ b/format.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+isort .
 autopep8 --in-place --recursive .
 npx prettier --write {**.md,**.yml,**.json}
 flake8

--- a/lint.sh
+++ b/lint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+flake8
+mypy .

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,8 @@
+[mypy]
+python_version = 3.6
+warn_return_any = True
+warn_unused_configs = True
+exclude = setup\.py$|build/
+
+[mypy-requests_oauthlib.*]
+ignore_missing_imports = True

--- a/tests/ViCareServiceMock.py
+++ b/tests/ViCareServiceMock.py
@@ -1,4 +1,5 @@
-from PyViCare.PyViCareService import ViCareDeviceAccessor, readFeature, buildSetPropertyUrl
+from PyViCare.PyViCareService import (ViCareDeviceAccessor,
+                                      buildSetPropertyUrl, readFeature)
 from tests.helper import readJson
 
 

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,5 +1,5 @@
-import os
 import json
+import os
 
 
 def readJson(fileName):

--- a/tests/test_GenericDevice.py
+++ b/tests/test_GenericDevice.py
@@ -1,6 +1,7 @@
 import unittest
-from tests.ViCareServiceMock import ViCareServiceMock, MockCircuitsData
+
 from PyViCare.PyViCareDevice import Device
+from tests.ViCareServiceMock import MockCircuitsData, ViCareServiceMock
 
 
 class GenericDevice(unittest.TestCase):

--- a/tests/test_Integration.py
+++ b/tests/test_Integration.py
@@ -1,7 +1,9 @@
-import unittest
-import os
-import pytest
 import json
+import os
+import unittest
+
+import pytest
+
 from PyViCare.PyViCare import PyViCare
 from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
 

--- a/tests/test_PyViCareCachedService.py
+++ b/tests/test_PyViCareCachedService.py
@@ -1,9 +1,10 @@
-import unittest
-from PyViCare.PyViCareService import ViCareDeviceAccessor
-from PyViCare.PyViCareCachedService import ViCareCachedService, ViCareTimer
-from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
-from unittest.mock import Mock, patch
 import datetime
+import unittest
+from unittest.mock import Mock, patch
+
+from PyViCare.PyViCareCachedService import ViCareCachedService, ViCareTimer
+from PyViCare.PyViCareService import ViCareDeviceAccessor
+from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
 
 
 class PyViCareCachedServiceTest(unittest.TestCase):

--- a/tests/test_PyViCareDeviceConfig.py
+++ b/tests/test_PyViCareDeviceConfig.py
@@ -1,4 +1,5 @@
 import unittest
+
 from PyViCare.PyViCareDeviceConfig import PyViCareDeviceConfig
 
 

--- a/tests/test_PyViCareExceptions.py
+++ b/tests/test_PyViCareExceptions.py
@@ -1,6 +1,7 @@
-import unittest
 import datetime
-from PyViCare.PyViCareUtils import PyViCareRateLimitError, PyViCareCommandError
+import unittest
+
+from PyViCare.PyViCareUtils import PyViCareCommandError, PyViCareRateLimitError
 from tests.helper import readJson
 
 

--- a/tests/test_PyViCareService.py
+++ b/tests/test_PyViCareService.py
@@ -1,6 +1,7 @@
 import unittest
-from PyViCare.PyViCareService import ViCareDeviceAccessor, ViCareService
 from unittest.mock import Mock
+
+from PyViCare.PyViCareService import ViCareDeviceAccessor, ViCareService
 
 
 class PyViCareServiceTest(unittest.TestCase):

--- a/tests/test_Solar.py
+++ b/tests/test_Solar.py
@@ -1,5 +1,6 @@
-from PyViCare.PyViCareDevice import Device
 import unittest
+
+from PyViCare.PyViCareDevice import Device
 from tests.ViCareServiceMock import ViCareServiceMock
 
 

--- a/tests/test_ViCareOAuthManager.py
+++ b/tests/test_ViCareOAuthManager.py
@@ -1,7 +1,8 @@
-from PyViCare.PyViCareUtils import PyViCareRateLimitError, PyViCareCommandError
 import unittest
-from PyViCare.PyViCareOAuthManager import AbstractViCareOAuthManager
 from unittest.mock import Mock
+
+from PyViCare.PyViCareOAuthManager import AbstractViCareOAuthManager
+from PyViCare.PyViCareUtils import PyViCareCommandError, PyViCareRateLimitError
 from tests.helper import readJson
 
 

--- a/tests/test_Vitocal200.py
+++ b/tests/test_Vitocal200.py
@@ -1,7 +1,8 @@
 import unittest
-from tests.ViCareServiceMock import ViCareServiceMock
+
 from PyViCare.PyViCareHeatPump import HeatPump
 from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
+from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class Vitocal200(unittest.TestCase):

--- a/tests/test_Vitocal300G.py
+++ b/tests/test_Vitocal300G.py
@@ -1,6 +1,7 @@
 import unittest
-from tests.ViCareServiceMock import ViCareServiceMock
+
 from PyViCare.PyViCareHeatPump import HeatPump
+from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class Vitocal300G(unittest.TestCase):

--- a/tests/test_Vitodens200W.py
+++ b/tests/test_Vitodens200W.py
@@ -1,6 +1,7 @@
 import unittest
-from tests.ViCareServiceMock import ViCareServiceMock
+
 from PyViCare.PyViCareGazBoiler import GazBoiler
+from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class Vitodens200W(unittest.TestCase):

--- a/tests/test_Vitodens222W.py
+++ b/tests/test_Vitodens222W.py
@@ -1,7 +1,8 @@
 import unittest
-from tests.ViCareServiceMock import ViCareServiceMock
+
 from PyViCare.PyViCareGazBoiler import GazBoiler
 from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
+from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class Vitodens222W(unittest.TestCase):

--- a/tests/test_Vitodens300W.py
+++ b/tests/test_Vitodens300W.py
@@ -1,7 +1,8 @@
 import unittest
-from tests.ViCareServiceMock import ViCareServiceMock
+
 from PyViCare.PyViCareGazBoiler import GazBoiler
 from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
+from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class Vitodens300W(unittest.TestCase):

--- a/tests/test_Vitodens333F.py
+++ b/tests/test_Vitodens333F.py
@@ -1,6 +1,7 @@
 import unittest
-from tests.ViCareServiceMock import ViCareServiceMock
+
 from PyViCare.PyViCareGazBoiler import GazBoiler
+from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class Vitodens333F(unittest.TestCase):


### PR DESCRIPTION
1. Added isort to format command.
2. Added additional linting commands.
4. Fixed usage of `fromisoformat` which is not supported in Python < 3.7.