### PR TITLE
refactor: readable timefreezer in tests

### DIFF
--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,5 +1,9 @@
 import json
 import os
+from datetime import datetime
+from unittest.mock import patch
+
+from PyViCare.PyViCareUtils import ViCareTimer
 
 
 def readJson(fileName):
@@ -10,3 +14,7 @@ def readJson(fileName):
 
 def enablePrintStatementsForTest(test_case):
     return test_case.capsys.disabled()
+
+
+def now_is(date_time):
+    return patch.object(ViCareTimer, 'now', return_value=datetime.fromisoformat(date_time))

--- a/tests/test_PyViCareCachedService.py
+++ b/tests/test_PyViCareCachedService.py
@@ -1,10 +1,10 @@
-import datetime
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
-from PyViCare.PyViCareCachedService import ViCareCachedService, ViCareTimer
+from PyViCare.PyViCareCachedService import ViCareCachedService
 from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
+from tests.helper import now_is
 
 
 class PyViCareCachedServiceTest(unittest.TestCase):
@@ -36,12 +36,12 @@ class PyViCareCachedServiceTest(unittest.TestCase):
 
     def test_getProperty_existing_cached(self):
         # time+0 seconds
-        with patch.object(ViCareTimer, 'now', return_value=datetime.datetime(2000, 1, 1, 0, 0, 0)):
+        with now_is('2000-01-01 00:00:00'):
             self.service.getProperty("someprop")
             self.service.getProperty("someprop")
 
         # time+30 seconds
-        with patch.object(ViCareTimer, 'now', return_value=datetime.datetime(2000, 1, 1, 0, 0, 30)):
+        with now_is('2000-01-01 00:00:30'):
             self.service.getProperty("someprop")
 
         self.assertEqual(self.oauth_mock.get.call_count, 1)
@@ -49,14 +49,14 @@ class PyViCareCachedServiceTest(unittest.TestCase):
             '/equipment/installations/[id]/gateways/[serial]/devices/[device]/features/')
 
         # time+70 seconds (must be more than CACHE_DURATION)
-        with patch.object(ViCareTimer, 'now', return_value=datetime.datetime(2000, 1, 1, 0, 1, 10)):
+        with now_is('2000-01-01 00:01:10'):
             self.service.getProperty("someprop")
 
         self.assertEqual(self.oauth_mock.get.call_count, 2)
 
     def test_setProperty_invalidateCache(self):
         # freeze time
-        with patch.object(ViCareTimer, 'now', return_value=datetime.datetime(2000, 1, 1, 0, 0, 0)):
+        with now_is('2000-01-01 00:00:00'):
             self.assertEqual(self.service.is_cache_invalid(), True)
             self.service.getProperty("someprop")
             self.assertEqual(self.service.is_cache_invalid(), False)

--- a/tests/test_Vitocal200.py
+++ b/tests/test_Vitocal200.py
@@ -1,10 +1,8 @@
-import datetime
 import unittest
-from unittest.mock import patch
 
 from PyViCare.PyViCareHeatPump import HeatPump
-from PyViCare.PyViCareUtils import (PyViCareNotSupportedFeatureError,
-                                    ViCareTimer)
+from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
+from tests.helper import now_is
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
@@ -79,16 +77,16 @@ class Vitocal200(unittest.TestCase):
             self.device.getDomesticHotWaterCirculationPumpActive(), False)
 
     def test_getDomesticHotWaterActiveMode_fri_10_10_time(self):
-        with patch.object(ViCareTimer, 'now', return_value=datetime.datetime(2021, 9, 10, 10, 10, 0)):
+        with now_is('2021-09-10 10:10:00'):
             self.assertEqual(
                 self.device.getDomesticHotWaterActiveMode(), 'temp-2')
 
     def test_getDomesticHotWaterDesiredTemperature_fri_10_10_time(self):
-        with patch.object(ViCareTimer, 'now', return_value=datetime.datetime(2021, 9, 10, 10, 10, 0)):
+        with now_is('2021-09-10 10:10:00'):
             self.assertEqual(
                 self.device.getDomesticHotWaterDesiredTemperature(), 60)
 
     def test_getDomesticHotWaterDesiredTemperature_fri_20_00_time(self):
-        with patch.object(ViCareTimer, 'now', return_value=datetime.datetime(2021, 9, 10, 20, 0, 0)):
+        with now_is('2021-09-10 20:00:00'):
             self.assertEqual(
                 self.device.getDomesticHotWaterDesiredTemperature(), 50)

--- a/tests/test_Vitocal222S.py
+++ b/tests/test_Vitocal222S.py
@@ -1,9 +1,7 @@
-import datetime
 import unittest
-from unittest.mock import patch
 
 from PyViCare.PyViCareHeatPump import HeatPump
-from PyViCare.PyViCareUtils import ViCareTimer
+from tests.helper import now_is
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
@@ -13,6 +11,6 @@ class Vitocal222S(unittest.TestCase):
         self.device = HeatPump(self.service)
 
     def test_getDomesticHotWaterActiveMode_10_10_time(self):
-        with patch.object(ViCareTimer, 'now', return_value=datetime.datetime(2000, 1, 1, 10, 10, 0)):
+        with now_is('2000-01-01 10:10:00'):
             self.assertEqual(
                 self.device.getDomesticHotWaterActiveMode(), 'normal')

--- a/tests/test_Vitodens200W.py
+++ b/tests/test_Vitodens200W.py
@@ -1,9 +1,7 @@
-import datetime
 import unittest
-from unittest.mock import patch
 
 from PyViCare.PyViCareGazBoiler import GazBoiler
-from PyViCare.PyViCareUtils import ViCareTimer
+from tests.helper import now_is
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
@@ -75,11 +73,11 @@ class Vitodens200W(unittest.TestCase):
             self.device.getDomesticHotWaterCirculationScheduleModes(), ['on'])
 
     def test_getDomesticHotWaterCirculationMode_wed_07_30_time(self):
-        with patch.object(ViCareTimer, 'now', return_value=datetime.datetime(2021, 9, 8, 7, 30, 0)):
+        with now_is('2021-09-08 07:30:00'):
             self.assertEqual(
                 self.device.getDomesticHotWaterCirculationMode(), 'on')
 
     def test_getDomesticHotWaterCirculationMode_wed_10_10_time(self):
-        with patch.object(ViCareTimer, 'now', return_value=datetime.datetime(2021, 9, 8, 10, 10, 0)):
+        with now_is('2021-09-08 10:10:00'):
             self.assertEqual(
                 self.device.getDomesticHotWaterCirculationMode(), 'off')


### PR DESCRIPTION
make mocking of time in unittests a bit more readable