### PR TITLE
Fix set of domestic hot water temperature

### DIFF
--- a/PyViCare/PyViCareDevice.py
+++ b/PyViCare/PyViCareDevice.py
@@ -105,11 +105,11 @@ class Device:
 
     @handleNotSupported
     def getDomesticHotWaterMaxTemperature(self):
-        return self.service.getProperty("heating.dhw.temperature")["actions"][0]["fields"][0]["max"]
+        return self.service.getProperty("heating.dhw.temperature.main")["commands"]["setTargetTemperature"]["params"]["temperature"]["constraints"]["max"]
 
     @handleNotSupported
     def getDomesticHotWaterMinTemperature(self):
-        return self.service.getProperty("heating.dhw.temperature")["actions"][0]["fields"][0]["min"]
+        return self.service.getProperty("heating.dhw.temperature.main")["commands"]["setTargetTemperature"]["params"]["temperature"]["constraints"]["min"]
 
     @handleNotSupported
     def getDomesticHotWaterChargingActive(self):
@@ -129,7 +129,7 @@ class Device:
 
     @handleAPICommandErrors
     def setDomesticHotWaterTemperature(self, temperature):
-        return self.service.setProperty("heating.dhw.temperature", "setTargetTemperature", {'temperature': temperature})
+        return self.service.setProperty("heating.dhw.temperature.main", "setTargetTemperature", {'temperature': temperature})
 
     """ Set the target temperature 2 for domestic host water
     Parameters

--- a/tests/test_GenericDevice.py
+++ b/tests/test_GenericDevice.py
@@ -29,7 +29,7 @@ class GenericDevice(unittest.TestCase):
         self.device.setDomesticHotWaterTemperature(50)
         self.assertEqual(len(self.service.setPropertyData), 1)
         self.assertEqual(
-            self.service.setPropertyData[0]['property_name'], 'heating.dhw.temperature')
+            self.service.setPropertyData[0]['property_name'], 'heating.dhw.temperature.main')
         self.assertEqual(
             self.service.setPropertyData[0]['action'], 'setTargetTemperature')
         self.assertEqual(self.service.setPropertyData[0]['data'], {

--- a/tests/test_Vitodens200W.py
+++ b/tests/test_Vitodens200W.py
@@ -37,6 +37,12 @@ class Vitodens200W(unittest.TestCase):
     def test_getPowerConsumptionDays(self):
         self.assertRaises(PyViCareNotSupportedFeatureError, self.device.getPowerConsumptionDays)
 
+    def test_getDomesticHotWaterMaxTemperature(self):
+        self.assertEqual(self.device.getDomesticHotWaterMaxTemperature(), 60)
+
+    def test_getDomesticHotWaterMinTemperature(self):
+        self.assertEqual(self.device.getDomesticHotWaterMinTemperature(), 10)
+
     def test_getFrostProtectionActive(self):
         self.assertEqual(
             self.device.circuits[0].getFrostProtectionActive(), False)


### PR DESCRIPTION
Due to changes in the API, this PR fixes the setting of the dhw temperature.

Fixes #167. See https://github.com/oischinger/ha_vicare/issues/47