### PR TITLE
fix!: getBurnerActive

### DIFF
--- a/PyViCare/PyViCareGazBoiler.py
+++ b/PyViCare/PyViCareGazBoiler.py
@@ -18,10 +18,6 @@ class GazBoiler(Device):
         return self.service.getProperty("heating.burners")["components"]
 
     @handleNotSupported
-    def getBurnerActive(self):
-        return self.service.getProperty("heating.burner")["properties"]["active"]["value"]
-
-    @handleNotSupported
     def getGasConsumptionHeatingDays(self):
         return self.service.getProperty("heating.gas.consumption.heating")["properties"]["day"]["value"]
 
@@ -135,6 +131,10 @@ class GazBurner(DeviceWithComponent):
     @property
     def burner(self) -> str:
         return self.component
+
+    @handleNotSupported
+    def getIsActive(self):
+        return self.service.getProperty("heating.burners.{self.burner}")["properties"]["active"]["value"]
 
     @handleNotSupported
     def getHours(self):

--- a/PyViCare/PyViCareGazBoiler.py
+++ b/PyViCare/PyViCareGazBoiler.py
@@ -134,7 +134,7 @@ class GazBurner(DeviceWithComponent):
 
     @handleNotSupported
     def getIsActive(self):
-        return self.service.getProperty("heating.burners.{self.burner}")["properties"]["active"]["value"]
+        return self.service.getProperty(f"heating.burners.{self.burner}")["properties"]["active"]["value"]
 
     @handleNotSupported
     def getHours(self):

--- a/PyViCare/PyViCareOilBoiler.py
+++ b/PyViCare/PyViCareOilBoiler.py
@@ -5,7 +5,7 @@ from PyViCare.PyViCareUtils import handleNotSupported
 class OilBoiler(Device):
 
     @handleNotSupported
-    def getBurnerActive(self):
+    def getIsActive(self):
         return self.service.getProperty("heating.burner")["properties"]["active"]["value"]
 
     @handleNotSupported

--- a/PyViCare/PyViCarePelletsBoiler.py
+++ b/PyViCare/PyViCarePelletsBoiler.py
@@ -5,7 +5,7 @@ from PyViCare.PyViCareUtils import handleNotSupported
 class PelletsBoiler(Device):
 
     @handleNotSupported
-    def getBurnerActive(self):
+    def getIsActive(self):
         return self.service.getProperty("heating.burner")["properties"]["active"]["value"]
 
     @handleNotSupported

