### PR TITLE
Vitodens-100W, new json dump, added new methods

### DIFF
--- a/PyViCare/PyViCareGazBoiler.py
+++ b/PyViCare/PyViCareGazBoiler.py
@@ -137,6 +137,123 @@ class GazBoiler(Device):
     def getPowerConsumptionThisYear(self):
         return self.service.getProperty("heating.power.consumption.total")["properties"]["year"]["value"][0]
 
+    # For Vitodens-100W new "summary" api methods
+    # Gas consumption for Heating data:
+    @handleNotSupported
+    def getGasSummaryConsumptionHeatingUnit(self):
+        return self.service.getProperty("heating.gas.consumption.summary.heating")["properties"]["unit"]["value"]
+    
+    @handleNotSupported
+    def getGasSummaryConsumptionHeatingCurrentDay(self):
+        return self.service.getProperty("heating.gas.consumption.summary.heating")["properties"]["currentDay"]["value"]
+
+    @handleNotSupported
+    def getGasSummaryConsumptionHeatingCurrentMonth(self):
+        return self.service.getProperty("heating.gas.consumption.summary.heating")["properties"]["currentMonth"]["value"]
+
+    @handleNotSupported
+    def getGasSummaryConsumptionHeatingCurrentYear(self):
+        return self.service.getProperty("heating.gas.consumption.summary.heating")["properties"]["currentYear"]["value"]
+
+    @handleNotSupported
+    def getGasSummaryConsumptionHeatingLastMonth(self):
+        return self.service.getProperty("heating.gas.consumption.summary.heating")["properties"]["lastMonth"]["value"]
+
+    @handleNotSupported
+    def getGasSummaryConsumptionHeatingLastSevenDays(self):
+        return self.service.getProperty("heating.gas.consumption.summary.heating")["properties"]["lastSevenDays"]["value"]
+
+    @handleNotSupported
+    def getGasSummaryConsumptionHeatingLastYear(self):
+        return self.service.getProperty("heating.gas.consumption.summary.heating")["properties"]["lastYear"]["value"]
+
+    # Gas consumption for Domestic Hot Water data:
+    @handleNotSupported
+    def getGasSummaryConsumptionDomesticHotWaterUnit(self):
+        return self.service.getProperty("heating.gas.consumption.summary.dhw")["properties"]["unit"]["value"]
+    
+    @handleNotSupported
+    def getGasSummaryConsumptionDomesticHotWaterCurrentDay(self):
+        return self.service.getProperty("heating.gas.consumption.summary.dhw")["properties"]["currentDay"]["value"]
+
+    @handleNotSupported
+    def getGasSummaryConsumptionDomesticHotWaterCurrentMonth(self):
+        return self.service.getProperty("heating.gas.consumption.summary.dhw")["properties"]["currentMonth"]["value"]
+
+    @handleNotSupported
+    def getGasSummaryConsumptionDomesticHotWaterCurrentYear(self):
+        return self.service.getProperty("heating.gas.consumption.summary.dhw")["properties"]["currentYear"]["value"]
+
+    @handleNotSupported
+    def getGasSummaryConsumptionDomesticHotWaterLastMonth(self):
+        return self.service.getProperty("heating.gas.consumption.summary.dhw")["properties"]["lastMonth"]["value"]
+
+    @handleNotSupported
+    def getGasSummaryConsumptionDomesticHotWaterLastSevenDays(self):
+        return self.service.getProperty("heating.gas.consumption.summary.dhw")["properties"]["lastSevenDays"]["value"]
+
+    @handleNotSupported
+    def getGasSummaryConsumptionDomesticHotWaterLastYear(self):
+        return self.service.getProperty("heating.gas.consumption.summary.dhw")["properties"]["lastYear"]["value"]
+
+    # Power consumption for Heating:
+    @handleNotSupported
+    def getPowerSummaryConsumptionHeatingUnit(self):
+        return self.service.getProperty("heating.power.consumption.summary.heating")["properties"]["unit"]["value"]
+    
+    @handleNotSupported
+    def getPowerSummaryConsumptionHeatingCurrentDay(self):
+        return self.service.getProperty("heating.power.consumption.summary.heating")["properties"]["currentDay"]["value"]
+
+    @handleNotSupported
+    def getPowerSummaryConsumptionHeatingCurrentMonth(self):
+        return self.service.getProperty("heating.power.consumption.summary.heating")["properties"]["currentMonth"]["value"]
+
+    @handleNotSupported
+    def getPowerSummaryConsumptionHeatingCurrentYear(self):
+        return self.service.getProperty("heating.power.consumption.summary.heating")["properties"]["currentYear"]["value"]
+
+    @handleNotSupported
+    def getPowerSummaryConsumptionHeatingLastMonth(self):
+        return self.service.getProperty("heating.power.consumption.summary.heating")["properties"]["lastMonth"]["value"]
+
+    @handleNotSupported
+    def getPowerSummaryConsumptionHeatingLastSevenDays(self):
+        return self.service.getProperty("heating.power.consumption.summary.heating")["properties"]["lastSevenDays"]["value"]
+
+    @handleNotSupported
+    def getPowerSummaryConsumptionHeatingLastYear(self):
+        return self.service.getProperty("heating.power.consumption.summary.heating")["properties"]["lastYear"]["value"]
+
+    # Power consumption for Domestic Hot Water:
+    @handleNotSupported
+    def getPowerSummaryConsumptionDomesticHotWaterUnit(self):
+        return self.service.getProperty("heating.power.consumption.summary.dhw")["properties"]["unit"]["value"]
+    
+    @handleNotSupported
+    def getPowerSummaryConsumptionDomesticHotWaterCurrentDay(self):
+        return self.service.getProperty("heating.power.consumption.summary.dhw")["properties"]["currentDay"]["value"]
+
+    @handleNotSupported
+    def getPowerSummaryConsumptionDomesticHotWaterCurrentMonth(self):
+        return self.service.getProperty("heating.power.consumption.summary.dhw")["properties"]["currentMonth"]["value"]
+
+    @handleNotSupported
+    def getPowerSummaryConsumptionDomesticHotWaterCurrentYear(self):
+        return self.service.getProperty("heating.power.consumption.summary.dhw")["properties"]["currentYear"]["value"]
+
+    @handleNotSupported
+    def getPowerSummaryConsumptionDomesticHotWaterLastMonth(self):
+        return self.service.getProperty("heating.power.consumption.summary.dhw")["properties"]["lastMonth"]["value"]
+
+    @handleNotSupported
+    def getPowerSummaryConsumptionDomesticHotWaterLastSevenDays(self):
+        return self.service.getProperty("heating.power.consumption.summary.dhw")["properties"]["lastSevenDays"]["value"]
+
+    @handleNotSupported
+    def getPowerSummaryConsumptionDomesticHotWaterLastYear(self):
+        return self.service.getProperty("heating.power.consumption.summary.dhw")["properties"]["lastYear"]["value"]
+
 
 class GazBurner(DeviceWithComponent):
 

