### PR TITLE
feat: Add consumption units for gas heatings

### DIFF
--- a/PyViCare/PyViCareGazBoiler.py
+++ b/PyViCare/PyViCareGazBoiler.py
@@ -18,6 +18,10 @@ class GazBoiler(Device):
         return self.service.getProperty("heating.burners")["components"]
 
     @handleNotSupported
+    def getGasConsumptionHeatingUnit(self):
+        return self.service.getProperty("heating.gas.consumption.heating")["properties"]["unit"]["value"]
+
+    @handleNotSupported
     def getGasConsumptionHeatingDays(self):
         return self.service.getProperty("heating.gas.consumption.heating")["properties"]["day"]["value"]
 
@@ -48,6 +52,10 @@ class GazBoiler(Device):
     @handleNotSupported
     def getGasConsumptionHeatingThisYear(self):
         return self.service.getProperty("heating.gas.consumption.heating")["properties"]["year"]["value"][0]
+
+    @handleNotSupported
+    def getGasConsumptionDomesticHotWaterUnit(self):
+        return self.service.getProperty("heating.gas.consumption.dhw")["properties"]["unit"]["value"]
 
     @handleNotSupported
     def getGasConsumptionDomesticHotWaterDays(self):
@@ -92,6 +100,10 @@ class GazBoiler(Device):
     @handleNotSupported
     def getBoilerCommonSupplyTemperature(self):
         return self.service.getProperty("heating.boiler.sensors.temperature.commonSupply")["properties"]["value"]["value"]
+
+    @handleNotSupported
+    def getPowerConsumptionUnit(self):
+        return self.service.getProperty("heating.power.consumption.total")["properties"]["unit"]["value"]
 
     @handleNotSupported
     def getPowerConsumptionDays(self):

--- a/tests/test_Vitodens200W.py
+++ b/tests/test_Vitodens200W.py
@@ -81,3 +81,27 @@ class Vitodens200W(unittest.TestCase):
         with now_is('2021-09-08 10:10:00'):
             self.assertEqual(
                 self.device.getDomesticHotWaterCirculationMode(), 'off')
+
+    def test_getGasConsumptionHeatingUnit(self):
+        self.assertEqual(
+            self.device.getGasConsumptionHeatingUnit(), "cubicMeter")
+
+    def test_ggetGasConsumptionHeatingToday(self):
+        self.assertEqual(
+            self.device.getGasConsumptionHeatingToday(), 0)
+
+    def test_getGasConsumptionDomesticHotWaterUnit(self):
+        self.assertEqual(
+            self.device.getGasConsumptionDomesticHotWaterUnit(), "cubicMeter")
+
+    def test_getGasConsumptionDomesticHotWaterToday(self):
+        self.assertEqual(
+            self.device.getGasConsumptionDomesticHotWaterToday(), 1.3)
+
+    def test_getPowerConsumptionUnit(self):
+        self.assertEqual(
+            self.device.getPowerConsumptionUnit(), "kilowattHour")
+
+    def test_getPowerConsumptionToday(self):
+        self.assertEqual(
+            self.device.getPowerConsumptionToday(), 0.1)


### PR DESCRIPTION
Adds consumption units for gas heatings as described in #193. If this is useful for HA, we can add the units for fuel cell aswell.