### PR TITLE
fix: oil burner access via burner property

### DIFF
--- a/PyViCare/PyViCareOilBoiler.py
+++ b/PyViCare/PyViCareOilBoiler.py
@@ -1,25 +1,45 @@
-from PyViCare.PyViCareDevice import Device
+from typing import Any, List
+
+from PyViCare.PyViCareDevice import Device, DeviceWithComponent
 from PyViCare.PyViCareUtils import handleNotSupported
 
 
 class OilBoiler(Device):
 
-    @handleNotSupported
-    def getActive(self):
-        return self.service.getProperty("heating.burner")["properties"]["active"]["value"]
+    @property
+    def burners(self) -> List[Any]:
+        return list([self.getBurner(x) for x in self.getAvailableBurners()])
+
+    def getBurner(self, burner):
+        return OilBurner(self, burner)
 
     @handleNotSupported
-    def getBurnerModulation(self):
-        return self.service.getProperty('heating.burner.modulation')["properties"]["value"]["value"]
+    def getAvailableBurners(self):
+        return self.service.getProperty("heating.burners")["components"]
 
     @handleNotSupported
     def getBoilerTemperature(self):
         return self.service.getProperty("heating.boiler.sensors.temperature.main")["properties"]["value"]["value"]
 
-    @handleNotSupported
-    def getBurnerHours(self):
-        return self.service.getProperty('heating.burner.statistics')['properties']['hours']['value']
+
+class OilBurner(DeviceWithComponent):
+
+    @property
+    def burner(self) -> str:
+        return self.component
 
     @handleNotSupported
-    def getBurnerStarts(self):
-        return self.service.getProperty('heating.burner.statistics')['properties']['starts']['value']
+    def getActive(self):
+        return self.service.getProperty(f"heating.burners.{self.burner}")["properties"]["active"]["value"]
+
+    @handleNotSupported
+    def getHours(self):
+        return self.service.getProperty(f"heating.burners.{self.burner}.statistics")["properties"]["hours"]["value"]
+
+    @handleNotSupported
+    def getStarts(self):
+        return self.service.getProperty(f"heating.burners.{self.burner}.statistics")["properties"]["starts"]["value"]
+
+    @handleNotSupported
+    def getModulation(self):
+        return self.service.getProperty(f"heating.burners.{self.burner}.modulation")["properties"]["value"]["value"]


### PR DESCRIPTION
Fixes the access to the burner for oil devices. We are lacking a test response for this. But according to the API documentation, it behaves similar to the gaz devices.