--- a/tests/response/Vitodens100W.json
+++ b/tests/response/Vitodens100W.json
@@ -3,17 +3,394 @@
         {
             "apiVersion": 1,
             "commands": {},
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.modes.standby",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "timestamp": "2021-12-09T20:39:47.814Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.circuits.1.operating.programs.comfortEnergySaving",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2021-12-09T20:39:48.910Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortEnergySaving"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.circuits.1.operating.programs.normalEnergySaving",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2021-12-09T20:39:48.838Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalEnergySaving"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.solar.sensors.temperature.dhw",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2021-12-09T20:39:51.398Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.dhw"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.programs.comfortEnergySaving",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                },
+                "demand": {
+                    "type": "string",
+                    "value": "heating"
+                },
+                "reason": {
+                    "type": "string",
+                    "value": "noDemand"
+                }
+            },
+            "timestamp": "2021-12-09T20:39:48.870Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortEnergySaving"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
             "components": [
-                "supply"
+                "collector",
+                "dhw"
             ],
             "deviceId": "0",
-            "feature": "heating.circuits.1.sensors.temperature",
+            "feature": "heating.solar.sensors.temperature",
             "gatewayId": "################",
             "isEnabled": true,
             "isReady": true,
             "properties": {},
-            "timestamp": "2021-10-29T15:51:12.504Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature"
+            "timestamp": "2021-12-09T20:39:29.783Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.programs.reducedEnergySaving",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                },
+                "demand": {
+                    "type": "string",
+                    "value": "heating"
+                },
+                "reason": {
+                    "type": "string",
+                    "value": "noDemand"
+                }
+            },
+            "timestamp": "2021-12-09T20:50:48.979Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedEnergySaving"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.circuits.0.temperature",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "unit": {
+                    "type": "string",
+                    "value": "celsius"
+                },
+                "value": {
+                    "type": "number",
+                    "unit": "celsius",
+                    "value": 0
+                }
+            },
+            "timestamp": "2021-12-09T20:50:50.993Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.circuits.1.operating.programs.reducedEnergySaving",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2021-12-09T20:39:48.804Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedEnergySaving"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [
+                "supply"
+            ],
+            "deviceId": "0",
+            "feature": "heating.circuits.0.sensors.temperature",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2021-12-09T20:39:29.783Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [
+                "serial"
+            ],
+            "deviceId": "0",
+            "feature": "device",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2021-12-09T20:39:29.783Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/device"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [
+                "temperature"
+            ],
+            "deviceId": "0",
+            "feature": "heating.solar.sensors",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2021-12-09T20:39:29.783Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.sensors"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [
+                "frostprotection",
+                "operating",
+                "sensors",
+                "temperature"
+            ],
+            "deviceId": "0",
+            "feature": "heating.circuits.1",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2021-12-09T20:39:44.605Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [
+                "sensors"
+            ],
+            "deviceId": "0",
+            "feature": "heating.solar",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2021-12-09T20:39:50.612Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [
+                "active",
+                "dhw",
+                "dhwAndHeating",
+                "heating",
+                "standby"
+            ],
+            "deviceId": "0",
+            "feature": "heating.circuits.1.operating.modes",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2021-12-09T20:39:29.783Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [
+                "temperature"
+            ],
+            "deviceId": "0",
+            "feature": "heating.circuits.0.sensors",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2021-12-09T20:39:29.783Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [
+                "0",
+                "1"
+            ],
+            "deviceId": "0",
+            "feature": "heating.circuits",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "enabled": {
+                    "type": "array",
+                    "value": [
+                        "0"
+                    ]
+                }
+            },
+            "timestamp": "2021-12-09T20:39:44.623Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [
+                "hmiState"
+            ],
+            "deviceId": "0",
+            "feature": "heating.circuits.1.operating.programs.noDemand",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "timestamp": "2021-12-09T20:39:57.659Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.noDemand"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.circuits.1.operating.modes.dhwAndHeating",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2021-12-09T20:39:48.618Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [
+                "schedule"
+            ],
+            "deviceId": "0",
+            "feature": "heating.dhw.pumps.circulation",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2021-12-09T20:39:54.386Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.power.consumption.summary.dhw",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "currentDay": {
+                    "type": "number",
+                    "unit": "kilowattHour",
+                    "value": 0
+                },
+                "currentMonth": {
+                    "type": "number",
+                    "unit": "kilowattHour",
+                    "value": 0.8
+                },
+                "currentYear": {
+                    "type": "number",
+                    "unit": "kilowattHour",
+                    "value": 18
+                },
+                "lastMonth": {
+                    "type": "number",
+                    "unit": "kilowattHour",
+                    "value": 0
+                },
+                "lastSevenDays": {
+                    "type": "number",
+                    "unit": "kilowattHour",
+                    "value": 0.6
+                },
+                "lastYear": {
+                    "type": "number",
+                    "unit": "kilowattHour",
+                    "value": 0
+                },
+                "unit": {
+                    "type": "string",
+                    "value": "kilowattHour"
+                }
+            },
+            "timestamp": "2021-12-09T20:39:50.535Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.dhw"
         },
         {
             "apiVersion": 1,
@@ -52,11 +429,11 @@
                 },
                 "temperature": {
                     "type": "number",
-                    "unit": "",
-                    "value": 50
+                    "unit": "celsius",
+                    "value": 45
                 }
             },
