### PR TITLE
fix: nameing of getActive

### DIFF
--- a/PyViCare/PyViCareGazBoiler.py
+++ b/PyViCare/PyViCareGazBoiler.py
@@ -133,7 +133,7 @@ class GazBurner(DeviceWithComponent):
         return self.component
 
     @handleNotSupported
-    def getIsActive(self):
+    def getActive(self):
         return self.service.getProperty(f"heating.burners.{self.burner}")["properties"]["active"]["value"]
 
     @handleNotSupported

--- a/PyViCare/PyViCareOilBoiler.py
+++ b/PyViCare/PyViCareOilBoiler.py
@@ -5,7 +5,7 @@ from PyViCare.PyViCareUtils import handleNotSupported
 class OilBoiler(Device):
 
     @handleNotSupported
-    def getIsActive(self):
+    def getActive(self):
         return self.service.getProperty("heating.burner")["properties"]["active"]["value"]
 
     @handleNotSupported

--- a/PyViCare/PyViCarePelletsBoiler.py
+++ b/PyViCare/PyViCarePelletsBoiler.py
@@ -5,7 +5,7 @@ from PyViCare.PyViCareUtils import handleNotSupported
 class PelletsBoiler(Device):
 
     @handleNotSupported
-    def getIsActive(self):
+    def getActive(self):
         return self.service.getProperty("heating.burner")["properties"]["active"]["value"]
 
     @handleNotSupported

--- a/tests/test_Vitocaldens222F.py
+++ b/tests/test_Vitocaldens222F.py
@@ -18,8 +18,8 @@ class Vitocaldens222F(unittest.TestCase):
     def test_getAvailableCompressors(self):
         self.assertEqual(self.device.getAvailableCompressors(), ['0', '1'])
 
-    def test_getIsActive(self):
-        self.assertEqual(self.device.burners[0].getIsActive(), False)
+    def test_getActive(self):
+        self.assertEqual(self.device.burners[0].getActive(), False)
 
     def test_getBufferTopTemperature(self):
         self.assertEqual(

--- a/tests/test_Vitodens200W.py
+++ b/tests/test_Vitodens200W.py
@@ -16,8 +16,8 @@ class Vitodens200W(unittest.TestCase):
     def test_getBoilerCommonSupplyTemperature(self):
         self.assertEqual(self.device.getBoilerCommonSupplyTemperature(), 44.4)
 
-    def test_getIsActive(self):
-        self.assertEqual(self.device.burners[0].getIsActive(), False)
+    def test_getActive(self):
+        self.assertEqual(self.device.burners[0].getActive(), False)
 
     def test_getDomesticHotWaterActive(self):
         self.assertEqual(self.device.getDomesticHotWaterActive(), True)

--- a/tests/test_Vitodens222W.py
+++ b/tests/test_Vitodens222W.py
@@ -10,8 +10,8 @@ class Vitodens222W(unittest.TestCase):
         self.service = ViCareServiceMock('response/Vitodens222W.json')
         self.device = GazBoiler(self.service)
 
-    def test_getIsActive(self):
-        self.assertEqual(self.device.burners[0].getIsActive(), True)
+    def test_getActive(self):
+        self.assertEqual(self.device.burners[0].getActive(), True)
 
     def test_getBurnerStarts(self):
         self.assertEqual(self.device.burners[0].getStarts(), 8299)

--- a/tests/test_Vitodens300W.py
+++ b/tests/test_Vitodens300W.py
@@ -10,8 +10,8 @@ class Vitodens300W(unittest.TestCase):
         self.service = ViCareServiceMock('response/Vitodens300W.json')
         self.device = GazBoiler(self.service)
 
-    def test_getIsActive(self):
-        self.assertEqual(self.device.burners[0].getIsActive(), False)
+    def test_getActive(self):
+        self.assertEqual(self.device.burners[0].getActive(), False)
 
     def test_getDomesticHotWaterChargingLevel(self):
         self.assertEqual(self.device.getDomesticHotWaterChargingLevel(), 0)

--- a/tests/test_Vitodens333F.py
+++ b/tests/test_Vitodens333F.py
@@ -11,8 +11,8 @@ class Vitodens333F(unittest.TestCase):
         self.device = GazBoiler(self.service)
 
     # currently missing an up-to-date test response
-    def test_getIsActive(self):
-        self.assertRaises(PyViCareNotSupportedFeatureError, self.device.burners[0].getIsActive)
+    def test_getActive(self):
+        self.assertRaises(PyViCareNotSupportedFeatureError, self.device.burners[0].getActive)
 
     def test_getBurnerStarts(self):
         self.assertEqual(self.device.burners[0].getStarts(), 13987)


### PR DESCRIPTION
Follow up of PR #195, I chose the name `getIsActive` we already have the name `getActive` for compressor, so this is a change 
to keep this consistent.