### PR TITLE
fix: do not store invalid response in cache

### DIFF
--- a/PyViCare/PyViCareCachedService.py
+++ b/PyViCare/PyViCareCachedService.py
@@ -22,11 +22,6 @@ class ViCareCachedService(ViCareService):
 
     def getProperty(self, property_name: str) -> Any:
         data = self.__get_or_update_cache()
-
-        if "data" not in data:
-            logger.error("Missing 'data' property when fetching data.")
-            raise PyViCareInvalidDataError(data)
-
         entities = data["data"]
         return readFeature(entities, property_name)
 
@@ -38,7 +33,11 @@ class ViCareCachedService(ViCareService):
     def __get_or_update_cache(self):
         with self.__lock:
             if self.is_cache_invalid():
-                self.__cache = self.fetch_all_features()
+                data = self.fetch_all_features()
+                if "data" not in data:
+                    logger.error("Missing 'data' property when fetching data.")
+                    raise PyViCareInvalidDataError(data)
+                self.__cache = data
                 self.__cacheTime = ViCareTimer().now()
             return self.__cache
 


### PR DESCRIPTION
Previously, the invalid response has been stored into the cache, so that consecutive calls used the invalid response. 

This change validates the data and throws the exception one step earlier so that the response does not end up in the cache in the first place. 