-            "timestamp": "2021-11-02T14:47:20.858Z",
+            "timestamp": "2021-12-09T20:50:49.239Z",
             "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal"
         },
         {
@@ -64,173 +441,25 @@
             "commands": {},
             "components": [],
             "deviceId": "0",
-            "feature": "heating.solar.sensors.temperature.collector",
-            "gatewayId": "################",
-            "isEnabled": false,
-            "isReady": true,
-            "properties": {},
-            "timestamp": "2021-10-29T15:51:13.697Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.collector"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [
-                "frostprotection",
-                "operating",
-                "sensors",
-                "temperature"
-            ],
-            "deviceId": "0",
-            "feature": "heating.circuits.1",
-            "gatewayId": "################",
-            "isEnabled": false,
-            "isReady": true,
-            "properties": {},
-            "timestamp": "2021-10-29T15:51:13.155Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [],
-            "deviceId": "0",
-            "feature": "heating.sensors",
-            "gatewayId": "################",
-            "isEnabled": true,
-            "isReady": true,
-            "properties": {},
-            "timestamp": "2021-10-29T15:51:12.503Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [
-                "temperature"
-            ],
-            "deviceId": "0",
-            "feature": "heating.circuits.1.sensors",
-            "gatewayId": "################",
-            "isEnabled": true,
-            "isReady": true,
-            "properties": {},
-            "timestamp": "2021-10-29T15:51:12.504Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [],
-            "deviceId": "0",
-            "feature": "heating.dhw.pumps.circulation.schedule",
-            "gatewayId": "################",
-            "isEnabled": false,
-            "isReady": true,
-            "properties": {},
-            "timestamp": "2021-11-02T08:17:00.791Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [
-                "hmiState"
-            ],
-            "deviceId": "0",
-            "feature": "heating.circuits.1.operating.programs.noDemand",
+            "feature": "device.serial",
             "gatewayId": "################",
             "isEnabled": true,
             "isReady": true,
             "properties": {
-                "active": {
-                    "type": "boolean",
-                    "value": false
-                }
-            },
-            "timestamp": "2021-10-29T15:51:14.221Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.noDemand"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [],
-            "deviceId": "0",
-            "feature": "heating.burners.0.modulation",
-            "gatewayId": "################",
-            "isEnabled": true,
-            "isReady": true,
-            "properties": {
-                "unit": {
+                "value": {
                     "type": "string",
-                    "value": "percent"
-                },
-                "value": {
-                    "type": "number",
-                    "unit": "percent",
-                    "value": 28.9
+                    "value": "################"
                 }
             },
-            "timestamp": "2021-11-02T15:39:04.642Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners.0.modulation"
+            "timestamp": "2021-12-09T20:39:43.724Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/device.serial"
         },
         {
             "apiVersion": 1,
             "commands": {},
             "components": [],
             "deviceId": "0",
-            "feature": "heating.circuits.1.operating.modes.dhwAndHeating",
-            "gatewayId": "################",
-            "isEnabled": false,
-            "isReady": true,
-            "properties": {},
-            "timestamp": "2021-10-29T15:51:13.660Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {
-                "setTargetTemperature": {
-                    "isExecutable": true,
-                    "name": "setTargetTemperature",
-                    "params": {
-                        "temperature": {
-                            "constraints": {
-                                "efficientLowerBorder": 10,
-                                "efficientUpperBorder": 60,
-                                "max": 60,
-                                "min": 10,
-                                "stepping": 1
-                            },
-                            "required": true,
-                            "type": "number"
-                        }
-                    },
-                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
-                }
-            },
-            "components": [],
-            "deviceId": "0",
-            "feature": "heating.dhw.temperature.main",
-            "gatewayId": "################",
-            "isEnabled": true,
-            "isReady": true,
-            "properties": {
-                "value": {
-                    "type": "number",
-                    "unit": "",
-                    "value": 45
-                }
-            },
-            "timestamp": "2021-10-31T20:00:24.891Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [],
-            "deviceId": "0",
-            "feature": "heating.circuits.0.operating.modes.standby",
+            "feature": "heating.configuration.multiFamilyHouse",
             "gatewayId": "################",
             "isEnabled": true,
             "isReady": true,
@@ -240,110 +469,35 @@
                     "value": false
                 }
             },
-            "timestamp": "2021-10-29T15:51:13.626Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
+            "timestamp": "2021-12-09T20:39:49.915Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.configuration.multiFamilyHouse"
         },
         {
             "apiVersion": 1,
             "commands": {},
             "components": [],
             "deviceId": "0",
-            "feature": "heating.solar.sensors.temperature.dhw",
-            "gatewayId": "################",
-            "isEnabled": false,
-            "isReady": true,
-            "properties": {},
-            "timestamp": "2021-10-29T15:51:13.699Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.dhw"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [],
-            "deviceId": "0",
-            "feature": "heating.dhw.sensors",
-            "gatewayId": "################",
-            "isEnabled": true,
-            "isReady": true,
-            "properties": {},
-            "timestamp": "2021-10-29T15:51:12.503Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [],
-            "deviceId": "0",
-            "feature": "heating.circuits.0.frostprotection",
+            "feature": "heating.dhw.sensors.temperature.hotWaterStorage",
             "gatewayId": "################",
             "isEnabled": true,
             "isReady": true,
             "properties": {
                 "status": {
                     "type": "string",
-                    "value": "off"
-                }
-            },
-            "timestamp": "2021-10-29T15:51:13.475Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [],
-            "deviceId": "0",
-            "feature": "heating.circuits.1.operating.programs.normal",
-            "gatewayId": "################",
-            "isEnabled": false,
-            "isReady": true,
-            "properties": {},
-            "timestamp": "2021-11-02T08:16:58.731Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [],
-            "deviceId": "0",
-            "feature": "heating.circuits.0.operating.programs.noDemand.hmiState",
-            "gatewayId": "################",
-            "isEnabled": true,
-            "isReady": true,
-            "properties": {
-                "program": {
-                    "type": "string",
-                    "value": "normal"
-                },
-                "temperature": {
-                    "type": "number",
-                    "unit": "celsius",
-                    "value": 50
+                    "value": "connected"
                 },
                 "unit": {
                     "type": "string",
                     "value": "celsius"
+                },
+                "value": {
+                    "type": "number",
+                    "unit": "celsius",
+                    "value": 44.6
                 }
             },
-            "timestamp": "2021-10-29T15:51:13.670Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.noDemand.hmiState"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [],
-            "deviceId": "0",
-            "feature": "heating.dhw.pumps.primary",
-            "gatewayId": "################",
-            "isEnabled": true,
-            "isReady": true,
-            "properties": {
-                "status": {
-                    "type": "string",
-                    "value": "off"
-                }
-            },
-            "timestamp": "2021-10-29T15:51:13.295Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.primary"
+            "timestamp": "2021-12-09T20:54:19.963Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
         },
         {
             "apiVersion": 1,
@@ -365,188 +519,65 @@
                     "value": 20
                 }
             },