--- a/tests/response/Vitodens222W.json
+++ b/tests/response/Vitodens222W.json
@@ -1,102 +1,14 @@
 {
   "data": [
     {
-      "properties": {
-        "status": {
-          "type": "string",
-          "value": "off"
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.dhw.pumps.primary",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.dhw.pumps.primary",
-      "timestamp": "2021-08-04T19:19:48.245Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
       "properties": {},
       "commands": {},
-      "components": [],
+      "components": ["active", "dhw", "dhwAndHeating", "heating", "standby"],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.1.operating.modes.dhwAndHeating",
-      "timestamp": "2021-08-01T11:06:25.720Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.operating.programs.holiday",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.operating.programs.holiday",
-      "timestamp": "2021-08-01T11:06:25.779Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.operating.programs.standby",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.1.operating.programs.standby",
-      "timestamp": "2021-08-01T11:06:26.514Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.operating.modes.heating",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.0.operating.modes.heating",
-      "timestamp": "2021-08-01T11:06:25.728Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "active": {
-          "type": "boolean",
-          "value": false
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.dhw.charging",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.dhw.charging",
-      "timestamp": "2021-08-04T19:19:17.154Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["pump"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.circulation",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.0.circulation",
-      "timestamp": "2021-08-01T11:06:24.548Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.operating.modes",
+      "timestamp": "2021-09-22T01:32:19.036Z",
       "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
@@ -104,167 +16,117 @@
     {
       "properties": {
         "active": {
-          "type": "boolean",
-          "value": true
-        },
-        "status": {
-          "type": "string",
-          "value": "on"
-        }
-      },
-      "commands": {},
-      "components": ["charging", "schedule", "sensors", "temperature"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.dhw",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.dhw",
-      "timestamp": "2021-08-01T11:06:26.333Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["temperature"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.sensors",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.0.sensors",
-      "timestamp": "2021-08-01T11:06:24.548Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.operating.modes.heating",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.operating.modes.heating",
-      "timestamp": "2021-08-01T11:06:25.745Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/device",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "device",
-      "timestamp": "2021-08-01T11:06:24.548Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.operating.modes.active",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.operating.modes.active",
-      "timestamp": "2021-08-01T11:06:26.459Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "value": {
-          "type": "string",
-          "value": "7438335101213102"
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.boiler.serial",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.boiler.serial",
-      "timestamp": "2021-08-01T11:06:25.703Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["time"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.device",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.device",
-      "timestamp": "2021-08-01T11:06:24.548Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "hours": {
-          "type": "number",
-          "value": 25123.2,
-          "unit": ""
-        },
-        "starts": {
-          "type": "number",
-          "value": 79167,
-          "unit": ""
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.burners.0.statistics",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.burners.0.statistics",
-      "timestamp": "2021-08-04T19:11:16.805Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.operating.programs.active",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.1.operating.programs.active",
-      "timestamp": "2021-08-01T11:06:26.330Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "value": {
-          "value": 50,
-          "unit": "",
-          "type": "number"
+          "value": false,
+          "type": "boolean"
         }
       },
       "commands": {
-        "setTargetTemperature": {
-          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature",
-          "name": "setTargetTemperature",
+        "activate": {
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/activate",
+          "name": "activate",
+          "isExecutable": true,
+          "params": {}
+        },
+        "deactivate": {
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate",
+          "name": "deactivate",
+          "isExecutable": false,
+          "params": {}
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge",
+      "gatewayId": "################",
+      "feature": "heating.dhw.oneTimeCharge",
+      "timestamp": "2021-09-22T01:33:01.993Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.frostprotection",
+      "gatewayId": "################",
+      "feature": "heating.circuits.3.frostprotection",
+      "timestamp": "2021-09-22T01:33:03.885Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.dhw",
+      "gatewayId": "################",
+      "feature": "heating.circuits.3.operating.modes.dhw",
+      "timestamp": "2021-09-22T01:32:53.711Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "unit": {
+          "value": "percent",
+          "type": "string"
+        },
+        "value": {
+          "type": "number",
+          "value": 15.8,
+          "unit": "percent"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners.0.modulation",
+      "gatewayId": "################",
+      "feature": "heating.burners.0.modulation",
+      "timestamp": "2021-09-30T15:03:14.128Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "shift": {
+          "type": "number",
+          "unit": "",
+          "value": 13
+        },
+        "slope": {
+          "type": "number",
+          "unit": "",
+          "value": 0.9
+        }
+      },
+      "commands": {
+        "setCurve": {
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve",
+          "name": "setCurve",
           "isExecutable": true,
           "params": {
-            "temperature": {
+            "slope": {
               "type": "number",
               "required": true,
               "constraints": {
-                "min": 10,
-                "efficientLowerBorder": 10,
-                "efficientUpperBorder": 60,
-                "max": 60,
+                "min": 0.2,
+                "max": 3.5,
+                "stepping": 0.1
+              }
+            },
+            "shift": {
+              "type": "number",
+              "required": true,
+              "constraints": {
+                "min": -13,
+                "max": 40,
                 "stepping": 1
               }
             }
@@ -273,150 +135,10 @@
       },
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.dhw.temperature.main",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.dhw.temperature.main",
-      "timestamp": "2021-08-01T11:06:25.588Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "active": {
-          "value": true,
-          "type": "boolean"
-        },
-        "entries": {
-          "value": {
-            "mon": [
-              {
-                "start": "06:00",
-                "end": "24:00",
-                "mode": "on",
-                "position": 0
-              },
-              {
-                "start": "00:00",
-                "end": "01:00",
-                "mode": "on",
-                "position": 1
-              }
-            ],
-            "tue": [
-              {
-                "start": "06:00",
-                "end": "24:00",
-                "mode": "on",
-                "position": 0
-              },
-              {
-                "start": "00:00",
-                "end": "01:00",
-                "mode": "on",
-                "position": 1
-              }
-            ],
-            "wed": [
-              {
-                "start": "06:00",
-                "end": "24:00",
-                "mode": "on",
-                "position": 0
-              },
-              {
-                "start": "00:00",
-                "end": "01:00",
-                "mode": "on",
-                "position": 1
-              }
-            ],
-            "thu": [
-              {
-                "start": "06:00",
-                "end": "24:00",
-                "mode": "on",
-                "position": 0
-              },
-              {
-                "start": "00:00",
-                "end": "01:00",
-                "mode": "on",
-                "position": 1
-              }
-            ],
-            "fri": [
-              {
-                "start": "06:00",
-                "end": "24:00",
-                "mode": "on",
-                "position": 0
-              },
-              {
-                "start": "00:00",
-                "end": "01:00",
-                "mode": "on",
-                "position": 1
-              }
-            ],
-            "sat": [
-              {
-                "start": "06:00",
-                "end": "24:00",
-                "mode": "on",
-                "position": 0
-              },
-              {
-                "start": "00:00",
-                "end": "01:00",
-                "mode": "on",
-                "position": 1
-              }
-            ],
-            "sun": [
-              {
-                "start": "06:00",
-                "end": "24:00",
-                "mode": "on",
-                "position": 0
-              },
-              {
-                "start": "00:00",
-                "end": "01:00",
-                "mode": "on",
-                "position": 1
-              }
-            ]
-          },
-          "type": "Schedule"
-        }
-      },
-      "commands": {
-        "setSchedule": {
-          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.dhw.schedule/commands/setSchedule",
-          "name": "setSchedule",
-          "isExecutable": true,
-          "params": {
-            "newSchedule": {
-              "type": "Schedule",
-              "required": true,
-              "constraints": {
-                "modes": ["on"],
-                "maxEntries": 4,
-                "resolution": 10,
-                "defaultMode": "off",
-                "overlapAllowed": true
-              }
-            }
-          }
-        }
-      },
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.dhw.schedule",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.dhw.schedule",
-      "timestamp": "2021-08-01T11:06:26.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.curve",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.heating.curve",
+      "timestamp": "2021-09-30T12:31:49.238Z",
       "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
@@ -426,10 +148,49 @@
       "commands": {},
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeating",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.operating.modes.dhwAndHeating",
-      "timestamp": "2021-08-01T11:06:25.724Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.circulation.pump",
+      "gatewayId": "################",
+      "feature": "heating.circuits.3.circulation.pump",
+      "timestamp": "2021-09-22T01:32:44.501Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["dhw", "heating", "total"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.power.consumption",
+      "gatewayId": "################",
+      "feature": "heating.power.consumption",
+      "timestamp": "2021-09-22T01:32:19.037Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.circulation.pump",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.circulation.pump",
+      "timestamp": "2021-09-22T01:32:44.483Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.operating.programs.forcedLastFromSchedule",
+      "timestamp": "2021-09-30T05:50:47.756Z",
       "isEnabled": false,
       "isReady": true,
       "deviceId": "0"
@@ -442,7 +203,7 @@
         },
         "value": {
           "type": "number",
-          "value": 73,
+          "value": 47.1,
           "unit": "celsius"
         },
         "status": {
@@ -453,10 +214,10 @@
       "commands": {},
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.boiler.sensors.temperature.main",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.boiler.sensors.temperature.main",
-      "timestamp": "2021-08-04T19:50:37.422Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.sensors.temperature.supply",
+      "timestamp": "2021-09-30T15:02:19.289Z",
       "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
@@ -464,13 +225,13 @@
     {
       "properties": {},
       "commands": {},
-      "components": ["curve", "schedule"],
+      "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.heating",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.0.heating",
-      "timestamp": "2021-08-01T11:06:24.548Z",
-      "isEnabled": true,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.operating.modes.dhwAndHeating",
+      "timestamp": "2021-09-22T01:32:54.126Z",
+      "isEnabled": false,
       "isReady": true,
       "deviceId": "0"
     },
@@ -482,7 +243,7 @@
         },
         "value": {
           "type": "number",
-          "value": 16.3,
+          "value": 39.8,
           "unit": "celsius"
         },
         "status": {
@@ -493,23 +254,10 @@
       "commands": {},
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.sensors.temperature.outside",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.sensors.temperature.outside",
-      "timestamp": "2021-08-04T19:20:08.602Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["circulation"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.dhw.pumps",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.dhw.pumps",
-      "timestamp": "2021-08-01T11:06:24.548Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.outlet",
+      "gatewayId": "################",
+      "feature": "heating.dhw.sensors.temperature.outlet",
+      "timestamp": "2021-09-30T15:02:51.240Z",
       "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
@@ -519,10 +267,10 @@
       "commands": {},
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.operating.programs.comfort",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.1.operating.programs.comfort",
-      "timestamp": "2021-08-01T11:06:25.620Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.dhwAndHeating",
+      "gatewayId": "################",
+      "feature": "heating.circuits.3.operating.modes.dhwAndHeating",
+      "timestamp": "2021-09-22T01:32:55.649Z",
       "isEnabled": false,
       "isReady": true,
       "deviceId": "0"
@@ -530,25 +278,12 @@
     {
       "properties": {},
       "commands": {},
-      "components": [],
+      "components": ["sensors", "serial", "temperature"],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.operating.programs.external",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.1.operating.programs.external",
-      "timestamp": "2021-08-01T11:06:25.671Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["collector", "dhw"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.solar.sensors.temperature",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.solar.sensors.temperature",
-      "timestamp": "2021-08-01T11:06:24.548Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler",
+      "gatewayId": "################",
+      "feature": "heating.boiler",
+      "timestamp": "2021-09-22T01:32:19.036Z",
       "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
@@ -558,10 +293,10 @@
       "commands": {},
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.boiler.sensors.temperature.commonSupply",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.boiler.sensors.temperature.commonSupply",
-      "timestamp": "2021-08-01T11:06:25.702Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.frostprotection",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.frostprotection",
+      "timestamp": "2021-09-22T01:33:03.854Z",
       "isEnabled": false,
       "isReady": true,
       "deviceId": "0"
@@ -571,85 +306,47 @@
       "commands": {},
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.operating.modes.dhw",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.1.operating.modes.dhw",
-      "timestamp": "2021-08-01T11:06:25.655Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.sensors.temperature.supply",
+      "timestamp": "2021-09-22T01:33:02.394Z",
       "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["temperature"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.solar.sensors",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.solar.sensors",
-      "timestamp": "2021-08-01T11:06:24.548Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["room", "supply"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.sensors.temperature",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.1.sensors.temperature",
-      "timestamp": "2021-08-01T11:06:24.548Z",
-      "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
     },
     {
       "properties": {
-        "active": {
-          "value": true,
+        "enabled": {
+          "value": false,
           "type": "boolean"
-        },
-        "entries": {
-          "value": {
-            "mon": [],
-            "tue": [],
-            "wed": [],
-            "thu": [],
-            "fri": [],
-            "sat": [],
-            "sun": []
-          },
-          "type": "Schedule"
         }
       },
       "commands": {
-        "setSchedule": {
-          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/setSchedule",
-          "name": "setSchedule",
+        "activate": {
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/activate",
+          "name": "activate",
+          "isExecutable": false,
+          "params": {}
+        },
+        "enable": {
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/enable",
+          "name": "enable",
           "isExecutable": true,
-          "params": {
-            "newSchedule": {
-              "type": "Schedule",
-              "required": true,
-              "constraints": {
-                "modes": ["on"],
-                "maxEntries": 4,
-                "resolution": 10,
-                "defaultMode": "off",
-                "overlapAllowed": true
-              }
-            }
-          }
+          "params": {}
+        },
+        "disable": {
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/disable",
+          "name": "disable",
+          "isExecutable": false,
+          "params": {}
         }
       },
-      "components": [],
+      "components": ["trigger"],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.dhw.pumps.circulation.schedule",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.dhw.pumps.circulation.schedule",
-      "timestamp": "2021-08-01T11:06:26.357Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.hygiene",
+      "gatewayId": "################",
+      "feature": "heating.dhw.hygiene",
+      "timestamp": "2021-09-22T01:33:03.918Z",
       "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
@@ -659,10 +356,10 @@
       "commands": {},
       "components": ["temperature"],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.sensors",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.sensors",
-      "timestamp": "2021-08-01T11:06:24.548Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.sensors",
+      "gatewayId": "################",
+      "feature": "heating.circuits.3.sensors",
+      "timestamp": "2021-09-22T01:32:19.038Z",
       "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
@@ -672,154 +369,119 @@
       "commands": {},
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.operating.programs.external",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.operating.programs.external",
-      "timestamp": "2021-08-01T11:06:25.672Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.hygiene.trigger",
+      "gatewayId": "################",
+      "feature": "heating.dhw.hygiene.trigger",
+      "timestamp": "2021-09-22T01:33:03.965Z",
       "isEnabled": false,
       "isReady": true,
       "deviceId": "0"
     },
     {
       "properties": {
-        "active": {
-          "type": "boolean",
-          "value": false
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.operating.modes.standby",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.0.operating.modes.standby",
-      "timestamp": "2021-08-01T11:06:26.475Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "value": {
+        "unit": {
+          "value": "kilowattHour",
+          "type": "string"
+        },
+        "day": {
+          "type": "array",
+          "value": [0.4, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
+        },
+        "week": {
+          "type": "array",
+          "value": [0.7, 0.7, 0.7, 0.7, 1.2, 0.7, 0.7, 0.7, 0.7]
+        },
+        "month": {
+          "type": "array",
+          "value": [
+            3.8, 4.1, 3.5, 3.4, 14.4, 23.2, 28.8, 31.7, 34.7, 31.3, 30.2, 29.3,
+            26.3
+          ]
+        },
+        "year": {
+          "type": "array",
+          "value": [148.2, 227.6]
+        },
+        "dayValueReadAt": {
           "type": "string",
-          "value": "7429629140108102"
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.controller.serial",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.controller.serial",
-      "timestamp": "2021-08-01T11:06:26.163Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["multiFamilyHouse"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.configuration",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.configuration",
-      "timestamp": "2021-08-01T11:06:24.548Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["pumps", "schedule"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.dhw",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.dhw",
-      "timestamp": "2021-08-01T11:06:24.548Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["pump"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.circulation",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.circulation",
-      "timestamp": "2021-08-01T11:06:24.548Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [
-        "circulation",
-        "dhw",
-        "frostprotection",
-        "heating",
-        "operating",
-        "sensors"
-      ],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.1",
-      "timestamp": "2021-08-01T11:06:25.607Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.heating.schedule",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.heating.schedule",
-      "timestamp": "2021-08-01T11:06:26.365Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "status": {
+          "value": "2021-09-30T14:55:39.000Z"
+        },
+        "weekValueReadAt": {
           "type": "string",
-          "value": "off"
+          "value": "2021-09-30T13:21:33.000Z"
+        },
+        "monthValueReadAt": {
+          "type": "string",
+          "value": "2021-09-30T14:55:39.000Z"
+        },
+        "yearValueReadAt": {
+          "type": "string",
+          "value": "2021-09-30T14:55:39.000Z"
         }
       },
       "commands": {},
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.frostprotection",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.0.frostprotection",
-      "timestamp": "2021-08-01T11:06:25.713Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.power.consumption.heating",
+      "gatewayId": "################",
+      "feature": "heating.power.consumption.heating",
+      "timestamp": "2021-09-30T14:56:23.104Z",
       "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
     },
     {
       "properties": {
-        "active": {
-          "type": "boolean",
-          "value": false
+        "unit": {
+          "value": "kilowattHour",
+          "type": "string"
+        },
+        "day": {
+          "type": "array",
+          "value": [0.4, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
+        },
+        "week": {
+          "type": "array",
+          "value": [
+            0.7, 0.7, 1.0999999999999999, 1.3, 1.7999999999999998, 1.2, 1.4,
+            1.0999999999999999, 1.2000000000000002
+          ]
+        },
+        "month": {
+          "type": "array",
+          "value": [
+            6, 7.699999999999999, 6.9, 6.5, 18, 27.099999999999998, 33.2, 35.8,
+            39, 38.7, 37.2, 36.7, 32.4
+          ]
+        },
+        "year": {
+          "type": "array",
+          "value": [181.1, 284]
+        },
+        "dayValueReadAt": {
+          "type": "string",
+          "value": "2021-09-30T14:55:39.000Z"
+        },
+        "weekValueReadAt": {
+          "type": "string",
+          "value": "2021-09-30T13:21:33.000Z"
+        },
+        "monthValueReadAt": {
+          "type": "string",
+          "value": "2021-09-30T14:55:39.000Z"
+        },
+        "yearValueReadAt": {
+          "type": "string",
+          "value": "2021-09-30T14:55:39.000Z"
         }
       },
       "commands": {},
-      "components": ["modulation", "statistics"],
+      "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.burners.0",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.burners.0",
-      "timestamp": "2021-08-04T19:19:08.202Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.power.consumption.total",
+      "gatewayId": "################",
+      "feature": "heating.power.consumption.total",
+      "timestamp": "2021-09-30T14:56:23.163Z",
       "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
@@ -841,7 +503,7 @@
       },
       "commands": {
         "changeEndDate": {
-          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate",
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/changeEndDate",
           "name": "changeEndDate",
           "isExecutable": false,
           "params": {
@@ -850,13 +512,13 @@
               "required": true,
               "constraints": {
                 "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
-                "sameDayAllowed": false
+                "sameDayAllowed": true
               }
             }
           }
         },
         "schedule": {
-          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.operating.programs.holiday/commands/schedule",
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/schedule",
           "name": "schedule",
           "isExecutable": true,
           "params": {
@@ -872,13 +534,13 @@
               "required": true,
               "constraints": {
                 "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
-                "sameDayAllowed": false
+                "sameDayAllowed": true
               }
             }
           }
         },
         "unschedule": {
-          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.operating.programs.holiday/commands/unschedule",
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/unschedule",
           "name": "unschedule",
           "isExecutable": true,
           "params": {}
@@ -886,10 +548,10 @@
       },
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.operating.programs.holiday",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.operating.programs.holiday",
-      "timestamp": "2021-08-01T11:06:26.538Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome",
+      "gatewayId": "################",
+      "feature": "heating.operating.programs.holidayAtHome",
+      "timestamp": "2021-09-22T01:33:03.721Z",
       "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
@@ -899,10 +561,10 @@
       "commands": {},
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.operating.programs.eco",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.operating.programs.eco",
-      "timestamp": "2021-08-01T11:06:26.017Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.standby",
+      "gatewayId": "################",
+      "feature": "heating.circuits.3.operating.modes.standby",
+      "timestamp": "2021-09-22T01:32:52.811Z",
       "isEnabled": false,
       "isReady": true,
       "deviceId": "0"
@@ -912,10 +574,10 @@
       "commands": {},
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.heating.schedule",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.1.heating.schedule",
-      "timestamp": "2021-08-01T11:06:25.675Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeating",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.operating.modes.dhwAndHeating",
+      "timestamp": "2021-09-22T01:32:54.891Z",
       "isEnabled": false,
       "isReady": true,
       "deviceId": "0"
@@ -923,601 +585,12 @@
     {
       "properties": {},
       "commands": {},
-      "components": [],
+      "components": ["multiFamilyHouse"],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.operating.programs.reduced",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.1.operating.programs.reduced",
-      "timestamp": "2021-08-01T11:06:26.510Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.operating.modes.dhw",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.operating.modes.dhw",
-      "timestamp": "2021-08-01T11:06:25.657Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.operating.programs.holiday",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.1.operating.programs.holiday",
-      "timestamp": "2021-08-01T11:06:25.776Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["holiday"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.operating.programs",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.operating.programs",
-      "timestamp": "2021-08-01T11:06:24.547Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.dhw.schedule",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.0.dhw.schedule",
-      "timestamp": "2021-08-01T11:06:25.705Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.sensors.temperature.room",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.1.sensors.temperature.room",
-      "timestamp": "2021-08-01T11:06:25.677Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "active": {
-          "value": false,
-          "type": "boolean"
-        },
-        "demand": {
-          "value": "unknown",
-          "type": "string"
-        },
-        "temperature": {
-          "value": 10,
-          "unit": "",
-          "type": "number"
-        }
-      },
-      "commands": {
-        "setTemperature": {
-          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.operating.programs.reduced/commands/setTemperature",
-          "name": "setTemperature",
-          "isExecutable": true,
-          "params": {
-            "targetTemperature": {
-              "type": "number",
-              "required": true,
-              "constraints": {
-                "min": 3,
-                "max": 37,
-                "stepping": 1
-              }
-            }
-          }
-        }
-      },
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.operating.programs.reduced",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.0.operating.programs.reduced",
-      "timestamp": "2021-08-01T11:06:25.674Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [
-        "active",
-        "comfort",
-        "eco",
-        "external",
-        "holiday",
-        "normal",
-        "reduced",
-        "standby"
-      ],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.operating.programs",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.operating.programs",
-      "timestamp": "2021-08-01T11:06:24.548Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [
-        "active",
-        "comfort",
-        "eco",
-        "external",
-        "holiday",
-        "normal",
-        "reduced",
-        "standby"
-      ],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.operating.programs",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.0.operating.programs",
-      "timestamp": "2021-08-01T11:06:24.548Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "shift": {
-          "type": "number",
-          "unit": "",
-          "value": 0
-        },
-        "slope": {
-          "type": "number",
-          "unit": "",
-          "value": 1.4
-        }
-      },
-      "commands": {
-        "setCurve": {
-          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.heating.curve/commands/setCurve",
-          "name": "setCurve",
-          "isExecutable": true,
-          "params": {
-            "slope": {
-              "type": "number",
-              "required": true,
-              "constraints": {
-                "min": 0.2,
-                "max": 3.5,
-                "stepping": 0.1
-              }
-            },
-            "shift": {
-              "type": "number",
-              "required": true,
-              "constraints": {
-                "min": -13,
-                "max": 40,
-                "stepping": 1
-              }
-            }
-          }
-        }
-      },
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.heating.curve",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.heating.curve",
-      "timestamp": "2021-08-01T11:06:25.610Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.sensors.temperature.supply",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.sensors.temperature.supply",
-      "timestamp": "2021-08-01T11:06:26.070Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["outside"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.sensors.temperature",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.sensors.temperature",
-      "timestamp": "2021-08-01T11:06:24.548Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["sensors", "serial", "temperature"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.boiler",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.boiler",
-      "timestamp": "2021-08-01T11:06:24.548Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.operating.programs.eco",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.1.operating.programs.eco",
-      "timestamp": "2021-08-01T11:06:25.858Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "active": {
-          "value": false,
-          "type": "boolean"
-        },
-        "demand": {
-          "value": "unknown",
-          "type": "string"
-        },
-        "temperature": {
-          "value": 10,
-          "unit": "",
-          "type": "number"
-        }
-      },
-      "commands": {
-        "setTemperature": {
-          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature",
-          "name": "setTemperature",
-          "isExecutable": true,
-          "params": {
-            "targetTemperature": {
-              "type": "number",
-              "required": true,
-              "constraints": {
-                "min": 3,
-                "max": 37,
-                "stepping": 1
-              }
-            }
-          }
-        }
-      },
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.operating.programs.normal",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.0.operating.programs.normal",
-      "timestamp": "2021-08-01T11:06:25.783Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["curve", "schedule"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.heating",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.1.heating",
-      "timestamp": "2021-08-01T11:06:24.548Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["pumps", "schedule"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.dhw",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.1.dhw",
-      "timestamp": "2021-08-01T11:06:24.547Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["active", "dhw", "dhwAndHeating", "heating", "standby"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.operating.modes",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.operating.modes",
-      "timestamp": "2021-08-01T11:06:24.548Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.operating.programs.holiday",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.0.operating.programs.holiday",
-      "timestamp": "2021-08-01T11:06:25.764Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.solar.sensors.temperature.dhw",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.solar.sensors.temperature.dhw",
-      "timestamp": "2021-08-01T11:06:26.363Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["0"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.burners",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.burners",
-      "timestamp": "2021-08-01T11:06:24.548Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["pump"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.circulation",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.1.circulation",
-      "timestamp": "2021-08-01T11:06:24.548Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.sensors.temperature.room",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.sensors.temperature.room",
-      "timestamp": "2021-08-01T11:06:25.678Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.frostprotection",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.1.frostprotection",
-      "timestamp": "2021-08-01T11:06:25.714Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.dhw.schedule",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.dhw.schedule",
-      "timestamp": "2021-08-01T11:06:25.710Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "unit": {
-          "value": "celsius",
-          "type": "string"
-        },
-        "value": {
-          "type": "number",
-          "value": 5,
-          "unit": "celsius"
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.boiler.temperature",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.boiler.temperature",
-      "timestamp": "2021-08-01T11:06:25.623Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "unit": {
-          "value": "celsius",
-          "type": "string"
-        },
-        "value": {
-          "type": "number",
-          "value": 48.7,
-          "unit": "celsius"
-        },
-        "status": {
-          "type": "string",
-          "value": "connected"
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.dhw.sensors.temperature.hotWaterStorage",
-      "timestamp": "2021-08-04T19:29:18.289Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "unit": {
-          "value": "celsius",
-          "type": "string"
-        },
-        "value": {
-          "type": "number",
-          "value": 73,
-          "unit": "celsius"
-        },
-        "status": {
-          "type": "string",
-          "value": "connected"
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.sensors.temperature.supply",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.0.sensors.temperature.supply",
-      "timestamp": "2021-08-04T19:50:39.390Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.operating.programs.reduced",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.operating.programs.reduced",
-      "timestamp": "2021-08-01T11:06:26.511Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "value": {
-          "value": "dhw",
-          "type": "string"
-        }
-      },
-      "commands": {
-        "setMode": {
-          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode",
-          "name": "setMode",
-          "isExecutable": true,
-          "params": {
-            "mode": {
-              "type": "string",
-              "required": true,
-              "constraints": {
-                "enum": [
-                  "standby",
-                  "dhw",
-                  "dhwAndHeating",
-                  "forcedReduced",
-                  "forcedNormal"
-                ]
-              }
-            }
-          }
-        }
-      },
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.operating.modes.active",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.0.operating.modes.active",
-      "timestamp": "2021-08-01T11:06:26.476Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["curve", "schedule"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.heating",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.heating",
-      "timestamp": "2021-08-01T11:06:24.548Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "active": {
-          "type": "boolean",
-          "value": false
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.burner",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.burner",
-      "timestamp": "2021-08-04T19:19:08.187Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.configuration",
+      "gatewayId": "################",
+      "feature": "heating.configuration",
+      "timestamp": "2021-09-22T01:32:19.034Z",
       "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
@@ -1532,49 +605,10 @@
       "commands": {},
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.operating.modes.dhw",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.0.operating.modes.dhw",
-      "timestamp": "2021-08-01T11:06:25.653Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["active", "dhw", "dhwAndHeating", "heating", "standby"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.operating.modes",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.0.operating.modes",
-      "timestamp": "2021-08-01T11:06:24.548Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["offset"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.device.time",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.device.time",
-      "timestamp": "2021-08-01T11:06:24.548Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["temperature"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.sensors",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.1.sensors",
-      "timestamp": "2021-08-01T11:06:24.548Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.operating.modes.dhwAndHeating",
+      "timestamp": "2021-09-30T05:50:47.198Z",
       "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
@@ -1584,23 +618,63 @@
       "commands": {},
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.frostprotection",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.frostprotection",
-      "timestamp": "2021-08-01T11:06:25.715Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reduced",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.operating.programs.reduced",
+      "timestamp": "2021-09-29T00:17:32.831Z",
       "isEnabled": false,
       "isReady": true,
       "deviceId": "0"
     },
     {
-      "properties": {},
+      "properties": {
+        "unit": {
+          "value": "cubicMeter",
+          "type": "string"
+        },
+        "day": {
+          "type": "array",
+          "value": [2.8, 0, 0, 0, 0, 0, 0, 0]
+        },
+        "week": {
+          "type": "array",
+          "value": [2.8, 0, 0, 0, 2.5999999999999996, 0, 0, 0, 0]
+        },
+        "month": {
+          "type": "array",
+          "value": [
+            2.8, 2.6, 0, 0, 72.2, 148.5, 201.2, 260.1, 287.2, 226.7, 191.7,
+            132.5, 61.9
+          ]
+        },
+        "year": {
+          "type": "array",
+          "value": [974.9, 818.6]
+        },
+        "dayValueReadAt": {
+          "type": "string",
+          "value": "2021-09-30T14:17:37.000Z"
+        },
+        "weekValueReadAt": {
+          "type": "string",
+          "value": "2021-09-30T14:17:37.000Z"
+        },
+        "monthValueReadAt": {
+          "type": "string",
+          "value": "2021-09-30T14:17:37.000Z"
+        },
+        "yearValueReadAt": {
+          "type": "string",
+          "value": "2021-09-30T14:17:37.000Z"
+        }
+      },
       "commands": {},
-      "components": ["modes", "programs"],
+      "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.operating",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.0.operating",
-      "timestamp": "2021-08-01T11:06:24.548Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.gas.consumption.heating",
+      "gatewayId": "################",
+      "feature": "heating.gas.consumption.heating",
+      "timestamp": "2021-09-30T14:25:09.690Z",
       "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
@@ -1611,125 +685,742 @@
           "value": false,
           "type": "boolean"
         },
-        "entries": {
-          "value": {
-            "mon": [
-              {
-                "start": "05:30",
-                "end": "09:00",
-                "mode": "normal",
-                "position": 0
-              },
-              {
-                "start": "17:30",
-                "end": "21:00",
-                "mode": "normal",
-                "position": 1
-              }
-            ],
-            "tue": [
-              {
-                "start": "05:30",
-                "end": "09:00",
-                "mode": "normal",
-                "position": 0
-              },
-              {
-                "start": "17:30",
-                "end": "21:00",
-                "mode": "normal",
-                "position": 1
-              }
-            ],
-            "wed": [
-              {
-                "start": "05:30",
-                "end": "09:00",
-                "mode": "normal",
-                "position": 0
-              },
-              {
-                "start": "17:30",
-                "end": "21:00",
-                "mode": "normal",
-                "position": 1
-              }
-            ],
-            "thu": [
-              {
-                "start": "05:30",
-                "end": "09:00",
-                "mode": "normal",
-                "position": 0
-              },
-              {
-                "start": "17:30",
-                "end": "21:00",
-                "mode": "normal",
-                "position": 1
-              }
-            ],
-            "fri": [
-              {
-                "start": "05:30",
-                "end": "09:00",
-                "mode": "normal",
-                "position": 0
-              },
-              {
-                "start": "17:30",
-                "end": "21:00",
-                "mode": "normal",
-                "position": 1
-              }
-            ],
-            "sat": [
-              {
-                "start": "05:30",
-                "end": "09:00",
-                "mode": "normal",
-                "position": 0
-              },
-              {
-                "start": "17:30",
-                "end": "21:00",
-                "mode": "normal",
-                "position": 1
-              }
-            ],
-            "sun": [
-              {
-                "start": "05:30",
-                "end": "09:00",
-                "mode": "normal",
-                "position": 0
-              },
-              {
-                "start": "17:30",
-                "end": "21:00",
-                "mode": "normal",
-                "position": 1
-              }
-            ]
-          },
-          "type": "Schedule"
+        "demand": {
+          "value": "unknown",
+          "type": "string"
+        },
+        "temperature": {
+          "value": 24,
+          "unit": "",
+          "type": "number"
         }
       },
       "commands": {
-        "setSchedule": {
-          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule",
-          "name": "setSchedule",
+        "setTemperature": {
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/setTemperature",
+          "name": "setTemperature",
           "isExecutable": true,
           "params": {
-            "newSchedule": {
-              "type": "Schedule",
+            "targetTemperature": {
+              "type": "number",
               "required": true,
               "constraints": {
-                "modes": ["normal"],
-                "maxEntries": 4,
-                "resolution": 10,
-                "defaultMode": "reduced",
-                "overlapAllowed": true
+                "min": 3,
+                "max": 37,
+                "stepping": 1
+              }
+            }
+          }
+        },
+        "activate": {
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/activate",
+          "name": "activate",
+          "isExecutable": false,
+          "params": {
+            "temperature": {
+              "type": "number",
+              "required": false,
+              "constraints": {
+                "min": 3,
+                "max": 37,
+                "stepping": 1
+              }
+            }
+          }
+        },
+        "deactivate": {
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/deactivate",
+          "name": "deactivate",
+          "isExecutable": false,
+          "params": {}
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.operating.programs.comfort",
+      "timestamp": "2021-09-29T00:17:32.729Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["0"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners",
+      "gatewayId": "################",
+      "feature": "heating.burners",
+      "timestamp": "2021-09-22T01:32:19.036Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["room", "supply"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature",
+      "gatewayId": "################",
+      "feature": "heating.circuits.3.sensors.temperature",
+      "timestamp": "2021-09-22T01:32:19.038Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": true
+        },
+        "status": {
+          "type": "string",
+          "value": "on"
+        }
+      },
+      "commands": {},
+      "components": [
+        "hygiene",
+        "oneTimeCharge",
+        "schedule",
+        "sensors",
+        "temperature"
+      ],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw",
+      "gatewayId": "################",
+      "feature": "heating.dhw",
+      "timestamp": "2021-09-30T05:50:47.068Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["temperature"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.sensors",
+      "gatewayId": "################",
+      "feature": "heating.sensors",
+      "timestamp": "2021-09-22T01:32:19.035Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [
+        "circulation",
+        "frostprotection",
+        "heating",
+        "operating",
+        "sensors",
+        "temperature"
+      ],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2",
+      "timestamp": "2021-09-22T01:32:46.565Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.frostprotection",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.frostprotection",
+      "timestamp": "2021-09-22T01:33:03.843Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "unit": {
+          "value": "cubicMeter",
+          "type": "string"
+        },
+        "day": {
+          "type": "array",
+          "value": [3.3, 0, 0, 0, 0, 0, 0, 0]
+        },
+        "week": {
+          "type": "array",
+          "value": [
+            3.3, 0, 7.300000000000001, 8.999999999999998, 11.6, 8,
+            9.299999999999999, 8.700000000000001, 8.5
+          ]
+        },
+        "month": {
+          "type": "array",
+          "value": [
+            27.1, 41.7, 34.5, 33.7, 108.9, 194.9, 255.29999999999998,
+            313.70000000000005, 343.59999999999997, 296.5, 256.29999999999995,
+            198.8, 96.19999999999999
+          ]
+        },
+        "year": {
+          "type": "array",
+          "value": [1354.1, 1208.1]
+        },
+        "dayValueReadAt": {
+          "type": "string",
+          "value": "2021-09-30T14:17:37.000Z"
+        },
+        "weekValueReadAt": {
+          "type": "string",
+          "value": "2021-09-30T14:17:37.000Z"
+        },
+        "monthValueReadAt": {
+          "type": "string",
+          "value": "2021-09-30T14:17:37.000Z"
+        },
+        "yearValueReadAt": {
+          "type": "string",
+          "value": "2021-09-30T14:17:37.000Z"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.gas.consumption.total",
+      "gatewayId": "################",
+      "feature": "heating.gas.consumption.total",
+      "timestamp": "2021-09-30T14:25:09.773Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.heating",
+      "gatewayId": "################",
+      "feature": "heating.circuits.3.operating.modes.heating",
+      "timestamp": "2021-09-22T01:33:00.857Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.sensors.temperature.collector",
+      "gatewayId": "################",
+      "feature": "heating.solar.sensors.temperature.collector",
+      "timestamp": "2021-09-22T01:32:43.722Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["curve", "schedule"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.heating",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.heating",
+      "timestamp": "2021-09-22T01:32:19.036Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.forcedLastFromSchedule",
+      "gatewayId": "################",
+      "feature": "heating.circuits.3.operating.programs.forcedLastFromSchedule",
+      "timestamp": "2021-09-30T05:50:47.785Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "unit": {
+          "value": "cubicMeter",
+          "type": "string"
+        },
+        "day": {
+          "type": "array",
+          "value": [0.5, 0, 0, 0, 0, 0, 0, 0]
+        },
+        "week": {
+          "type": "array",
+          "value": [
+            0.5, 0, 7.300000000000001, 8.999999999999998, 9, 8,
+            9.299999999999999, 8.700000000000001, 8.5
+          ]
+        },
+        "month": {
+          "type": "array",
+          "value": [
+            24.3, 39.1, 34.5, 33.7, 36.7, 46.4, 54.1, 53.6, 56.4, 69.8, 64.6,
+            66.3, 34.3
+          ]
+        },
+        "year": {
+          "type": "array",
+          "value": [379.2, 389.5]
+        },
+        "dayValueReadAt": {
+          "type": "string",
+          "value": "2021-09-30T06:15:06.000Z"
+        },
+        "weekValueReadAt": {
+          "type": "string",
+          "value": "2021-09-30T06:15:06.000Z"
+        },
+        "monthValueReadAt": {
+          "type": "string",
+          "value": "2021-09-30T06:15:06.000Z"
+        },
+        "yearValueReadAt": {
+          "type": "string",
+          "value": "2021-09-30T06:15:06.000Z"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.gas.consumption.dhw",
+      "gatewayId": "################",
+      "feature": "heating.gas.consumption.dhw",
+      "timestamp": "2021-09-30T07:57:07.078Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "value": {
+          "type": "number",
+          "value": 116,
+          "unit": ""
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.device.time.offset",
+      "gatewayId": "################",
+      "feature": "heating.device.time.offset",
+      "timestamp": "2021-09-26T22:04:12.871Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.operating.modes.active",
+      "timestamp": "2021-09-30T05:50:47.742Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.pumps.circuit",
+      "gatewayId": "################",
+      "feature": "heating.solar.pumps.circuit",
+      "timestamp": "2021-09-22T01:32:43.740Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.operating.programs.standby",
+      "timestamp": "2021-09-22T01:32:49.776Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "value": false,
+          "type": "boolean"
+        },
+        "start": {
+          "value": "",
+          "type": "string"
+        },
+        "end": {
+          "value": "",
+          "type": "string"
+        }
+      },
+      "commands": {
+        "changeEndDate": {
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate",
+          "name": "changeEndDate",
+          "isExecutable": false,
+          "params": {
+            "end": {
+              "type": "string",
+              "required": true,
+              "constraints": {
+                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
+                "sameDayAllowed": true
+              }
+            }
+          }
+        },
+        "schedule": {
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/schedule",
+          "name": "schedule",
+          "isExecutable": true,
+          "params": {
+            "start": {
+              "type": "string",
+              "required": true,
+              "constraints": {
+                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$"
+              }
+            },
+            "end": {
+              "type": "string",
+              "required": true,
+              "constraints": {
+                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
+                "sameDayAllowed": true
+              }
+            }
+          }
+        },
+        "unschedule": {
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/unschedule",
+          "name": "unschedule",
+          "isExecutable": true,
+          "params": {}
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holiday",
+      "gatewayId": "################",
+      "feature": "heating.operating.programs.holiday",
+      "timestamp": "2021-09-22T01:33:03.230Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["offset"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.device.time",
+      "gatewayId": "################",
+      "feature": "heating.device.time",
+      "timestamp": "2021-09-22T01:32:19.036Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["temperature"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.sensors",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.sensors",
+      "timestamp": "2021-09-22T01:32:19.037Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "value": false,
+          "type": "boolean"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.operating.programs.standby",
+      "timestamp": "2021-09-30T05:50:43.015Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.operating.modes.heating",
+      "timestamp": "2021-09-22T01:32:59.969Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["modes", "programs"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.operating",
+      "timestamp": "2021-09-22T01:32:19.035Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "unit": {
+          "value": "celsius",
+          "type": "string"
+        },
+        "value": {
+          "type": "number",
+          "value": 11.9,
+          "unit": "celsius"
+        },
+        "status": {
+          "type": "string",
+          "value": "connected"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.sensors.temperature.outside",
+      "gatewayId": "################",
+      "feature": "heating.sensors.temperature.outside",
+      "timestamp": "2021-09-30T15:03:23.602Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.supply",
+      "gatewayId": "################",
+      "feature": "heating.circuits.3.sensors.temperature.supply",
+      "timestamp": "2021-09-22T01:33:02.494Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["temperature"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.sensors",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.sensors",
+      "timestamp": "2021-09-22T01:32:19.038Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.temperature",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.temperature",
+      "timestamp": "2021-09-22T01:32:49.355Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhw",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.operating.modes.dhw",
+      "timestamp": "2021-09-22T01:32:53.428Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.standby",
+      "gatewayId": "################",
+      "feature": "heating.circuits.3.operating.programs.standby",
+      "timestamp": "2021-09-22T01:32:49.805Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "unit": {
+          "value": "celsius",
+          "type": "string"
+        },
+        "value": {
+          "type": "number",
+          "value": 33.7,
+          "unit": "celsius"
+        },
+        "status": {
+          "type": "string",
+          "value": "connected"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage",
+      "gatewayId": "################",
+      "feature": "heating.dhw.sensors.temperature.hotWaterStorage",
+      "timestamp": "2021-09-30T15:03:02.629Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.heating.schedule",
+      "timestamp": "2021-09-22T01:33:01.047Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.sensors.temperature.room",
+      "timestamp": "2021-09-22T01:33:02.104Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfort",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.operating.programs.comfort",
+      "timestamp": "2021-09-29T00:17:32.730Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler.sensors",
+      "gatewayId": "################",
+      "feature": "heating.boiler.sensors",
+      "timestamp": "2021-09-22T01:32:19.036Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["pump"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.circulation",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.circulation",
+      "timestamp": "2021-09-22T01:32:19.037Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "value": false,
+          "type": "boolean"
+        },
+        "demand": {
+          "value": "unknown",
+          "type": "string"
+        },
+        "temperature": {
+          "value": 22,
+          "unit": "",
+          "type": "number"
+        }
+      },
+      "commands": {
+        "setTemperature": {
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced/commands/setTemperature",
+          "name": "setTemperature",
+          "isExecutable": true,
+          "params": {
+            "targetTemperature": {
+              "type": "number",
+              "required": true,
+              "constraints": {
+                "min": 3,
+                "max": 37,
+                "stepping": 1
               }
             }
           }
@@ -1737,10 +1428,622 @@
       },
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.heating.schedule",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.0.heating.schedule",
-      "timestamp": "2021-08-01T11:06:25.612Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.operating.programs.reduced",
+      "timestamp": "2021-09-29T00:17:32.830Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["modes", "programs"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.operating",
+      "timestamp": "2021-09-22T01:32:19.035Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "unit": {
+          "value": "kilowattHour",
+          "type": "string"
+        },
+        "day": {
+          "type": "array",
+          "value": [0, 0, 0, 0, 0, 0, 0, 0]
+        },
+        "week": {
+          "type": "array",
+          "value": [0, 0, 0.4, 0.6, 0.6, 0.5, 0.7, 0.4, 0.5]
+        },
+        "month": {
+          "type": "array",
+          "value": [
+            2.2, 3.6, 3.4, 3.1, 3.6, 3.9, 4.4, 4.1, 4.3, 7.4, 7, 7.4, 6.1
+          ]
+        },
+        "year": {
+          "type": "array",
+          "value": [32.9, 56.4]
+        },
+        "dayValueReadAt": {
+          "type": "string",
+          "value": "2021-09-29T00:17:29.000Z"
+        },
+        "weekValueReadAt": {
+          "type": "string",
+          "value": "2021-09-29T00:17:32.000Z"
+        },
+        "monthValueReadAt": {
+          "type": "string",
+          "value": "2021-09-29T00:17:29.000Z"
+        },
+        "yearValueReadAt": {
+          "type": "string",
+          "value": "2021-09-29T00:17:29.000Z"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.power.consumption.dhw",
+      "gatewayId": "################",
+      "feature": "heating.power.consumption.dhw",
+      "timestamp": "2021-09-29T00:17:35.303Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [
+        "boiler",
+        "burners",
+        "circuits",
+        "configuration",
+        "device",
+        "dhw",
+        "operating",
+        "sensors",
+        "solar"
+      ],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating",
+      "gatewayId": "################",
+      "feature": "heating",
+      "timestamp": "2021-09-22T01:32:19.034Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["temperature"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.sensors",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.sensors",
+      "timestamp": "2021-09-22T01:32:19.037Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.active",
+      "gatewayId": "################",
+      "feature": "heating.circuits.3.operating.programs.active",
+      "timestamp": "2021-09-22T01:33:05.024Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["curve", "schedule"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.heating",
+      "timestamp": "2021-09-22T01:32:19.035Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["room", "supply"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.sensors.temperature",
+      "timestamp": "2021-09-22T01:32:19.038Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["pump"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.circulation",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.circulation",
+      "timestamp": "2021-09-22T01:32:19.037Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [
+        "circulation",
+        "frostprotection",
+        "heating",
+        "operating",
+        "sensors",
+        "temperature"
+      ],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1",
+      "timestamp": "2021-09-22T01:32:45.615Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "unit": {
+          "value": "celsius",
+          "type": "string"
+        },
+        "value": {
+          "type": "number",
+          "value": 47.1,
+          "unit": "celsius"
+        },
+        "status": {
+          "type": "string",
+          "value": "connected"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply",
+      "gatewayId": "################",
+      "feature": "heating.boiler.sensors.temperature.commonSupply",
+      "timestamp": "2021-09-30T15:02:21.505Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.operating.programs.comfort",
+      "timestamp": "2021-09-29T00:17:32.730Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.sensors.temperature.supply",
+      "timestamp": "2021-09-22T01:33:02.272Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["curve", "schedule"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.heating",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.heating",
+      "timestamp": "2021-09-22T01:32:19.035Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.sensors.temperature.room",
+      "timestamp": "2021-09-22T01:33:02.193Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [
+        "active",
+        "comfort",
+        "forcedLastFromSchedule",
+        "normal",
+        "reduced",
+        "standby"
+      ],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.operating.programs",
+      "timestamp": "2021-09-22T01:32:19.035Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["pumps", "sensors"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar",
+      "gatewayId": "################",
+      "feature": "heating.solar",
+      "timestamp": "2021-09-22T01:32:43.700Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": false
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.operating.modes.heating",
+      "timestamp": "2021-09-30T05:50:47.727Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["room", "supply"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.sensors.temperature",
+      "timestamp": "2021-09-22T01:32:19.037Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.heating.schedule",
+      "gatewayId": "################",
+      "feature": "heating.circuits.3.heating.schedule",
+      "timestamp": "2021-09-22T01:33:01.088Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.operating.modes.heating",
+      "timestamp": "2021-09-22T01:32:58.316Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [
+        "active",
+        "comfort",
+        "forcedLastFromSchedule",
+        "normal",
+        "reduced",
+        "standby"
+      ],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs",
+      "gatewayId": "################",
+      "feature": "heating.circuits.3.operating.programs",
+      "timestamp": "2021-09-22T01:32:19.035Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["room", "supply"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.sensors.temperature",
+      "timestamp": "2021-09-22T01:32:19.037Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.sensors.temperature.room",
+      "timestamp": "2021-09-22T01:33:02.152Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.active",
+      "gatewayId": "################",
+      "feature": "heating.circuits.3.operating.modes.active",
+      "timestamp": "2021-09-30T05:50:47.773Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": false
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.operating.modes.standby",
+      "timestamp": "2021-09-30T05:50:27.127Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["time"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.device",
+      "gatewayId": "################",
+      "feature": "heating.device",
+      "timestamp": "2021-09-22T01:32:19.036Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [
+        "circulation",
+        "frostprotection",
+        "heating",
+        "operating",
+        "sensors",
+        "temperature"
+      ],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3",
+      "gatewayId": "################",
+      "feature": "heating.circuits.3",
+      "timestamp": "2021-09-22T01:32:47.827Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["hygiene", "main"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.temperature",
+      "gatewayId": "################",
+      "feature": "heating.dhw.temperature",
+      "timestamp": "2021-09-22T01:32:19.035Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.sensors",
+      "gatewayId": "################",
+      "feature": "heating.dhw.sensors",
+      "timestamp": "2021-09-22T01:32:19.036Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": false
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.configuration.multiFamilyHouse",
+      "gatewayId": "################",
+      "feature": "heating.configuration.multiFamilyHouse",
+      "timestamp": "2021-09-22T01:33:01.096Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "status": {
+          "type": "string",
+          "value": "off"
+        }
+      },
+      "commands": {},
+      "components": ["schedule"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.pumps.circulation",
+      "gatewayId": "################",
+      "feature": "heating.dhw.pumps.circulation",
+      "timestamp": "2021-09-30T06:16:26.721Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.operating.programs.reduced",
+      "timestamp": "2021-09-29T00:17:32.830Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "value": {
+          "type": "string",
+          "value": "normal"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.operating.programs.active",
+      "timestamp": "2021-09-30T05:50:43.048Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "value": {
+          "type": "string",
+          "value": "################"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/device.serial",
+      "gatewayId": "################",
+      "feature": "device.serial",
+      "timestamp": "2021-09-22T01:32:40.518Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "status": {
+          "type": "string",
+          "value": "off"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.frostprotection",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.frostprotection",
+      "timestamp": "2021-09-22T01:33:03.823Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "status": {
+          "type": "string",
+          "value": "off"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.pumps.primary",
+      "gatewayId": "################",
+      "feature": "heating.dhw.pumps.primary",
+      "timestamp": "2021-09-22T01:32:42.228Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["holiday", "holidayAtHome"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs",
+      "gatewayId": "################",
+      "feature": "heating.operating.programs",
+      "timestamp": "2021-09-22T01:32:19.035Z",
       "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
@@ -1762,7 +2065,7 @@
       },
       "commands": {
         "setName": {
-          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0/commands/setName",
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0/commands/setName",
           "name": "setName",
           "isExecutable": true,
           "params": {
@@ -1779,17 +2082,17 @@
       },
       "components": [
         "circulation",
-        "dhw",
         "frostprotection",
         "heating",
         "operating",
-        "sensors"
+        "sensors",
+        "temperature"
       ],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0",
+      "gatewayId": "################",
       "feature": "heating.circuits.0",
-      "timestamp": "2021-08-01T11:06:25.603Z",
+      "timestamp": "2021-09-22T01:32:44.526Z",
       "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
@@ -1797,30 +2100,12 @@
     {
       "properties": {},
       "commands": {},
-      "components": ["schedule"],
+      "components": ["active", "dhw", "dhwAndHeating", "heating", "standby"],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.dhw.pumps.circulation",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.dhw.pumps.circulation",
-      "timestamp": "2021-08-01T11:06:24.548Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "value": {
-          "type": "string",
-          "value": "standby"
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.operating.programs.active",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.0.operating.programs.active",
-      "timestamp": "2021-08-01T11:06:25.688Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.operating.modes",
+      "timestamp": "2021-09-22T01:32:19.036Z",
       "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
@@ -1830,10 +2115,10 @@
       "commands": {},
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.operating.programs.normal",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.operating.programs.normal",
-      "timestamp": "2021-08-01T11:06:25.920Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.temperature",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.temperature",
+      "timestamp": "2021-09-22T01:32:49.093Z",
       "isEnabled": false,
       "isReady": true,
       "deviceId": "0"
@@ -1843,99 +2128,11 @@
       "commands": {},
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.solar.sensors.temperature.collector",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.solar.sensors.temperature.collector",
-      "timestamp": "2021-08-01T11:06:25.691Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.operating.programs.standby",
+      "timestamp": "2021-09-22T01:32:49.790Z",
       "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.sensors.temperature.supply",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.1.sensors.temperature.supply",
-      "timestamp": "2021-08-01T11:06:25.680Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.operating.programs.normal",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.1.operating.programs.normal",
-      "timestamp": "2021-08-01T11:06:25.835Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["modes", "programs"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.operating",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.operating",
-      "timestamp": "2021-08-01T11:06:24.548Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.circulation.pump",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.circulation.pump",
-      "timestamp": "2021-08-01T11:06:25.687Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "value": {
-          "value": 50,
-          "unit": "",
-          "type": "number"
-        }
-      },
-      "commands": {
-        "setTargetTemperature": {
-          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.dhw.temperature/commands/setTargetTemperature",
-          "name": "setTargetTemperature",
-          "isExecutable": true,
-          "params": {
-            "temperature": {
-              "type": "number",
-              "required": true,
-              "constraints": {
-                "min": 10,
-                "max": 60,
-                "stepping": 1
-              }
-            }
-          }
-        }
-      },
-      "components": ["main"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.dhw.temperature",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.dhw.temperature",
-      "timestamp": "2021-08-01T11:06:25.587Z",
-      "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
     },
@@ -1943,16 +2140,16 @@
       "properties": {
         "status": {
           "type": "string",
-          "value": "off"
+          "value": "on"
         }
       },
       "commands": {},
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.circulation.pump",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.circulation.pump",
+      "gatewayId": "################",
       "feature": "heating.circuits.0.circulation.pump",
-      "timestamp": "2021-08-01T11:06:25.685Z",
+      "timestamp": "2021-09-30T05:50:28.483Z",
       "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
@@ -1960,30 +2157,43 @@
     {
       "properties": {},
       "commands": {},
-      "components": ["schedule"],
+      "components": [
+        "active",
+        "comfort",
+        "forcedLastFromSchedule",
+        "normal",
+        "reduced",
+        "standby"
+      ],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.dhw.pumps.circulation",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.1.dhw.pumps.circulation",
-      "timestamp": "2021-08-01T11:06:24.548Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.operating.programs",
+      "timestamp": "2021-09-22T01:32:19.035Z",
       "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
     },
     {
       "properties": {
-        "status": {
-          "type": "string",
-          "value": "off"
+        "hours": {
+          "type": "number",
+          "value": 5674,
+          "unit": ""
+        },
+        "starts": {
+          "type": "number",
+          "value": 8299,
+          "unit": ""
         }
       },
       "commands": {},
-      "components": ["schedule"],
+      "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.dhw.pumps.circulation",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.dhw.pumps.circulation",
-      "timestamp": "2021-08-01T11:06:25.682Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners.0.statistics",
+      "gatewayId": "################",
+      "feature": "heating.burners.0.statistics",
+      "timestamp": "2021-09-30T14:44:33.768Z",
       "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
@@ -1993,133 +2203,10 @@
       "commands": {},
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.dhw.pumps.circulation.schedule",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.dhw.pumps.circulation.schedule",
-      "timestamp": "2021-08-01T11:06:25.646Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.solar.power.production",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.solar.power.production",
-      "timestamp": "2021-08-01T11:06:26.364Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["room", "supply"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.sensors.temperature",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.0.sensors.temperature",
-      "timestamp": "2021-08-01T11:06:24.548Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "active": {
-          "value": false,
-          "type": "boolean"
-        },
-        "demand": {
-          "value": "unknown",
-          "type": "string"
-        },
-        "temperature": {
-          "value": 20,
-          "unit": "",
-          "type": "number"
-        }
-      },
-      "commands": {
-        "setTemperature": {
-          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/setTemperature",
-          "name": "setTemperature",
-          "isExecutable": true,
-          "params": {
-            "targetTemperature": {
-              "type": "number",
-              "required": true,
-              "constraints": {
-                "min": 4,
-                "max": 37,
-                "stepping": 1
-              }
-            }
-          }
-        },
-        "activate": {
-          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/activate",
-          "name": "activate",
-          "isExecutable": false,
-          "params": {
-            "temperature": {
-              "type": "number",
-              "required": false,
-              "constraints": {
-                "min": 4,
-                "max": 37,
-                "stepping": 1
-              }
-            }
-          }
-        },
-        "deactivate": {
-          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/deactivate",
-          "name": "deactivate",
-          "isExecutable": false,
-          "params": {}
-        }
-      },
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.operating.programs.comfort",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.0.operating.programs.comfort",
-      "timestamp": "2021-08-01T11:06:25.617Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "active": {
-          "type": "boolean",
-          "value": false
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.0.operating.modes.dhwAndHeating",
-      "timestamp": "2021-08-01T11:06:25.716Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.dhw.schedule",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.1.dhw.schedule",
-      "timestamp": "2021-08-01T11:06:25.708Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.room",
+      "gatewayId": "################",
+      "feature": "heating.circuits.3.sensors.temperature.room",
+      "timestamp": "2021-09-22T01:33:02.213Z",
       "isEnabled": false,
       "isReady": true,
       "deviceId": "0"
@@ -2139,7 +2226,7 @@
       },
       "commands": {
         "setCurve": {
-          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.heating.curve/commands/setCurve",
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.heating.curve/commands/setCurve",
           "name": "setCurve",
           "isExecutable": true,
           "params": {
@@ -2166,10 +2253,10 @@
       },
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.heating.curve",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.heating.curve",
+      "gatewayId": "################",
       "feature": "heating.circuits.1.heating.curve",
-      "timestamp": "2021-08-01T11:06:25.650Z",
+      "timestamp": "2021-09-22T01:33:02.887Z",
       "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
@@ -2179,30 +2266,24 @@
       "commands": {},
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.operating.modes.standby",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.1.operating.modes.standby",
-      "timestamp": "2021-08-01T11:06:26.492Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.operating.programs.normal",
+      "timestamp": "2021-09-29T00:17:32.745Z",
       "isEnabled": false,
       "isReady": true,
       "deviceId": "0"
     },
     {
-      "properties": {
-        "value": {
-          "type": "number",
-          "value": 119,
-          "unit": ""
-        }
-      },
+      "properties": {},
       "commands": {},
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.device.time.offset",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.device.time.offset",
-      "timestamp": "2021-08-01T11:06:26.194Z",
-      "isEnabled": true,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.temperature.hygiene",
+      "gatewayId": "################",
+      "feature": "heating.dhw.temperature.hygiene",
+      "timestamp": "2021-09-22T01:33:03.933Z",
+      "isEnabled": false,
       "isReady": true,
       "deviceId": "0"
     },
@@ -2216,160 +2297,409 @@
       "commands": {},
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.configuration.multiFamilyHouse",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.configuration.multiFamilyHouse",
-      "timestamp": "2021-08-01T11:06:26.355Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhw",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.operating.modes.dhw",
+      "timestamp": "2021-09-22T01:32:52.923Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfort",
+      "gatewayId": "################",
+      "feature": "heating.circuits.3.operating.programs.comfort",
+      "timestamp": "2021-09-29T00:17:32.730Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.operating.modes.active",
+      "timestamp": "2021-09-30T05:50:47.758Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["circuit"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.pumps",
+      "gatewayId": "################",
+      "feature": "heating.solar.pumps",
+      "timestamp": "2021-09-22T01:32:19.037Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["curve", "schedule"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.heating",
+      "gatewayId": "################",
+      "feature": "heating.circuits.3.heating",
+      "timestamp": "2021-09-22T01:32:19.036Z",
       "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
     },
     {
       "properties": {
-        "unit": {
-          "value": "celsius",
-          "type": "string"
-        },
         "value": {
-          "type": "number",
-          "value": 44.8,
-          "unit": "celsius"
-        },
-        "status": {
-          "type": "string",
-          "value": "connected"
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.dhw.sensors.temperature.outlet",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.dhw.sensors.temperature.outlet",
-      "timestamp": "2021-08-04T19:49:16.313Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [
-        "boiler",
-        "burner",
-        "burners",
-        "circuits",
-        "configuration",
-        "device",
-        "dhw",
-        "operating",
-        "sensors",
-        "solar"
-      ],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating",
-      "timestamp": "2021-08-01T11:06:24.547Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["temperature"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.sensors",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.sensors",
-      "timestamp": "2021-08-01T11:06:24.548Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "active": {
-          "value": false,
-          "type": "boolean"
-        },
-        "temperature": {
-          "value": 0,
-          "unit": "",
-          "type": "number"
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.operating.programs.external",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.0.operating.programs.external",
-      "timestamp": "2021-08-01T11:06:25.670Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "active": {
-          "value": false,
-          "type": "boolean"
-        },
-        "temperature": {
-          "value": 10,
+          "value": 55,
           "unit": "",
           "type": "number"
         }
       },
       "commands": {
-        "activate": {
-          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.operating.programs.eco/commands/activate",
-          "name": "activate",
-          "isExecutable": false,
-          "params": {}
-        },
-        "deactivate": {
-          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.operating.programs.eco/commands/deactivate",
-          "name": "deactivate",
-          "isExecutable": false,
-          "params": {}
+        "setTargetTemperature": {
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature",
+          "name": "setTargetTemperature",
+          "isExecutable": true,
+          "params": {
+            "temperature": {
+              "type": "number",
+              "required": true,
+              "constraints": {
+                "min": 10,
+                "efficientLowerBorder": 10,
+                "efficientUpperBorder": 60,
+                "max": 60,
+                "stepping": 1
+              }
+            }
+          }
         }
       },
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.operating.programs.eco",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.0.operating.programs.eco",
-      "timestamp": "2021-08-01T11:06:25.791Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.temperature.main",
+      "gatewayId": "################",
+      "feature": "heating.dhw.temperature.main",
+      "timestamp": "2021-09-22T01:32:49.732Z",
       "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
     },
     {
-      "properties": {
-        "unit": {
-          "value": "celsius",
-          "type": "string"
-        },
-        "value": {
-          "type": "number",
-          "value": 21.1,
-          "unit": "celsius"
-        },
-        "status": {
-          "type": "string",
-          "value": "connected"
-        }
-      },
+      "properties": {},
+      "commands": {},
+      "components": ["collector", "dhw"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.sensors.temperature",
+      "gatewayId": "################",
+      "feature": "heating.solar.sensors.temperature",
+      "timestamp": "2021-09-22T01:32:19.037Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
       "commands": {},
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.sensors.temperature.room",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.0.sensors.temperature.room",
-      "timestamp": "2021-08-04T19:31:20.266Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.operating.modes.standby",
+      "timestamp": "2021-09-22T01:32:52.460Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["pump"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.circulation",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.circulation",
+      "timestamp": "2021-09-22T01:32:19.035Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["active", "dhw", "dhwAndHeating", "heating", "standby"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.modes",
+      "gatewayId": "################",
+      "feature": "heating.circuits.3.operating.modes",
+      "timestamp": "2021-09-22T01:32:19.036Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhw",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.operating.modes.dhw",
+      "timestamp": "2021-09-22T01:32:53.567Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.power.production",
+      "gatewayId": "################",
+      "feature": "heating.solar.power.production",
+      "timestamp": "2021-09-22T01:32:43.731Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "value": true,
+          "type": "boolean"
+        },
+        "demand": {
+          "value": "unknown",
+          "type": "string"
+        },
+        "temperature": {
+          "value": 22,
+          "unit": "",
+          "type": "number"
+        }
+      },
+      "commands": {
+        "setTemperature": {
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature",
+          "name": "setTemperature",
+          "isExecutable": true,
+          "params": {
+            "targetTemperature": {
+              "type": "number",
+              "required": true,
+              "constraints": {
+                "min": 3,
+                "max": 37,
+                "stepping": 1
+              }
+            }
+          }
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.operating.programs.normal",
+      "timestamp": "2021-09-30T05:50:43.040Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.heating.schedule",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.heating.schedule",
+      "timestamp": "2021-09-22T01:33:01.067Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "value": true,
+          "type": "boolean"
+        },
+        "entries": {
+          "value": {
+            "mon": [
+              {
+                "mode": "normal",
+                "start": "05:30",
+                "end": "22:00",
+                "position": 0
+              }
+            ],
+            "tue": [
+              {
+                "mode": "normal",
+                "start": "05:30",
+                "end": "22:00",
+                "position": 0
+              }
+            ],
+            "wed": [
+              {
+                "mode": "normal",
+                "start": "05:30",
+                "end": "22:00",
+                "position": 0
+              }
+            ],
+            "thu": [
+              {
+                "mode": "normal",
+                "start": "05:30",
+                "end": "22:00",
+                "position": 0
+              }
+            ],
+            "fri": [
+              {
+                "mode": "normal",
+                "start": "05:30",
+                "end": "23:00",
+                "position": 0
+              }
+            ],
+            "sat": [
+              {
+                "mode": "normal",
+                "start": "06:30",
+                "end": "23:00",
+                "position": 0
+              }
+            ],
+            "sun": [
+              {
+                "mode": "normal",
+                "start": "06:30",
+                "end": "22:00",
+                "position": 0
+              }
+            ]
+          },
+          "type": "Schedule"
+        }
+      },
+      "commands": {
+        "setSchedule": {
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule",
+          "name": "setSchedule",
+          "isExecutable": true,
+          "params": {
+            "newSchedule": {
+              "type": "Schedule",
+              "required": true,
+              "constraints": {
+                "modes": ["normal", "comfort"],
+                "maxEntries": 4,
+                "resolution": 10,
+                "defaultMode": "reduced",
+                "overlapAllowed": false
+              }
+            }
+          }
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.heating.schedule",
+      "timestamp": "2021-09-30T05:50:27.166Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["modes", "programs"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.operating",
+      "timestamp": "2021-09-22T01:32:19.035Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.sensors.temperature.dhw",
+      "gatewayId": "################",
+      "feature": "heating.solar.sensors.temperature.dhw",
+      "timestamp": "2021-09-22T01:32:43.778Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "shift": {
+          "type": "number",
+          "unit": "",
+          "value": 0
+        },
+        "slope": {
+          "type": "number",
+          "unit": "",
+          "value": 1.4
+        }
+      },
+      "commands": {
+        "setCurve": {
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.heating.curve/commands/setCurve",
+          "name": "setCurve",
+          "isExecutable": true,
+          "params": {
+            "slope": {
+              "type": "number",
+              "required": true,
+              "constraints": {
+                "min": 0.2,
+                "max": 3.5,
+                "stepping": 0.1
+              }
+            },
+            "shift": {
+              "type": "number",
+              "required": true,
+              "constraints": {
+                "min": -13,
+                "max": 40,
+                "stepping": 1
+              }
+            }
+          }
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.heating.curve",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.heating.curve",
+      "timestamp": "2021-09-22T01:33:02.924Z",
       "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
@@ -2379,63 +2709,290 @@
         "active": {
           "value": true,
           "type": "boolean"
+        },
+        "entries": {
+          "value": {
+            "mon": [
+              {
+                "mode": "on",
+                "start": "05:30",
+                "end": "08:00",
+                "position": 0
+              },
+              {
+                "mode": "on",
+                "start": "17:00",
+                "end": "18:00",
+                "position": 1
+              }
+            ],
+            "tue": [
+              {
+                "mode": "on",
+                "start": "05:30",
+                "end": "08:00",
+                "position": 0
+              },
+              {
+                "mode": "on",
+                "start": "17:00",
+                "end": "18:00",
+                "position": 1
+              }
+            ],
+            "wed": [
+              {
+                "mode": "on",
+                "start": "05:30",
+                "end": "08:00",
+                "position": 0
+              },
+              {
+                "mode": "on",
+                "start": "17:00",
+                "end": "18:00",
+                "position": 1
+              }
+            ],
+            "thu": [
+              {
+                "mode": "on",
+                "start": "05:30",
+                "end": "08:00",
+                "position": 0
+              },
+              {
+                "mode": "on",
+                "start": "17:00",
+                "end": "18:00",
+                "position": 1
+              }
+            ],
+            "fri": [
+              {
+                "mode": "on",
+                "start": "05:30",
+                "end": "08:00",
+                "position": 0
+              },
+              {
+                "mode": "on",
+                "start": "17:00",
+                "end": "18:00",
+                "position": 1
+              }
+            ],
+            "sat": [
+              {
+                "mode": "on",
+                "start": "06:30",
+                "end": "09:00",
+                "position": 0
+              },
+              {
+                "mode": "on",
+                "start": "17:00",
+                "end": "18:00",
+                "position": 1
+              }
+            ],
+            "sun": [
+              {
+                "mode": "on",
+                "start": "06:30",
+                "end": "09:00",
+                "position": 0
+              },
+              {
+                "mode": "on",
+                "start": "17:00",
+                "end": "18:00",
+                "position": 1
+              }
+            ]
+          },
+          "type": "Schedule"
         }
       },
+      "commands": {
+        "setSchedule": {
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/setSchedule",
+          "name": "setSchedule",
+          "isExecutable": true,
+          "params": {
+            "newSchedule": {
+              "type": "Schedule",
+              "required": true,
+              "constraints": {
+                "modes": ["on"],
+                "maxEntries": 4,
+                "resolution": 10,
+                "defaultMode": "off",
+                "overlapAllowed": false
+              }
+            }
+          }
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule",
+      "gatewayId": "################",
+      "feature": "heating.dhw.pumps.circulation.schedule",
+      "timestamp": "2021-09-30T05:50:47.069Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
       "commands": {},
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.operating.programs.standby",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.0.operating.programs.standby",
-      "timestamp": "2021-08-01T11:06:26.513Z",
-      "isEnabled": true,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normal",
+      "gatewayId": "################",
+      "feature": "heating.circuits.3.operating.programs.normal",
+      "timestamp": "2021-09-29T00:17:32.745Z",
+      "isEnabled": false,
       "isReady": true,
       "deviceId": "0"
     },
     {
-      "properties": {},
-      "commands": {},
-      "components": ["pumps", "schedule"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.dhw",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.0.dhw",
-      "timestamp": "2021-08-01T11:06:24.547Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
+      "properties": {
+        "active": {
+          "value": true,
+          "type": "boolean"
+        },
+        "entries": {
+          "value": {
+            "mon": [
+              {
+                "mode": "on",
+                "start": "05:30",
+                "end": "09:00",
+                "position": 0
+              },
+              {
+                "mode": "on",
+                "start": "17:00",
+                "end": "18:30",
+                "position": 1
+              }
+            ],
+            "tue": [
+              {
+                "mode": "on",
+                "start": "05:30",
+                "end": "09:00",
+                "position": 0
+              },
+              {
+                "mode": "on",
+                "start": "17:00",
+                "end": "18:30",
+                "position": 1
+              }
+            ],
+            "wed": [
+              {
+                "mode": "on",
+                "start": "05:30",
+                "end": "09:00",
+                "position": 0
+              },
+              {
+                "mode": "on",
+                "start": "17:00",
+                "end": "18:30",
+                "position": 1
+              }
+            ],
+            "thu": [
+              {
+                "mode": "on",
+                "start": "05:30",
+                "end": "09:00",
+                "position": 0
+              },
+              {
+                "mode": "on",
+                "start": "17:00",
+                "end": "18:30",
+                "position": 1
+              }
+            ],
+            "fri": [
+              {
+                "mode": "on",
+                "start": "05:30",
+                "end": "09:00",
+                "position": 0
+              },
+              {
+                "mode": "on",
+                "start": "17:00",
+                "end": "18:30",
+                "position": 1
+              }
+            ],
+            "sat": [
+              {
+                "mode": "on",
+                "start": "06:30",
+                "end": "10:00",
+                "position": 0
+              },
+              {
+                "mode": "on",
+                "start": "17:00",
+                "end": "18:30",
+                "position": 1
+              }
+            ],
+            "sun": [
+              {
+                "mode": "on",
+                "start": "06:30",
+                "end": "10:00",
+                "position": 0
+              },
+              {
+                "mode": "on",
+                "start": "17:00",
+                "end": "18:30",
+                "position": 1
+              }
+            ]
+          },
+          "type": "Schedule"
+        }
+      },
+      "commands": {
+        "setSchedule": {
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule",
+          "name": "setSchedule",
+          "isExecutable": true,
+          "params": {
+            "newSchedule": {
+              "type": "Schedule",
+              "required": true,
+              "constraints": {
+                "modes": ["on"],
+                "maxEntries": 4,
+                "resolution": 10,
+                "defaultMode": "off",
+                "overlapAllowed": false
+              }
+            }
+          }
+        }
+      },
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.dhw.sensors",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.dhw.sensors",
-      "timestamp": "2021-08-01T11:06:24.548Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [
-        "active",
-        "comfort",
-        "eco",
-        "external",
-        "holiday",
-        "normal",
-        "reduced",
-        "standby"
-      ],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.operating.programs",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.1.operating.programs",
-      "timestamp": "2021-08-01T11:06:24.548Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.schedule",
+      "gatewayId": "################",
+      "feature": "heating.dhw.schedule",
+      "timestamp": "2021-09-30T05:50:47.786Z",
       "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
@@ -2450,12 +3007,12 @@
         "slope": {
           "type": "number",
           "unit": "",
-          "value": 0.9
+          "value": 1.4
         }
       },
       "commands": {
         "setCurve": {
-          "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve",
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.heating.curve/commands/setCurve",
           "name": "setCurve",
           "isExecutable": true,
           "params": {
@@ -2482,10 +3039,10 @@
       },
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.heating.curve",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.0.heating.curve",
-      "timestamp": "2021-08-01T11:06:25.649Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.heating.curve",
+      "gatewayId": "################",
+      "feature": "heating.circuits.3.heating.curve",
+      "timestamp": "2021-09-22T01:33:03.001Z",
       "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
@@ -2493,12 +3050,58 @@
     {
       "properties": {},
       "commands": {},
-      "components": ["schedule"],
+      "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.dhw.pumps.circulation",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.0.dhw.pumps.circulation",
-      "timestamp": "2021-08-01T11:06:24.547Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normal",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.operating.programs.normal",
+      "timestamp": "2021-09-29T00:17:32.745Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "value": {
+          "value": "dhwAndHeating",
+          "type": "string"
+        }
+      },
+      "commands": {
+        "setMode": {
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode",
+          "name": "setMode",
+          "isExecutable": true,
+          "params": {
+            "mode": {
+              "type": "string",
+              "required": true,
+              "constraints": {
+                "enum": ["standby", "heating", "dhw", "dhwAndHeating"]
+              }
+            }
+          }
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.operating.modes.active",
+      "timestamp": "2021-09-30T05:50:47.728Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["active", "dhw", "dhwAndHeating", "heating", "standby"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.operating.modes",
+      "timestamp": "2021-09-22T01:32:19.036Z",
       "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
@@ -2507,185 +3110,19 @@
       "properties": {},
       "commands": {},
       "components": [
-        "circulation",
-        "dhw",
-        "frostprotection",
-        "heating",
-        "operating",
-        "sensors"
+        "active",
+        "comfort",
+        "forcedLastFromSchedule",
+        "normal",
+        "reduced",
+        "standby"
       ],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2",
-      "timestamp": "2021-08-01T11:06:25.626Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["circulation"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.dhw.pumps",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.0.dhw.pumps",
-      "timestamp": "2021-08-01T11:06:24.547Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.operating.programs",
+      "timestamp": "2021-09-22T01:32:19.035Z",
       "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["programs"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.operating",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.operating",
-      "timestamp": "2021-08-01T11:06:24.547Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["pumps", "sensors"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.solar",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.solar",
-      "timestamp": "2021-08-01T11:06:25.690Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.0.dhw.pumps.circulation.schedule",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.0.dhw.pumps.circulation.schedule",
-      "timestamp": "2021-08-01T11:06:25.630Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.dhw.pumps.circulation.schedule",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.1.dhw.pumps.circulation.schedule",
-      "timestamp": "2021-08-01T11:06:25.642Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["circulation"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.dhw.pumps",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.1.dhw.pumps",
-      "timestamp": "2021-08-01T11:06:24.547Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.solar.pumps.circuit",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.solar.pumps.circuit",
-      "timestamp": "2021-08-01T11:06:26.537Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.operating.modes.standby",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.operating.modes.standby",
-      "timestamp": "2021-08-01T11:06:25.667Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "unit": {
-          "value": "percent",
-          "type": "string"
-        },
-        "value": {
-          "type": "number",
-          "value": 0,
-          "unit": "percent"
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.burners.0.modulation",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.burners.0.modulation",
-      "timestamp": "2021-08-04T19:19:08.101Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["modes", "programs"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.operating",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.1.operating",
-      "timestamp": "2021-08-01T11:06:24.548Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["circuit"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.solar.pumps",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.solar.pumps",
-      "timestamp": "2021-08-01T11:06:24.548Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.operating.programs.standby",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.operating.programs.standby",
-      "timestamp": "2021-08-01T11:06:26.515Z",
-      "isEnabled": false,
       "isReady": true,
       "deviceId": "0"
     },
@@ -2697,12 +3134,25 @@
         }
       },
       "commands": {},
-      "components": ["0", "1", "2"],
+      "components": ["0", "1", "2", "3"],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits",
+      "gatewayId": "################",
       "feature": "heating.circuits",
-      "timestamp": "2021-08-01T11:06:25.627Z",
+      "timestamp": "2021-09-22T01:32:47.835Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["modes", "programs"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating",
+      "gatewayId": "################",
+      "feature": "heating.circuits.3.operating",
+      "timestamp": "2021-09-22T01:32:19.035Z",
       "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
@@ -2712,23 +3162,90 @@
       "commands": {},
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.operating.modes.active",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.1.operating.modes.active",
-      "timestamp": "2021-08-01T11:06:26.494Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.operating.programs.active",
+      "timestamp": "2021-09-22T01:33:04.992Z",
       "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "value": false,
+          "type": "boolean"
+        }
+      },
+      "commands": {
+        "activate": {
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule/commands/activate",
+          "name": "activate",
+          "isExecutable": true,
+          "params": {}
+        },
+        "deactivate": {
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule/commands/deactivate",
+          "name": "deactivate",
+          "isExecutable": false,
+          "params": {}
+        }
+      },
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule",
+      "gatewayId": "################",
+      "feature": "heating.circuits.0.operating.programs.forcedLastFromSchedule",
+      "timestamp": "2021-09-30T05:50:47.740Z",
+      "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
     },
     {
       "properties": {},
       "commands": {},
-      "components": ["active", "dhw", "dhwAndHeating", "heating", "standby"],
+      "components": ["pump"],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.operating.modes",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.1.operating.modes",
-      "timestamp": "2021-08-01T11:06:24.548Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.circulation",
+      "gatewayId": "################",
+      "feature": "heating.circuits.3.circulation",
+      "timestamp": "2021-09-22T01:32:19.037Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "unit": {
+          "value": "celsius",
+          "type": "string"
+        },
+        "value": {
+          "type": "number",
+          "value": 20,
+          "unit": "celsius"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler.temperature",
+      "gatewayId": "################",
+      "feature": "heating.boiler.temperature",
+      "timestamp": "2021-09-22T01:32:41.617Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["programs"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating",
+      "gatewayId": "################",
+      "feature": "heating.operating",
+      "timestamp": "2021-09-22T01:32:19.035Z",
       "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
@@ -2738,49 +3255,10 @@
       "commands": {},
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.operating.modes.heating",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.1.operating.modes.heating",
-      "timestamp": "2021-08-01T11:06:25.732Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.operating.programs.active",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.operating.programs.active",
-      "timestamp": "2021-08-01T11:06:26.332Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.operating.programs.comfort",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.operating.programs.comfort",
-      "timestamp": "2021-08-01T11:06:25.614Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.1.circulation.pump",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.circulation.pump",
+      "gatewayId": "################",
       "feature": "heating.circuits.1.circulation.pump",
-      "timestamp": "2021-08-01T11:06:25.686Z",
+      "timestamp": "2021-09-22T01:32:44.469Z",
       "isEnabled": false,
       "isReady": true,
       "deviceId": "0"
@@ -2790,10 +3268,28 @@
       "commands": {},
       "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.boiler.sensors",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.boiler.sensors",
-      "timestamp": "2021-08-01T11:06:24.548Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.forcedLastFromSchedule",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.operating.programs.forcedLastFromSchedule",
+      "timestamp": "2021-09-30T05:50:47.770Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": true
+        }
+      },
+      "commands": {},
+      "components": ["modulation", "statistics"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners.0",
+      "gatewayId": "################",
+      "feature": "heating.burners.0",
+      "timestamp": "2021-09-30T14:40:10.515Z",
       "isEnabled": true,
       "isReady": true,
       "deviceId": "0"
@@ -2801,13 +3297,122 @@
     {
       "properties": {},
       "commands": {},
-      "components": ["room", "supply"],
+      "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/XXXXX/gateways/XXXXXXXXXXXXXXXX/devices/0/features/heating.circuits.2.sensors.temperature",
-      "gatewayId": "XXXXXXXXXXXXXXXX",
-      "feature": "heating.circuits.2.sensors.temperature",
-      "timestamp": "2021-08-01T11:06:24.548Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.operating.programs.active",
+      "timestamp": "2021-09-22T01:33:05.013Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reduced",
+      "gatewayId": "################",
+      "feature": "heating.circuits.3.operating.programs.reduced",
+      "timestamp": "2021-09-29T00:17:32.831Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["outside"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.sensors.temperature",
+      "gatewayId": "################",
+      "feature": "heating.sensors.temperature",
+      "timestamp": "2021-09-22T01:32:19.037Z",
       "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.temperature",
+      "gatewayId": "################",
+      "feature": "heating.circuits.2.temperature",
+      "timestamp": "2021-09-22T01:32:49.417Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {
+        "value": {
+          "type": "string",
+          "value": "################"
+        }
+      },
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler.serial",
+      "gatewayId": "################",
+      "feature": "heating.boiler.serial",
+      "timestamp": "2021-09-22T01:32:39.657Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["temperature"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.sensors",
+      "gatewayId": "################",
+      "feature": "heating.solar.sensors",
+      "timestamp": "2021-09-22T01:32:19.036Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby",
+      "gatewayId": "################",
+      "feature": "heating.circuits.1.operating.modes.standby",
+      "timestamp": "2021-09-22T01:32:51.843Z",
+      "isEnabled": false,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": ["serial"],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/device",
+      "gatewayId": "################",
+      "feature": "device",
+      "timestamp": "2021-09-22T01:32:19.034Z",
+      "isEnabled": true,
+      "isReady": true,
+      "deviceId": "0"
+    },
+    {
+      "properties": {},
+      "commands": {},
+      "components": [],
+      "apiVersion": 1,
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.temperature",
+      "gatewayId": "################",
+      "feature": "heating.circuits.3.temperature",
+      "timestamp": "2021-09-22T01:32:49.435Z",
+      "isEnabled": false,
       "isReady": true,
       "deviceId": "0"
     }

