### PR TITLE
feat: Change available compressors for heatpumps

### DIFF
--- a/PyViCare/PyViCareHeatPump.py
+++ b/PyViCare/PyViCareHeatPump.py
@@ -15,7 +15,7 @@ class HeatPump(Device):
 
     @handleNotSupported
     def getAvailableCompressors(self):
-        return self.service.getProperty("heating.compressors")["components"]
+        return self.service.getProperty("heating.compressors")["properties"]["enabled"]["value"]
 
     @handleNotSupported
     def getBufferMainTemperature(self):

--- a/tests/test_Vitocal200.py
+++ b/tests/test_Vitocal200.py
@@ -17,6 +17,9 @@ class Vitocal200(unittest.TestCase):
     def test_getCompressorHours(self):
         self.assertAlmostEqual(
             self.device.compressors[0].getHours(), 8583.2)
+            
+    def test_getAvailableCompressors(self):
+        self.assertEqual(self.device.getAvailableCompressors(), ['0'])
 
     def test_getCompressorStarts(self):
         self.assertAlmostEqual(

--- a/tests/test_Vitocal200S.py
+++ b/tests/test_Vitocal200S.py
@@ -13,6 +13,9 @@ class Vitocal200S(unittest.TestCase):
         self.assertEqual(
             self.device.getDomesticHotWaterConfiguredTemperature(), 40)
 
+    def test_getAvailableCompressors(self):
+        self.assertEqual(self.device.getAvailableCompressors(), ['0'])
+
     def test_getDomesticHotWaterConfiguredTemperature2(self):
         self.assertEqual(
             self.device.getDomesticHotWaterConfiguredTemperature2(), 60)

--- a/tests/test_Vitocaldens222F.py
+++ b/tests/test_Vitocaldens222F.py
@@ -16,7 +16,7 @@ class Vitocaldens222F(unittest.TestCase):
         self.assertEqual(self.device.getAvailableBurners(), ['0'])
 
     def test_getAvailableCompressors(self):
-        self.assertEqual(self.device.getAvailableCompressors(), ['0', '1'])
+        self.assertEqual(self.device.getAvailableCompressors(), ['0'])
 
     def test_getActive(self):
         self.assertEqual(self.device.burners[0].getActive(), False)


### PR DESCRIPTION
The API for heatpumps delivers the currently enabled compressors, so we can use that instead of going trial and error on the second compressor ;)