-            "timestamp": "2021-10-29T15:51:13.132Z",
+            "timestamp": "2021-12-09T20:39:43.845Z",
             "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.temperature"
         },
         {
             "apiVersion": 1,
-            "commands": {
-                "setMode": {
-                    "isExecutable": true,
-                    "name": "setMode",
-                    "params": {
-                        "mode": {
-                            "constraints": {
-                                "enum": [
-                                    "standby",
-                                    "heating",
-                                    "dhw",
-                                    "dhwAndHeating"
-                                ]
-                            },
-                            "required": true,
-                            "type": "string"
-                        }
-                    },
-                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
-                }
-            },
+            "commands": {},
             "components": [],
             "deviceId": "0",
-            "feature": "heating.circuits.0.operating.modes.active",
+            "feature": "heating.circuits.1.operating.programs.noDemand.hmiState",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2021-12-09T20:39:49.854Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.noDemand.hmiState"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.dhw.pumps.secondary",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2021-12-09T20:39:47.552Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.secondary"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.programs.active",
             "gatewayId": "################",
             "isEnabled": true,
             "isReady": true,
             "properties": {
                 "value": {
                     "type": "string",
-                    "value": "dhwAndHeating"
+                    "value": "normalEnergySaving"
                 }
             },
-            "timestamp": "2021-11-02T08:17:07.402Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
+            "timestamp": "2021-12-09T20:50:49.231Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
         },
         {
             "apiVersion": 1,
             "commands": {},
             "components": [],
             "deviceId": "0",
-            "feature": "heating.boiler.sensors.temperature.commonSupply",
-            "gatewayId": "################",
-            "isEnabled": true,
-            "isReady": true,
-            "properties": {
-                "status": {
-                    "type": "string",
-                    "value": "connected"
-                },
-                "unit": {
-                    "type": "string",
-                    "value": "celsius"
-                },
-                "value": {
-                    "type": "number",
-                    "unit": "celsius",
-                    "value": 65.8
-                }
-            },
-            "timestamp": "2021-11-02T15:39:00.417Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [],
-            "deviceId": "0",
-            "feature": "heating.gas.consumption.summary.dhw",
-            "gatewayId": "################",
-            "isEnabled": true,
-            "isReady": true,
-            "properties": {
-                "currentDay": {
-                    "type": "number",
-                    "unit": "cubicMeter",
-                    "value": 0.6
-                },
-                "currentMonth": {
-                    "type": "number",
-                    "unit": "cubicMeter",
-                    "value": 1.7
-                },
-                "currentYear": {
-                    "type": "number",
-                    "unit": "cubicMeter",
-                    "value": 23.1
-                },
-                "lastMonth": {
-                    "type": "number",
-                    "unit": "cubicMeter",
-                    "value": 0
-                },
-                "lastSevenDays": {
-                    "type": "number",
-                    "unit": "cubicMeter",
-                    "value": 9.5
-                },
-                "lastYear": {
-                    "type": "number",
-                    "unit": "cubicMeter",
-                    "value": 0
-                },
-                "unit": {
-                    "type": "string",
-                    "value": "cubicMeter"
-                }
-            },
-            "timestamp": "2021-11-02T15:35:53.783Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.summary.dhw"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [
-                "hmiState"
-            ],
-            "deviceId": "0",
-            "feature": "heating.circuits.0.operating.programs.noDemand",
-            "gatewayId": "################",
-            "isEnabled": true,
-            "isReady": true,
-            "properties": {
-                "active": {
-                    "type": "boolean",
-                    "value": true
-                }
-            },
-            "timestamp": "2021-11-02T14:47:21.379Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.noDemand"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [
-                "serial"
-            ],
-            "deviceId": "0",
-            "feature": "device",
+            "feature": "heating.circuits.0.circulation",
             "gatewayId": "################",
             "isEnabled": true,
             "isReady": true,
             "properties": {},
-            "timestamp": "2021-10-29T15:51:12.503Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/device"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [
-                "modes",
-                "programs"
-            ],
-            "deviceId": "0",
-            "feature": "heating.circuits.0.operating",
-            "gatewayId": "################",
-            "isEnabled": true,
-            "isReady": true,
-            "properties": {},
-            "timestamp": "2021-10-29T15:51:12.503Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [
-                "modes",
-                "programs"
-            ],
-            "deviceId": "0",
-            "feature": "heating.circuits.1.operating",
-            "gatewayId": "################",
-            "isEnabled": true,
-            "isReady": true,
-            "properties": {},
-            "timestamp": "2021-10-29T15:51:12.503Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating"
+            "timestamp": "2021-12-09T20:39:29.783Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.circulation"
         },
         {
             "apiVersion": 1,
@@ -593,135 +624,93 @@
                     "value": "heatingCircuit"
                 }
             },
-            "timestamp": "2021-10-29T15:51:13.149Z",
+            "timestamp": "2021-12-09T20:39:44.438Z",
             "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0"
         },
         {
             "apiVersion": 1,
             "commands": {},
             "components": [
-                "active",
-                "dhw",
-                "dhwAndHeating",
-                "heating",
-                "standby"
+                "main"
             ],
             "deviceId": "0",
-            "feature": "heating.circuits.1.operating.modes",
+            "feature": "heating.dhw.temperature",
             "gatewayId": "################",
             "isEnabled": true,
             "isReady": true,
             "properties": {},
-            "timestamp": "2021-10-29T15:51:12.503Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes"
+            "timestamp": "2021-12-09T20:39:29.783Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature"
         },
         {
             "apiVersion": 1,
             "commands": {},
             "components": [],
             "deviceId": "0",
-            "feature": "device.serial",
+            "feature": "heating.circuits.0.frostprotection",
             "gatewayId": "################",
             "isEnabled": true,
             "isReady": true,
             "properties": {
-                "value": {
+                "status": {
                     "type": "string",
-                    "value": "################"
+                    "value": "off"
                 }
             },
-            "timestamp": "2021-10-29T15:51:13.112Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/device.serial"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [
-                "boiler",
-                "burners",
-                "circuits",
-                "configuration",
-                "dhw",
-                "sensors",
-                "solar"
-            ],
-            "deviceId": "0",
-            "feature": "heating",
-            "gatewayId": "################",
-            "isEnabled": true,
-            "isReady": true,
-            "properties": {},
-            "timestamp": "2021-10-29T15:51:12.503Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating"
+            "timestamp": "2021-12-09T20:39:47.581Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
         },
         {
             "apiVersion": 1,
             "commands": {},
             "components": [],
             "deviceId": "0",
-            "feature": "heating.power.consumption",
+            "feature": "heating.burners.0.modulation",
             "gatewayId": "################",
             "isEnabled": true,
             "isReady": true,
-            "properties": {},
-            "timestamp": "2021-10-29T15:51:12.504Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption"
+            "properties": {
+                "unit": {
+                    "type": "string",
+                    "value": "percent"
+                },
+                "value": {
+                    "type": "number",
+                    "unit": "percent",
+                    "value": 0
+                }
+            },
+            "timestamp": "2021-12-09T20:51:01.120Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners.0.modulation"
         },
         {
             "apiVersion": 1,
             "commands": {},
             "components": [],
             "deviceId": "0",
-            "feature": "heating.circuits.0.circulation",
+            "feature": "heating.dhw.sensors.temperature.outlet",
             "gatewayId": "################",
             "isEnabled": true,
             "isReady": true,
-            "properties": {},
-            "timestamp": "2021-10-29T15:51:12.503Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.circulation"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [
-                "active",
-                "dhw",
-                "dhwAndHeating",
-                "heating",
-                "standby"
-            ],
-            "deviceId": "0",
-            "feature": "heating.circuits.0.operating.modes",
-            "gatewayId": "################",
-            "isEnabled": true,
-            "isReady": true,
-            "properties": {},
-            "timestamp": "2021-10-29T15:51:12.503Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [
-                "active",
-                "noDemand",
-                "normal"
-            ],
-            "deviceId": "0",
-            "feature": "heating.circuits.0.operating.programs",
-            "gatewayId": "################",
-            "isEnabled": true,
-            "isReady": true,
-            "properties": {},
-            "timestamp": "2021-10-29T15:51:12.503Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs"
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "notConnected"
+                },
+                "unit": {
+                    "type": "string",
+                    "value": "celsius"
+                }
+            },
+            "timestamp": "2021-12-09T20:39:45.393Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.outlet"
         },
         {
             "apiVersion": 1,
             "commands": {},
             "components": [],
             "deviceId": "0",
-            "feature": "heating.gas.consumption.summary.heating",
+            "feature": "heating.gas.consumption.summary.dhw",
             "gatewayId": "################",
             "isEnabled": true,
             "isReady": true,
@@ -729,17 +718,17 @@
                 "currentDay": {
                     "type": "number",
                     "unit": "cubicMeter",
-                    "value": 3
+                    "value": 1
                 },
                 "currentMonth": {
                     "type": "number",
                     "unit": "cubicMeter",
-                    "value": 7.7
+                    "value": 13.7
                 },
                 "currentYear": {
                     "type": "number",
                     "unit": "cubicMeter",
-                    "value": 95.7
+                    "value": 270
                 },
                 "lastMonth": {
                     "type": "number",
@@ -749,7 +738,7 @@
                 "lastSevenDays": {
                     "type": "number",
                     "unit": "cubicMeter",
-                    "value": 33.6
+                    "value": 10.4
                 },
                 "lastYear": {
                     "type": "number",
@@ -761,28 +750,279 @@
                     "value": "cubicMeter"
                 }
             },
-            "timestamp": "2021-11-02T14:16:12.207Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.summary.heating"
+            "timestamp": "2021-12-09T20:39:50.252Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.summary.dhw"
         },
         {
             "apiVersion": 1,
             "commands": {},
             "components": [],
             "deviceId": "0",
-            "feature": "heating.circuits.1.temperature",
+            "feature": "heating.dhw.sensors",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2021-12-09T20:39:29.783Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "setTargetTemperature": {
+                    "isExecutable": true,
+                    "name": "setTargetTemperature",
+                    "params": {
+                        "temperature": {
+                            "constraints": {
+                                "efficientLowerBorder": 10,
+                                "efficientUpperBorder": 60,
+                                "max": 60,
+                                "min": 10,
+                                "stepping": 1
+                            },
+                            "required": true,
+                            "type": "number"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
+                }
+            },
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.dhw.temperature.main",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "unit": "celsius",
+                    "value": 40
+                }
+            },
+            "timestamp": "2021-12-09T20:39:47.493Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.circuits.1.operating.modes.dhw",
             "gatewayId": "################",
             "isEnabled": false,
             "isReady": true,
             "properties": {},