--- a/tests/test_Vitocaldens222F.py
+++ b/tests/test_Vitocaldens222F.py
@@ -1,7 +1,6 @@
 import unittest
 
 from PyViCare.PyViCareHybrid import Hybrid
-from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
@@ -19,9 +18,8 @@ class Vitocaldens222F(unittest.TestCase):
     def test_getAvailableCompressors(self):
         self.assertEqual(self.device.getAvailableCompressors(), ['0', '1'])
 
-    # currently missing an up-to-date test response
     def test_getIsActive(self):
-        self.assertRaises(PyViCareNotSupportedFeatureError, self.device.getBurner(0).getIsActive)
+        self.assertEqual(self.device.burners[0].getIsActive(), False)
 
     def test_getBufferTopTemperature(self):
         self.assertEqual(

--- a/tests/test_Vitocaldens222F.py
+++ b/tests/test_Vitocaldens222F.py
@@ -1,6 +1,7 @@
 import unittest
 
 from PyViCare.PyViCareHybrid import Hybrid
+from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
@@ -18,8 +19,9 @@ class Vitocaldens222F(unittest.TestCase):
     def test_getAvailableCompressors(self):
         self.assertEqual(self.device.getAvailableCompressors(), ['0', '1'])
 
+    # currently missing an up-to-date test response
     def test_getIsActive(self):
-        self.assertEqual(self.device.getBurner(0).getIsActive(), False)
+        self.assertRaises(PyViCareNotSupportedFeatureError, self.device.getBurner(0).getIsActive)
 
     def test_getBufferTopTemperature(self):
         self.assertEqual(

--- a/tests/test_Vitocaldens222F.py
+++ b/tests/test_Vitocaldens222F.py
@@ -18,8 +18,8 @@ class Vitocaldens222F(unittest.TestCase):
     def test_getAvailableCompressors(self):
         self.assertEqual(self.device.getAvailableCompressors(), ['0', '1'])
 
-    def test_getBurnerActive(self):
-        self.assertEqual(self.device.getBurnerActive(), False)
+    def test_getIsActive(self):
+        self.assertEqual(self.device.getBurner(0).getIsActive(), False)
 
     def test_getBufferTopTemperature(self):
         self.assertEqual(

--- a/tests/test_Vitodens200W.py
+++ b/tests/test_Vitodens200W.py
@@ -1,7 +1,6 @@
 import unittest
 
 from PyViCare.PyViCareGazBoiler import GazBoiler
-from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
 from tests.helper import now_is
 from tests.ViCareServiceMock import ViCareServiceMock
 
@@ -17,9 +16,8 @@ class Vitodens200W(unittest.TestCase):
     def test_getBoilerCommonSupplyTemperature(self):
         self.assertEqual(self.device.getBoilerCommonSupplyTemperature(), 44.4)
 
-    # currently missing an up-to-date test response
     def test_getIsActive(self):
-        self.assertRaises(PyViCareNotSupportedFeatureError, self.device.getBurner(0).getIsActive)
+        self.assertEqual(self.device.burners[0].getIsActive(), False)
 
     def test_getDomesticHotWaterActive(self):
         self.assertEqual(self.device.getDomesticHotWaterActive(), True)

--- a/tests/test_Vitodens200W.py
+++ b/tests/test_Vitodens200W.py
@@ -1,6 +1,7 @@
 import unittest
 
 from PyViCare.PyViCareGazBoiler import GazBoiler
+from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
 from tests.helper import now_is
 from tests.ViCareServiceMock import ViCareServiceMock
 
@@ -16,8 +17,9 @@ class Vitodens200W(unittest.TestCase):
     def test_getBoilerCommonSupplyTemperature(self):
         self.assertEqual(self.device.getBoilerCommonSupplyTemperature(), 44.4)
 
+    # currently missing an up-to-date test response
     def test_getIsActive(self):
-        self.assertEqual(self.device.getBurner(0).getIsActive(), False)
+        self.assertRaises(PyViCareNotSupportedFeatureError, self.device.getBurner(0).getIsActive)
 
     def test_getDomesticHotWaterActive(self):
         self.assertEqual(self.device.getDomesticHotWaterActive(), True)

--- a/tests/test_Vitodens200W.py
+++ b/tests/test_Vitodens200W.py
@@ -16,8 +16,8 @@ class Vitodens200W(unittest.TestCase):
     def test_getBoilerCommonSupplyTemperature(self):
         self.assertEqual(self.device.getBoilerCommonSupplyTemperature(), 44.4)
 
-    def test_getBurnerActive(self):
-        self.assertEqual(self.device.getBurnerActive(), False)
+    def test_getIsActive(self):
+        self.assertEqual(self.device.getBurner(0).getIsActive(), False)
 
     def test_getDomesticHotWaterActive(self):
         self.assertEqual(self.device.getDomesticHotWaterActive(), True)

--- a/tests/test_Vitodens222W.py
+++ b/tests/test_Vitodens222W.py
@@ -10,8 +10,8 @@ class Vitodens222W(unittest.TestCase):
         self.service = ViCareServiceMock('response/Vitodens222W.json')
         self.device = GazBoiler(self.service)
 
-    def test_getBurnerActive(self):
-        self.assertEqual(self.device.getBurnerActive(), False)
+    def test_getIsActive(self):
+        self.assertEqual(self.device.getBurner(0).getIsActive(), False)
 
     def test_getBurnerStarts(self):
         self.assertEqual(self.device.burners[0].getStarts(), 79167)

--- a/tests/test_Vitodens222W.py
+++ b/tests/test_Vitodens222W.py
@@ -11,7 +11,7 @@ class Vitodens222W(unittest.TestCase):
         self.device = GazBoiler(self.service)
 
     def test_getIsActive(self):
-        self.assertRaises(PyViCareNotSupportedFeatureError, self.device.getBurner(0).getIsActive)
+        self.assertEqual(self.device.burners[0].getIsActive(), True)
 
     def test_getBurnerStarts(self):
         self.assertEqual(self.device.burners[0].getStarts(), 8299)

--- a/tests/test_Vitodens222W.py
+++ b/tests/test_Vitodens222W.py
@@ -11,32 +11,30 @@ class Vitodens222W(unittest.TestCase):
         self.device = GazBoiler(self.service)
 
     def test_getIsActive(self):
-        self.assertEqual(self.device.getBurner(0).getIsActive(), False)
+        self.assertRaises(PyViCareNotSupportedFeatureError, self.device.getBurner(0).getIsActive)
 
     def test_getBurnerStarts(self):
-        self.assertEqual(self.device.burners[0].getStarts(), 79167)
+        self.assertEqual(self.device.burners[0].getStarts(), 8299)
 
     def test_getBurnerHours(self):
-        self.assertEqual(self.device.burners[0].getHours(), 25123.2)
+        self.assertEqual(self.device.burners[0].getHours(), 5674)
 
     def test_getBurnerModulation(self):
-        self.assertEqual(self.device.burners[0].getModulation(), 0)
+        self.assertEqual(self.device.burners[0].getModulation(), 15.8)
 
     def test_getPrograms(self):
-        expected_programs = ['active', 'comfort', 'eco',
-                             'external', 'holiday', 'normal', 'reduced', 'standby']
+        expected_programs = ['active', 'comfort', 'forcedLastFromSchedule', 'normal', 'reduced', 'standby']
         self.assertListEqual(
             self.device.circuits[0].getPrograms(), expected_programs)
 
     def test_getModes(self):
-        expected_modes = ['standby', 'dhw', 'dhwAndHeating',
-                          'forcedReduced', 'forcedNormal']
+        expected_modes = ['standby', 'heating', 'dhw', 'dhwAndHeating']
         self.assertListEqual(
             self.device.circuits[0].getModes(), expected_modes)
 
     def test_getPowerConsumptionDays(self):
-        self.assertRaises(PyViCareNotSupportedFeatureError,
-                          self.device.getPowerConsumptionDays)
+        expected_consumption = [0.4, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
+        self.assertListEqual(self.device.getPowerConsumptionDays(), expected_consumption)
 
     def test_getFrostProtectionActive(self):
         self.assertEqual(
@@ -48,7 +46,7 @@ class Vitodens222W(unittest.TestCase):
 
     def test_getDomesticHotWaterOutletTemperature(self):
         self.assertEqual(
-            self.device.getDomesticHotWaterOutletTemperature(), 44.8)
+            self.device.getDomesticHotWaterOutletTemperature(), 39.8)
 
     def test_getDomesticHotWaterCirculationScheduleModes(self):
         self.assertEqual(
@@ -56,8 +54,7 @@ class Vitodens222W(unittest.TestCase):
 
     def test_getOutsideTemperature(self):
         self.assertEqual(
-            self.device.getOutsideTemperature(), 16.3)
+            self.device.getOutsideTemperature(), 11.9)
 
     def test_getBoilerTemperature(self):
-        self.assertEqual(
-            self.device.getBoilerTemperature(), 73)
+        self.assertRaises(PyViCareNotSupportedFeatureError, self.device.getBoilerTemperature)

--- a/tests/test_Vitodens300W.py
+++ b/tests/test_Vitodens300W.py
@@ -10,8 +10,8 @@ class Vitodens300W(unittest.TestCase):
         self.service = ViCareServiceMock('response/Vitodens300W.json')
         self.device = GazBoiler(self.service)
 
-    def test_getBurnerActive(self):
-        self.assertEqual(self.device.getBurnerActive(), False)
+    def test_getIsActive(self):
+        self.assertEqual(self.device.getBurner(0).getIsActive(), False)
 
     def test_getDomesticHotWaterChargingLevel(self):
         self.assertEqual(self.device.getDomesticHotWaterChargingLevel(), 0)

--- a/tests/test_Vitodens300W.py
+++ b/tests/test_Vitodens300W.py
@@ -11,7 +11,7 @@ class Vitodens300W(unittest.TestCase):
         self.device = GazBoiler(self.service)
 
     def test_getIsActive(self):
-        self.assertRaises(PyViCareNotSupportedFeatureError, self.device.getBurner(0).getIsActive)
+        self.assertEqual(self.device.burners[0].getIsActive(), False)
 
     def test_getDomesticHotWaterChargingLevel(self):
         self.assertEqual(self.device.getDomesticHotWaterChargingLevel(), 0)

--- a/tests/test_Vitodens300W.py
+++ b/tests/test_Vitodens300W.py
@@ -11,7 +11,7 @@ class Vitodens300W(unittest.TestCase):
         self.device = GazBoiler(self.service)
 
     def test_getIsActive(self):
-        self.assertEqual(self.device.getBurner(0).getIsActive(), False)
+        self.assertRaises(PyViCareNotSupportedFeatureError, self.device.getBurner(0).getIsActive)
 
     def test_getDomesticHotWaterChargingLevel(self):
         self.assertEqual(self.device.getDomesticHotWaterChargingLevel(), 0)

--- a/tests/test_Vitodens333F.py
+++ b/tests/test_Vitodens333F.py
@@ -10,8 +10,9 @@ class Vitodens333F(unittest.TestCase):
         self.service = ViCareServiceMock('response/Vitodens333F.json')
         self.device = GazBoiler(self.service)
 
+    # currently missing an up-to-date test response
     def test_getIsActive(self):
-        self.assertEqual(self.device.burners[0].getIsActive(), False)
+        self.assertRaises(PyViCareNotSupportedFeatureError, self.device.burners[0].getIsActive)
 
     def test_getBurnerStarts(self):
         self.assertEqual(self.device.burners[0].getStarts(), 13987)

--- a/tests/test_Vitodens333F.py
+++ b/tests/test_Vitodens333F.py
@@ -10,8 +10,8 @@ class Vitodens333F(unittest.TestCase):
         self.service = ViCareServiceMock('response/Vitodens333F.json')
         self.device = GazBoiler(self.service)
 
-    def test_getBurnerActive(self):
-        self.assertEqual(self.device.getBurnerActive(), False)
+    def test_getIsActive(self):
+        self.assertEqual(self.device.burners[0].getIsActive(), False)
 
     def test_getBurnerStarts(self):
         self.assertEqual(self.device.burners[0].getStarts(), 13987)


### PR DESCRIPTION
Fixes #194 

It's also a breaking change, as now the active state is retrieved by the burner ID.

Instead of `device.getBurnerActive()` the new call is: `device.burners[0].getIsActive()`