### PR TITLE
fix: access unit via new fields

### DIFF
--- a/PyViCare/PyViCareDevice.py
+++ b/PyViCare/PyViCareDevice.py
@@ -224,7 +224,7 @@ class Device:
 
     @handleNotSupported
     def getSolarPowerProductionUnit(self):
-        return self.service.getProperty("heating.solar.power.production")["properties"]["unit"]["value"]
+        return self.service.getProperty("heating.solar.power.production")["properties"]["value"]["unit"]
 
     @handleNotSupported
     def getSolarPowerProductionDays(self):

--- a/PyViCare/PyViCareFuelCell.py
+++ b/PyViCare/PyViCareFuelCell.py
@@ -24,7 +24,7 @@ class FuelCell(Device):
 
     @handleNotSupported
     def getPowerConsumptionUnit(self):
-        return self.service.getProperty("heating.power.consumption.total")["properties"]["unit"]["value"]
+        return self.service.getProperty("heating.power.consumption.total")["properties"]["value"]["unit"]
 
     @handleNotSupported
     def getPowerConsumptionDays(self):
@@ -60,7 +60,7 @@ class FuelCell(Device):
 
     @handleNotSupported
     def getPowerConsumptionHeatingUnit(self):
-        return self.service.getProperty("heating.power.consumption.heating")["properties"]["unit"]["value"]
+        return self.service.getProperty("heating.power.consumption.heating")["properties"]["value"]["unit"]
 
     @handleNotSupported
     def getPowerConsumptionHeatingDays(self):
@@ -96,7 +96,7 @@ class FuelCell(Device):
 
     @handleNotSupported
     def getGasConsumptionUnit(self):
-        return self.service.getProperty("heating.gas.consumption.total")["properties"]["unit"]["value"]
+        return self.service.getProperty("heating.gas.consumption.total")["properties"]["value"]["unit"]
 
     @handleNotSupported
     def getGasConsumptionTotalDays(self):

--- a/PyViCare/PyViCareGazBoiler.py
+++ b/PyViCare/PyViCareGazBoiler.py
@@ -20,7 +20,7 @@ class GazBoiler(Device):
 
     @handleNotSupported
     def getGasConsumptionHeatingUnit(self):
-        return self.service.getProperty("heating.gas.consumption.heating")["properties"]["unit"]["value"]
+        return self.service.getProperty("heating.gas.consumption.heating")["properties"]["value"]["unit"]
 
     @handleNotSupported
     def getGasConsumptionHeatingDays(self):
@@ -56,7 +56,7 @@ class GazBoiler(Device):
 
     @handleNotSupported
     def getGasConsumptionDomesticHotWaterUnit(self):
-        return self.service.getProperty("heating.gas.consumption.dhw")["properties"]["unit"]["value"]
+        return self.service.getProperty("heating.gas.consumption.dhw")["properties"]["value"]["unit"]
 
     @handleNotSupported
     def getGasConsumptionDomesticHotWaterDays(self):
@@ -104,7 +104,7 @@ class GazBoiler(Device):
 
     @handleNotSupported
     def getPowerConsumptionUnit(self):
-        return self.service.getProperty("heating.power.consumption.total")["properties"]["unit"]["value"]
+        return self.service.getProperty("heating.power.consumption.total")["properties"]["value"]["unit"]
 
     @handleNotSupported
     def getPowerConsumptionDays(self):
@@ -142,7 +142,7 @@ class GazBoiler(Device):
     # Gas consumption for Heating data:
     @handleNotSupported
     def getGasSummaryConsumptionHeatingUnit(self):
-        return self.service.getProperty("heating.gas.consumption.summary.heating")["properties"]["unit"]["value"]
+        return self.service.getProperty("heating.gas.consumption.summary.heating")["properties"]["value"]["unit"]
 
     @handleNotSupported
     def getGasSummaryConsumptionHeatingCurrentDay(self):
@@ -171,7 +171,7 @@ class GazBoiler(Device):
     # Gas consumption for Domestic Hot Water data:
     @handleNotSupported
     def getGasSummaryConsumptionDomesticHotWaterUnit(self):
-        return self.service.getProperty("heating.gas.consumption.summary.dhw")["properties"]["unit"]["value"]
+        return self.service.getProperty("heating.gas.consumption.summary.dhw")["properties"]["value"]["unit"]
 
     @handleNotSupported
     def getGasSummaryConsumptionDomesticHotWaterCurrentDay(self):
@@ -200,7 +200,7 @@ class GazBoiler(Device):
     # Power consumption for Heating:
     @handleNotSupported
     def getPowerSummaryConsumptionHeatingUnit(self):
-        return self.service.getProperty("heating.power.consumption.summary.heating")["properties"]["unit"]["value"]
+        return self.service.getProperty("heating.power.consumption.summary.heating")["properties"]["value"]["unit"]
 
     @handleNotSupported
     def getPowerSummaryConsumptionHeatingCurrentDay(self):
@@ -229,7 +229,7 @@ class GazBoiler(Device):
     # Power consumption for Domestic Hot Water:
     @handleNotSupported
     def getPowerSummaryConsumptionDomesticHotWaterUnit(self):
-        return self.service.getProperty("heating.power.consumption.summary.dhw")["properties"]["unit"]["value"]
+        return self.service.getProperty("heating.power.consumption.summary.dhw")["properties"]["value"]["unit"]
 
     @handleNotSupported
     def getPowerSummaryConsumptionDomesticHotWaterCurrentDay(self):


### PR DESCRIPTION
Fixes:

> Removal of standalone "unit"-properties
> The next step will be the removal of the standalone-properties named "unit" or the like. The properties are replaced by inline-> fields of the actual value-property. This means you will still have the “unit”  information available in the features.