-            "timestamp": "2021-10-29T15:51:13.235Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature"
+            "timestamp": "2021-12-09T20:40:00.138Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhw"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [
+                "active",
+                "comfortEnergySaving",
+                "noDemand",
+                "normal",
+                "normalEnergySaving",
+                "reducedEnergySaving"
+            ],
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.programs",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2021-12-09T20:39:29.783Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [
+                "hmiState"
+            ],
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.programs.noDemand",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "timestamp": "2021-12-09T20:50:49.243Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.noDemand"
         },
         {
             "apiVersion": 1,
             "commands": {},
             "components": [],
             "deviceId": "0",
-            "feature": "heating.dhw.sensors.temperature.hotWaterStorage",
+            "feature": "heating.dhw.pumps.primary",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "off"
+                }
+            },
+            "timestamp": "2021-12-09T20:39:47.522Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.primary"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.boiler.sensors",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2021-12-09T20:39:29.783Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.programs.noDemand.hmiState",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "program": {
+                    "type": "string",
+                    "value": "normal"
+                },
+                "temperature": {
+                    "type": "number",
+                    "unit": "celsius",
+                    "value": 45
+                },
+                "unit": {
+                    "type": "string",
+                    "value": "celsius"
+                }
+            },
+            "timestamp": "2021-12-09T20:39:49.807Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.noDemand.hmiState"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.modes.dhwAndHeating",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "timestamp": "2021-12-09T20:39:48.505Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.boiler.serial",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "################"
+                }
+            },
+            "timestamp": "2021-12-09T20:39:53.170Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.power.consumption.summary.heating",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "currentDay": {
+                    "type": "number",
+                    "unit": "kilowattHour",
+                    "value": 0.9
+                },
+                "currentMonth": {
+                    "type": "number",
+                    "unit": "kilowattHour",
+                    "value": 8.2
+                },
+                "currentYear": {
+                    "type": "number",
+                    "unit": "kilowattHour",
+                    "value": 55.5
+                },
+                "lastMonth": {
+                    "type": "number",
+                    "unit": "kilowattHour",
+                    "value": 0
+                },
+                "lastSevenDays": {
+                    "type": "number",
+                    "unit": "kilowattHour",
+                    "value": 6.4
+                },
+                "lastYear": {
+                    "type": "number",
+                    "unit": "kilowattHour",
+                    "value": 0
+                },
+                "unit": {
+                    "type": "string",
+                    "value": "kilowattHour"
+                }
+            },
+            "timestamp": "2021-12-09T20:54:32.928Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.heating"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.modes.dhw",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "timestamp": "2021-12-09T20:39:57.871Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhw"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.boiler.sensors.temperature.commonSupply",
             "gatewayId": "################",
             "isEnabled": true,
             "isReady": true,
@@ -798,72 +1038,93 @@
                 "value": {
                     "type": "number",
                     "unit": "celsius",
-                    "value": 43
+                    "value": 33.1
                 }
             },
-            "timestamp": "2021-11-02T15:38:55.763Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
+            "timestamp": "2021-12-09T20:55:21.037Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
         },
         {
             "apiVersion": 1,
             "commands": {},
-            "components": [],
+            "components": [
+                "modulation",
+                "statistics"
+            ],
             "deviceId": "0",
-            "feature": "heating.circuits.1.operating.modes.dhw",
+            "feature": "heating.burners.0",
             "gatewayId": "################",
-            "isEnabled": false,
+            "isEnabled": true,
             "isReady": true,
-            "properties": {},
-            "timestamp": "2021-10-29T15:51:14.236Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhw"
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "timestamp": "2021-12-09T20:51:10.031Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners.0"
         },
         {
             "apiVersion": 1,
             "commands": {},
             "components": [],
             "deviceId": "0",
-            "feature": "heating.power.consumption.summary.dhw",
+            "feature": "heating.gas.consumption.summary.heating",
             "gatewayId": "################",
             "isEnabled": true,
             "isReady": true,
             "properties": {
                 "currentDay": {
                     "type": "number",
-                    "unit": "kilowattHour",
-                    "value": 0
+                    "unit": "cubicMeter",
+                    "value": 11.2
                 },
                 "currentMonth": {
                     "type": "number",
-                    "unit": "kilowattHour",
-                    "value": 0.1
+                    "unit": "cubicMeter",
+                    "value": 98.5
                 },
                 "currentYear": {
                     "type": "number",
-                    "unit": "kilowattHour",
-                    "value": 1.8
+                    "unit": "cubicMeter",
+                    "value": 434.4
                 },
                 "lastMonth": {
                     "type": "number",
-                    "unit": "kilowattHour",
+                    "unit": "cubicMeter",
                     "value": 0
                 },
                 "lastSevenDays": {
                     "type": "number",
-                    "unit": "kilowattHour",
-                    "value": 0.7
+                    "unit": "cubicMeter",
+                    "value": 77.3
                 },
                 "lastYear": {
                     "type": "number",
-                    "unit": "kilowattHour",
+                    "unit": "cubicMeter",
                     "value": 0
                 },
                 "unit": {
                     "type": "string",
-                    "value": "kilowattHour"
+                    "value": "cubicMeter"
                 }
             },
-            "timestamp": "2021-11-02T15:08:04.370Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.dhw"
+            "timestamp": "2021-12-09T20:40:04.601Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.summary.heating"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.circuits.1.sensors.temperature.supply",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2021-12-09T20:39:50.133Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
         },
         {
             "apiVersion": 1,
@@ -888,39 +1149,57 @@
                     "value": "on"
                 }
             },
