### PR TITLE
Fix inheritance of Fuelcell

### DIFF
--- a/PyViCare/PyViCareFuelCell.py
+++ b/PyViCare/PyViCareFuelCell.py
@@ -1,8 +1,8 @@
-from PyViCare.PyViCareGazBoiler import GazBoiler
+from PyViCare.PyViCareDevice import Device
 from PyViCare.PyViCareUtils import handleNotSupported
 
 
-class FuelCell(GazBoiler):
+class FuelCell(Device):
 
     @handleNotSupported
     def getOperatingPhase(self):


### PR DESCRIPTION
`FuelCell` is not of type `GazBoiler`. This fixes the inheritance issue. If methods should be available there to, they should be either moved to `Device` or duplicated.