-            "timestamp": "2021-10-29T15:51:14.136Z",
+            "timestamp": "2021-12-09T20:39:54.589Z",
             "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw"
         },
         {
             "apiVersion": 1,
             "commands": {},
-            "components": [],
+            "components": [
+                "active",
+                "dhw",
+                "dhwAndHeating",
+                "heating",
+                "standby"
+            ],
             "deviceId": "0",
-            "feature": "heating.boiler.sensors",
+            "feature": "heating.circuits.0.operating.modes",
             "gatewayId": "################",
             "isEnabled": true,
             "isReady": true,
             "properties": {},
-            "timestamp": "2021-10-29T15:51:12.503Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors"
+            "timestamp": "2021-12-09T20:39:29.783Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [
+                "sensors",
+                "serial",
+                "temperature"
+            ],
+            "deviceId": "0",
+            "feature": "heating.boiler",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2021-12-09T20:39:29.783Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler"
         },
         {
             "apiVersion": 1,
             "commands": {},
             "components": [],
             "deviceId": "0",
-            "feature": "heating.circuits.0.operating.modes.dhwAndHeating",
+            "feature": "heating.solar.sensors.temperature.collector",
             "gatewayId": "################",
-            "isEnabled": true,
+            "isEnabled": false,
             "isReady": true,
-            "properties": {
-                "active": {
-                    "type": "boolean",
-                    "value": true
-                }
-            },
-            "timestamp": "2021-10-29T15:51:13.656Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating"
+            "properties": {},
+            "timestamp": "2021-12-09T20:39:51.307Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.collector"
         },
         {
             "apiVersion": 1,
@@ -932,105 +1211,32 @@
             "isEnabled": false,
             "isReady": true,
             "properties": {},
-            "timestamp": "2021-10-29T15:51:13.550Z",
+            "timestamp": "2021-12-09T20:39:47.632Z",
             "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
         },
         {
             "apiVersion": 1,
             "commands": {},
-            "components": [
-                "supply"
-            ],
+            "components": [],
             "deviceId": "0",
-            "feature": "heating.circuits.0.sensors.temperature",
+            "feature": "heating.sensors",
             "gatewayId": "################",
             "isEnabled": true,
             "isReady": true,
             "properties": {},
-            "timestamp": "2021-10-29T15:51:12.504Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [],
-            "deviceId": "0",
-            "feature": "heating.circuits.0.operating.modes.dhw",
-            "gatewayId": "################",
-            "isEnabled": true,
-            "isReady": true,
-            "properties": {
-                "active": {
-                    "type": "boolean",
-                    "value": false
-                }
-            },
-            "timestamp": "2021-10-29T15:51:14.223Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhw"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [
-                "0",
-                "1"
-            ],
-            "deviceId": "0",
-            "feature": "heating.circuits",
-            "gatewayId": "################",
-            "isEnabled": true,
-            "isReady": true,
-            "properties": {
-                "enabled": {
-                    "type": "array",
-                    "value": [
-                        "0"
-                    ]
-                }
-            },
-            "timestamp": "2021-10-29T15:51:13.156Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [
-                "temperature"
-            ],
-            "deviceId": "0",
-            "feature": "heating.solar.sensors",
-            "gatewayId": "################",
-            "isEnabled": true,
-            "isReady": true,
-            "properties": {},
-            "timestamp": "2021-10-29T15:51:12.504Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.sensors"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [],
-            "deviceId": "0",
-            "feature": "heating.circuits.0.operating.programs.active",
-            "gatewayId": "################",
-            "isEnabled": true,
-            "isReady": true,
-            "properties": {
-                "value": {
-                    "type": "string",
-                    "value": "noDemand"
-                }
-            },
-            "timestamp": "2021-11-02T14:47:20.481Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
+            "timestamp": "2021-12-09T20:39:29.783Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors"
         },
         {
             "apiVersion": 1,
             "commands": {},
             "components": [
                 "active",
+                "comfortEnergySaving",
                 "noDemand",
-                "normal"
+                "normal",
+                "normalEnergySaving",
+                "reducedEnergySaving"
             ],
             "deviceId": "0",
             "feature": "heating.circuits.1.operating.programs",
@@ -1038,65 +1244,133 @@
             "isEnabled": true,
             "isReady": true,
             "properties": {},
-            "timestamp": "2021-10-29T15:51:12.503Z",
+            "timestamp": "2021-12-09T20:39:29.783Z",
             "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs"
         },
         {
             "apiVersion": 1,
             "commands": {},
+            "components": [
+                "modes",
+                "programs"
+            ],
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2021-12-09T20:39:29.783Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
             "components": [],
             "deviceId": "0",
-            "feature": "heating.configuration.multiFamilyHouse",
+            "feature": "heating.circuits.1.operating.programs.active",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2021-12-09T20:39:56.969Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.power.consumption",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2021-12-09T20:39:29.783Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.circuits.1.temperature",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2021-12-09T20:39:47.474Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.burners.0.statistics",
             "gatewayId": "################",
             "isEnabled": true,
             "isReady": true,
             "properties": {
-                "active": {
-                    "type": "boolean",
-                    "value": false
+                "hours": {
+                    "type": "number",
+                    "unit": "hour",
+                    "value": 675
+                },
+                "hoursUnit": {
+                    "type": "string",
+                    "value": "hour"
+                },
+                "starts": {
+                    "type": "number",
+                    "unit": "",
+                    "value": 6826
                 }
             },
-            "timestamp": "2021-10-29T15:51:13.674Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.configuration.multiFamilyHouse"
+            "timestamp": "2021-12-09T20:45:42.800Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners.0.statistics"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [
+                "modes",
+                "programs"
+            ],
+            "deviceId": "0",
+            "feature": "heating.circuits.1.operating",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2021-12-09T20:39:29.783Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating"
         },
         {
             "apiVersion": 1,
             "commands": {},
             "components": [],
             "deviceId": "0",
-            "feature": "heating.circuits.1.operating.modes.active",
+            "feature": "heating.dhw.comfort",
             "gatewayId": "################",
             "isEnabled": false,
             "isReady": true,
             "properties": {},
-            "timestamp": "2021-11-02T08:17:10.108Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
+            "timestamp": "2021-12-09T20:39:45.360Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.comfort"
         },
         {
             "apiVersion": 1,
             "commands": {},
             "components": [],
             "deviceId": "0",
-            "feature": "heating.circuits.1.operating.modes.standby",
+            "feature": "heating.dhw.pumps.circulation.schedule",
             "gatewayId": "################",
             "isEnabled": false,
             "isReady": true,
             "properties": {},
-            "timestamp": "2021-10-29T15:51:13.649Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [],
-            "deviceId": "0",
-            "feature": "heating.circuits.1.sensors.temperature.supply",
-            "gatewayId": "################",
-            "isEnabled": false,
-            "isReady": true,
-            "properties": {},
-            "timestamp": "2021-10-29T15:51:13.683Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
+            "timestamp": "2021-12-09T20:39:54.650Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
         },
         {
             "apiVersion": 1,
@@ -1119,11 +1393,32 @@
                 "value": {
                     "type": "number",
                     "unit": "celsius",
-                    "value": 65.7
+                    "value": 33.2
                 }
             },
-            "timestamp": "2021-11-02T15:38:58.704Z",
+            "timestamp": "2021-12-09T20:55:19.921Z",
             "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [
+                "boiler",
+                "burners",
+                "circuits",
+                "configuration",
+                "dhw",
+                "sensors",
+                "solar"
+            ],
+            "deviceId": "0",
+            "feature": "heating",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2021-12-09T20:39:29.783Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating"
         },
         {
             "apiVersion": 1,
@@ -1135,23 +1430,51 @@
             "isEnabled": false,
             "isReady": true,
             "properties": {},
-            "timestamp": "2021-10-29T15:51:13.666Z",
+            "timestamp": "2021-12-09T20:39:49.157Z",
             "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
         },
         {
             "apiVersion": 1,
             "commands": {},
             "components": [
-                "main"
+                "multiFamilyHouse"
             ],
             "deviceId": "0",
-            "feature": "heating.dhw.temperature",
+            "feature": "heating.configuration",
             "gatewayId": "################",
             "isEnabled": true,
             "isReady": true,
             "properties": {},
-            "timestamp": "2021-10-29T15:51:12.503Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature"
+            "timestamp": "2021-12-09T20:39:29.783Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.configuration"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [
+                "supply"
+            ],
+            "deviceId": "0",
+            "feature": "heating.circuits.1.sensors.temperature",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2021-12-09T20:39:29.783Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.circuits.1.operating.programs.normal",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2021-12-09T20:39:57.350Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal"
         },
         {
             "apiVersion": 1,
@@ -1165,8 +1488,49 @@
             "isEnabled": true,
             "isReady": true,
             "properties": {},
-            "timestamp": "2021-10-29T15:51:12.503Z",
+            "timestamp": "2021-12-09T20:39:29.783Z",
             "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.programs.normalEnergySaving",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                },
+                "demand": {
+                    "type": "string",
+                    "value": "heating"
+                },
+                "reason": {
+                    "type": "string",
+                    "value": "noDemand"
+                }
+            },
+            "timestamp": "2021-12-09T20:50:49.110Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalEnergySaving"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [
+                "temperature"
+            ],
+            "deviceId": "0",
+            "feature": "heating.circuits.1.sensors",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2021-12-09T20:39:29.783Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors"
         },
         {
             "apiVersion": 1,
@@ -1183,280 +1547,119 @@
                     "value": false
                 }
             },
-            "timestamp": "2021-10-29T15:51:13.663Z",
+            "timestamp": "2021-12-09T20:39:48.982Z",
             "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
         },
         {
             "apiVersion": 1,
             "commands": {},
-            "components": [
-                "temperature"
-            ],
+            "components": [],
             "deviceId": "0",
-            "feature": "heating.circuits.0.sensors",
+            "feature": "heating.circuits.1.operating.modes.active",
             "gatewayId": "################",
-            "isEnabled": true,
+            "isEnabled": false,
             "isReady": true,
             "properties": {},
-            "timestamp": "2021-10-29T15:51:12.504Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors"
+            "timestamp": "2021-12-09T20:40:00.165Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
         },
         {
             "apiVersion": 1,
-            "commands": {},
+            "commands": {
+                "setMode": {
+                    "isExecutable": true,
+                    "name": "setMode",
+                    "params": {
+                        "mode": {
+                            "constraints": {
+                                "enum": [
+                                    "standby",
+                                    "heating",
+                                    "dhw",
+                                    "dhwAndHeating"
+                                ]
+                            },
+                            "required": true,
+                            "type": "string"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
+                }
+            },
             "components": [],
             "deviceId": "0",
-            "feature": "heating.boiler.serial",
+            "feature": "heating.circuits.0.operating.modes.active",
             "gatewayId": "################",
             "isEnabled": true,
             "isReady": true,
             "properties": {
                 "value": {
                     "type": "string",
-                    "value": "################"
+                    "value": "dhwAndHeating"
                 }
             },
-            "timestamp": "2021-10-29T15:51:13.718Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
+            "timestamp": "2021-12-09T20:39:57.928Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
         },
         {
             "apiVersion": 1,
             "commands": {},
             "components": [],
             "deviceId": "0",
-            "feature": "heating.dhw.pumps.secondary",
+            "feature": "heating.circuits.1.operating.modes.standby",
             "gatewayId": "################",
             "isEnabled": false,
             "isReady": true,
             "properties": {},
-            "timestamp": "2021-10-29T15:51:13.360Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.secondary"
+            "timestamp": "2021-12-09T20:39:48.027Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
         },
         {
             "apiVersion": 1,
-            "commands": {},
-            "components": [
-                "schedule"
-            ],
-            "deviceId": "0",
-            "feature": "heating.dhw.pumps.circulation",
-            "gatewayId": "################",
-            "isEnabled": false,
-            "isReady": true,
-            "properties": {},
-            "timestamp": "2021-10-29T15:51:13.897Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
+            "commands": {
+                "setName": {
+                    "isExecutable": true,
+                    "name": "setName",
+                    "params": {
+                        "name": {
+                            "constraints": {
+                                "maxLength": 20,
+                                "minLength": 1
+                            },
+                            "required": true,
+                            "type": "string"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name/commands/setName"
+                }
+            },
             "components": [],
             "deviceId": "0",
-            "feature": "heating.circuits.1.operating.programs.noDemand.hmiState",
-            "gatewayId": "################",
-            "isEnabled": false,
-            "isReady": true,
-            "properties": {},
-            "timestamp": "2021-10-29T15:51:13.672Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.noDemand.hmiState"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [],
-            "deviceId": "0",
-            "feature": "heating.circuits.0.temperature",
+            "feature": "heating.circuits.0.name",
             "gatewayId": "################",
             "isEnabled": true,
             "isReady": true,
             "properties": {
-                "value": {
-                    "type": "number",
-                    "unit": "",
-                    "value": 0
-                }
-            },
-            "timestamp": "2021-11-02T14:47:22.604Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [
-                "multiFamilyHouse"
-            ],
-            "deviceId": "0",
-            "feature": "heating.configuration",
-            "gatewayId": "################",
-            "isEnabled": true,
-            "isReady": true,
-            "properties": {},
-            "timestamp": "2021-10-29T15:51:12.504Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.configuration"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [],
-            "deviceId": "0",
-            "feature": "heating.power.consumption.summary.heating",
-            "gatewayId": "################",
-            "isEnabled": true,
-            "isReady": true,
-            "properties": {
-                "currentDay": {
-                    "type": "number",
-                    "unit": "kilowattHour",
-                    "value": 0.2
-                },
-                "currentMonth": {
-                    "type": "number",
-                    "unit": "kilowattHour",
-                    "value": 0.5
-                },
-                "currentYear": {
-                    "type": "number",
-                    "unit": "kilowattHour",
-                    "value": 6.8
-                },
-                "lastMonth": {
-                    "type": "number",
-                    "unit": "kilowattHour",
-                    "value": 0
-                },
-                "lastSevenDays": {
-                    "type": "number",
-                    "unit": "kilowattHour",
-                    "value": 2.3
-                },
-                "lastYear": {
-                    "type": "number",
-                    "unit": "kilowattHour",
-                    "value": 0
-                },
-                "unit": {
+                "name": {
                     "type": "string",
-                    "value": "kilowattHour"
+                    "value": ""
                 }
             },
-            "timestamp": "2021-11-02T14:41:22.729Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.heating"
+            "timestamp": "2021-12-09T20:39:44.438Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name"
         },
         {
             "apiVersion": 1,
             "commands": {},
             "components": [],
             "deviceId": "0",
-            "feature": "heating.dhw.sensors.temperature.outlet",
-            "gatewayId": "################",
-            "isEnabled": true,
-            "isReady": true,
-            "properties": {
-                "status": {
-                    "type": "string",
-                    "value": "notConnected"
-                },
-                "unit": {
-                    "type": "string",
-                    "value": "celsius"
-                }
-            },
-            "timestamp": "2021-10-29T15:51:13.173Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.outlet"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [
-                "sensors"
-            ],
-            "deviceId": "0",
-            "feature": "heating.solar",
+            "feature": "heating.circuits.1.name",
             "gatewayId": "################",
             "isEnabled": false,
             "isReady": true,
             "properties": {},
-            "timestamp": "2021-10-29T15:51:13.694Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [
-                "collector",
-                "dhw"
-            ],
-            "deviceId": "0",
-            "feature": "heating.solar.sensors.temperature",
-            "gatewayId": "################",
-            "isEnabled": true,
-            "isReady": true,
-            "properties": {},
-            "timestamp": "2021-10-29T15:51:12.504Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [
-                "sensors",
-                "serial",
-                "temperature"
-            ],
-            "deviceId": "0",
-            "feature": "heating.boiler",
-            "gatewayId": "################",
-            "isEnabled": true,
-            "isReady": true,
-            "properties": {},
-            "timestamp": "2021-10-29T15:51:12.503Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [],
-            "deviceId": "0",
-            "feature": "heating.circuits.1.operating.programs.active",
-            "gatewayId": "################",
-            "isEnabled": false,
-            "isReady": true,
-            "properties": {},
-            "timestamp": "2021-10-29T15:51:14.213Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [],
-            "deviceId": "0",
-            "feature": "heating.dhw.comfort",
-            "gatewayId": "################",
-            "isEnabled": false,
-            "isReady": true,
-            "properties": {},
-            "timestamp": "2021-10-29T15:51:13.171Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.comfort"
-        },
-        {
-            "apiVersion": 1,
-            "commands": {},
-            "components": [
-                "modulation"
-            ],
-            "deviceId": "0",
-            "feature": "heating.burners.0",
-            "gatewayId": "################",
-            "isEnabled": true,
-            "isReady": true,
-            "properties": {
-                "active": {
-                    "type": "boolean",
-                    "value": true
-                }
-            },
-            "timestamp": "2021-11-02T15:35:23.273Z",
-            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners.0"
+            "timestamp": "2021-11-29T14:55:09.761Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.name"
         }
     ]
 }

--- a/tests/test_TestForMissingProperties.py
+++ b/tests/test_TestForMissingProperties.py
@@ -44,7 +44,10 @@ class TestForMissingProperties(unittest.TestCase):
             'ventilation.operating.modes.standard',
             'ventilation.operating.modes.ventilation',
 
-            'heating.circuits.0.heating.roomInfluenceFactor'
+            'heating.circuits.0.heating.roomInfluenceFactor',
+            'heating.circuits.0.temperature', # TODO: to analyse, from Vitodens 100W 
+            'heating.circuits.0.operating.programs.noDemand.hmiState', # TODO: to analyse, from Vitodens 100W
+            'heating.circuits.0.name' # TODO: to analyse, from Vitodens 100W
         ]
 
         all_features = self.read_all_features()

--- a/tests/test_Vitodens100W.py
+++ b/tests/test_Vitodens100W.py
@@ -1,0 +1,35 @@
+import unittest
+
+from PyViCare.PyViCareGazBoiler import GazBoiler
+from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
+from tests.ViCareServiceMock import ViCareServiceMock
+
+
+class Vitodens100W(unittest.TestCase):
+    def setUp(self):
+        self.service = ViCareServiceMock('response/Vitodens100W.json')
+        self.device = GazBoiler(self.service)
+
+    def test_getActive(self):
+        self.assertEqual(self.device.burners[0].getActive(), False)
+
+    def test_getBurnerStarts(self):
+        self.assertEqual(self.device.burners[0].getStarts(), 6826)
+
+    def test_getBurnerHours(self):
+        self.assertEqual(self.device.burners[0].getHours(), 675)
+
+    def test_getBurnerModulation(self):
+        self.assertEqual(self.device.burners[0].getModulation(), 0)
+
+    def test_getGasSummaryConsumptionHeatingCurrentDay(self):
+        self.assertEqual(self.device.getGasSummaryConsumptionHeatingCurrentDay(), 11.2)
+
+    def test_getGasSummaryConsumptionDomesticHotWaterCurrentMonth(self):
+        self.assertEqual(self.device.getGasSummaryConsumptionDomesticHotWaterCurrentMonth(), 13.7)
+
+    def test_getPowerSummaryConsumptionHeatingCurrentDay(self):
+        self.assertEqual(self.device.getPowerSummaryConsumptionHeatingCurrentDay(), 0.9)
+
+    def test_getPowerSummaryConsumptionDomesticHotWaterCurrentYear(self):
+        self.assertEqual(self.device.getPowerSummaryConsumptionDomesticHotWaterCurrentYear(), 18)


### PR DESCRIPTION
I checked with new Vitodens-100W json dump, added new methods for gas/power consumption and added some simple tests for Vitodens-100W. I'm not sure if that should be done this way but IMO with new API methods its the only way.