### PR TITLE
fix: access unit from latest day

### DIFF
--- a/PyViCare/PyViCareDevice.py
+++ b/PyViCare/PyViCareDevice.py
@@ -224,7 +224,7 @@ class Device:
 
     @handleNotSupported
     def getSolarPowerProductionUnit(self):
-        return self.service.getProperty("heating.solar.power.production")["properties"]["unit"]["value"]
+        return self.service.getProperty("heating.solar.power.production")["properties"]["day"]["unit"]
 
     @handleNotSupported
     def getSolarPowerProductionDays(self):

--- a/PyViCare/PyViCareFuelCell.py
+++ b/PyViCare/PyViCareFuelCell.py
@@ -24,7 +24,7 @@ class FuelCell(Device):
 
     @handleNotSupported
     def getPowerConsumptionUnit(self):
-        return self.service.getProperty("heating.power.consumption.total")["properties"]["unit"]["value"]
+        return self.service.getProperty("heating.power.consumption.total")["properties"]["day"]["unit"]
 
     @handleNotSupported
     def getPowerConsumptionDays(self):
@@ -60,7 +60,7 @@ class FuelCell(Device):
 
     @handleNotSupported
     def getPowerConsumptionHeatingUnit(self):
-        return self.service.getProperty("heating.power.consumption.heating")["properties"]["unit"]["value"]
+        return self.service.getProperty("heating.power.consumption.heating")["properties"]["day"]["unit"]
 
     @handleNotSupported
     def getPowerConsumptionHeatingDays(self):
@@ -96,7 +96,7 @@ class FuelCell(Device):
 
     @handleNotSupported
     def getGasConsumptionUnit(self):
-        return self.service.getProperty("heating.gas.consumption.total")["properties"]["unit"]["value"]
+        return self.service.getProperty("heating.gas.consumption.total")["properties"]["day"]["unit"]
 
     @handleNotSupported
     def getGasConsumptionTotalDays(self):

--- a/PyViCare/PyViCareGazBoiler.py
+++ b/PyViCare/PyViCareGazBoiler.py
@@ -20,7 +20,7 @@ class GazBoiler(Device):
 
     @handleNotSupported
     def getGasConsumptionHeatingUnit(self):
-        return self.service.getProperty("heating.gas.consumption.heating")["properties"]["unit"]["value"]
+        return self.service.getProperty("heating.gas.consumption.heating")["properties"]["day"]["unit"]
 
     @handleNotSupported
     def getGasConsumptionHeatingDays(self):
@@ -56,7 +56,7 @@ class GazBoiler(Device):
 
     @handleNotSupported
     def getGasConsumptionDomesticHotWaterUnit(self):
-        return self.service.getProperty("heating.gas.consumption.dhw")["properties"]["unit"]["value"]
+        return self.service.getProperty("heating.gas.consumption.dhw")["properties"]["day"]["unit"]
 
     @handleNotSupported
     def getGasConsumptionDomesticHotWaterDays(self):
@@ -104,7 +104,7 @@ class GazBoiler(Device):
 
     @handleNotSupported
     def getPowerConsumptionUnit(self):
-        return self.service.getProperty("heating.power.consumption.total")["properties"]["unit"]["value"]
+        return self.service.getProperty("heating.power.consumption.total")["properties"]["day"]["unit"]
 
     @handleNotSupported
     def getPowerConsumptionDays(self):
@@ -142,7 +142,7 @@ class GazBoiler(Device):
     # Gas consumption for Heating data:
     @handleNotSupported
     def getGasSummaryConsumptionHeatingUnit(self):
-        return self.service.getProperty("heating.gas.consumption.summary.heating")["properties"]["unit"]["value"]
+        return self.service.getProperty("heating.gas.consumption.summary.heating")["properties"]["day"]["unit"]
 
     @handleNotSupported
     def getGasSummaryConsumptionHeatingCurrentDay(self):
@@ -171,7 +171,7 @@ class GazBoiler(Device):
     # Gas consumption for Domestic Hot Water data:
     @handleNotSupported
     def getGasSummaryConsumptionDomesticHotWaterUnit(self):
-        return self.service.getProperty("heating.gas.consumption.summary.dhw")["properties"]["unit"]["value"]
+        return self.service.getProperty("heating.gas.consumption.summary.dhw")["properties"]["day"]["unit"]
 
     @handleNotSupported
     def getGasSummaryConsumptionDomesticHotWaterCurrentDay(self):
@@ -200,7 +200,7 @@ class GazBoiler(Device):
     # Power consumption for Heating:
     @handleNotSupported
     def getPowerSummaryConsumptionHeatingUnit(self):
-        return self.service.getProperty("heating.power.consumption.summary.heating")["properties"]["unit"]["value"]
+        return self.service.getProperty("heating.power.consumption.summary.heating")["properties"]["day"]["unit"]
 
     @handleNotSupported
     def getPowerSummaryConsumptionHeatingCurrentDay(self):
@@ -229,7 +229,7 @@ class GazBoiler(Device):
     # Power consumption for Domestic Hot Water:
     @handleNotSupported
     def getPowerSummaryConsumptionDomesticHotWaterUnit(self):
-        return self.service.getProperty("heating.power.consumption.summary.dhw")["properties"]["unit"]["value"]
+        return self.service.getProperty("heating.power.consumption.summary.dhw")["properties"]["day"]["unit"]
 
     @handleNotSupported
     def getPowerSummaryConsumptionDomesticHotWaterCurrentDay(self):

--- a/tests/response/Vitodens200W_2.json
+++ b/tests/response/Vitodens200W_2.json
@@ -1,0 +1,2917 @@
+{
+    "data": [
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.0.circulation.pump",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "off"
+                }
+            },
+            "timestamp": "2022-09-02T08:10:49.438Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.circulation.pump"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.programs.external",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                },
+                "temperature": {
+                    "type": "number",
+                    "unit": "",
+                    "value": 0
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.external"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.1.operating.modes.standby",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.2.operating.programs.comfort",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfort"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.dhw.sensors.temperature.outlet",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "error"
+                }
+            },
+            "timestamp": "2022-09-02T08:10:49.415Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.sensors.temperature.outlet"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "setTargetTemperature": {
+                    "isExecutable": true,
+                    "name": "setTargetTemperature",
+                    "params": {
+                        "temperature": {
+                            "constraints": {
+                                "efficientLowerBorder": 10,
+                                "efficientUpperBorder": 60,
+                                "max": 60,
+                                "min": 10,
+                                "stepping": 1
+                            },
+                            "required": true,
+                            "type": "number"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
+                }
+            },
+            "deviceId": "0",
+            "feature": "heating.dhw.temperature.main",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "unit": "celsius",
+                    "value": 55
+                }
+            },
+            "timestamp": "2022-09-02T08:10:36.304Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.temperature.main"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.2.operating.modes.standby",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.1.sensors.temperature.supply",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                },
+                "value": {
+                    "type": "number",
+                    "unit": "celsius",
+                    "value": 27
+                }
+            },
+            "timestamp": "2022-09-03T15:58:35.610Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.2.operating.programs.standby",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.1.operating.modes.dhw",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhw"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "activate": {
+                    "isExecutable": false,
+                    "name": "activate",
+                    "params": {},
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.eco/commands/activate"
+                },
+                "deactivate": {
+                    "isExecutable": false,
+                    "name": "deactivate",
+                    "params": {},
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.eco/commands/deactivate"
+                }
+            },
+            "deviceId": "0",
+            "feature": "heating.circuits.1.operating.programs.eco",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                },
+                "temperature": {
+                    "type": "number",
+                    "unit": "",
+                    "value": 21
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.eco"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "setSchedule": {
+                    "isExecutable": true,
+                    "name": "setSchedule",
+                    "params": {
+                        "newSchedule": {
+                            "constraints": {
+                                "defaultMode": "off",
+                                "maxEntries": 4,
+                                "modes": [
+                                    "on"
+                                ],
+                                "overlapAllowed": true,
+                                "resolution": 10
+                            },
+                            "required": true,
+                            "type": "Schedule"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule"
+                }
+            },
+            "deviceId": "0",
+            "feature": "heating.dhw.schedule",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                },
+                "entries": {
+                    "type": "Schedule",
+                    "value": {
+                        "fri": [
+                            {
+                                "end": "23:30",
+                                "mode": "on",
+                                "position": 0,
+                                "start": "05:30"
+                            }
+                        ],
+                        "mon": [
+                            {
+                                "end": "23:30",
+                                "mode": "on",
+                                "position": 0,
+                                "start": "05:30"
+                            }
+                        ],
+                        "sat": [
+                            {
+                                "end": "23:30",
+                                "mode": "on",
+                                "position": 0,
+                                "start": "06:30"
+                            }
+                        ],
+                        "sun": [
+                            {
+                                "end": "23:30",
+                                "mode": "on",
+                                "position": 0,
+                                "start": "06:30"
+                            }
+                        ],
+                        "thu": [
+                            {
+                                "end": "23:30",
+                                "mode": "on",
+                                "position": 0,
+                                "start": "05:30"
+                            }
+                        ],
+                        "tue": [
+                            {
+                                "end": "23:30",
+                                "mode": "on",
+                                "position": 0,
+                                "start": "05:30"
+                            }
+                        ],
+                        "wed": [
+                            {
+                                "end": "23:30",
+                                "mode": "on",
+                                "position": 0,
+                                "start": "05:30"
+                            }
+                        ]
+                    }
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.schedule"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.2.sensors.temperature.room",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:48.082Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "activate": {
+                    "isExecutable": true,
+                    "name": "activate",
+                    "params": {},
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/activate"
+                },
+                "deactivate": {
+                    "isExecutable": false,
+                    "name": "deactivate",
+                    "params": {},
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate"
+                }
+            },
+            "deviceId": "0",
+            "feature": "heating.dhw.oneTimeCharge",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.oneTimeCharge"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.solar.power.production",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:49.284Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.solar.power.production"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.1.sensors.temperature.room",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:48.010Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.solar.sensors.temperature.collector",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:51.131Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.solar.sensors.temperature.collector"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.solar",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:51.113Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.solar"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "setTemperature": {
+                    "isExecutable": true,
+                    "name": "setTemperature",
+                    "params": {
+                        "targetTemperature": {
+                            "constraints": {
+                                "max": 37,
+                                "min": 3,
+                                "stepping": 1
+                            },
+                            "required": true,
+                            "type": "number"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced/commands/setTemperature"
+                }
+            },
+            "deviceId": "0",
+            "feature": "heating.circuits.1.operating.programs.reduced",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                },
+                "demand": {
+                    "type": "string",
+                    "value": "unknown"
+                },
+                "temperature": {
+                    "type": "number",
+                    "unit": "celsius",
+                    "value": 17
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.1.operating.programs.active",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "standby"
+                }
+            },
+            "timestamp": "2022-09-02T08:10:49.546Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.burners.0.modulation",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "unit": "percent",
+                    "value": 0
+                }
+            },
+            "timestamp": "2022-09-03T19:44:10.532Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.burners.0.modulation"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.2.heating.schedule",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.heating.schedule"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.0.sensors.temperature.supply",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                },
+                "value": {
+                    "type": "number",
+                    "unit": "celsius",
+                    "value": 66
+                }
+            },
+            "timestamp": "2022-09-03T20:33:37.533Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.dhw.charging",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "timestamp": "2022-09-03T19:44:23.356Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.charging"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.2.operating.programs.eco",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.programs.eco"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "activate": {
+                    "isExecutable": true,
+                    "name": "activate",
+                    "params": {
+                        "temperature": {
+                            "constraints": {
+                                "max": 37,
+                                "min": 4,
+                                "stepping": 1
+                            },
+                            "required": false,
+                            "type": "number"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/activate"
+                },
+                "deactivate": {
+                    "isExecutable": false,
+                    "name": "deactivate",
+                    "params": {},
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/deactivate"
+                },
+                "setTemperature": {
+                    "isExecutable": true,
+                    "name": "setTemperature",
+                    "params": {
+                        "targetTemperature": {
+                            "constraints": {
+                                "max": 37,
+                                "min": 4,
+                                "stepping": 1
+                            },
+                            "required": true,
+                            "type": "number"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/setTemperature"
+                }
+            },
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.programs.comfort",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                },
+                "demand": {
+                    "type": "string",
+                    "value": "unknown"
+                },
+                "temperature": {
+                    "type": "number",
+                    "unit": "celsius",
+                    "value": 22
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.2.frostprotection",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:37.019Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.frostprotection"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.1.operating.modes.dhwAndHeating",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "setCurve": {
+                    "isExecutable": true,
+                    "name": "setCurve",
+                    "params": {
+                        "shift": {
+                            "constraints": {
+                                "max": 40,
+                                "min": -13,
+                                "stepping": 1
+                            },
+                            "required": true,
+                            "type": "number"
+                        },
+                        "slope": {
+                            "constraints": {
+                                "max": 3.5,
+                                "min": 0.2,
+                                "stepping": 0.1
+                            },
+                            "required": true,
+                            "type": "number"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.heating.curve/commands/setCurve"
+                }
+            },
+            "deviceId": "0",
+            "feature": "heating.circuits.1.heating.curve",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "shift": {
+                    "type": "number",
+                    "unit": "",
+                    "value": 2
+                },
+                "slope": {
+                    "type": "number",
+                    "unit": "",
+                    "value": 0.6
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.heating.curve"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.2.operating.programs.active",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:49.574Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.2.operating.modes.active",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:50.328Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.2.sensors.temperature.supply",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:48.738Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "setSchedule": {
+                    "isExecutable": true,
+                    "name": "setSchedule",
+                    "params": {
+                        "newSchedule": {
+                            "constraints": {
+                                "defaultMode": "reduced",
+                                "maxEntries": 4,
+                                "modes": [
+                                    "normal"
+                                ],
+                                "overlapAllowed": true,
+                                "resolution": 10
+                            },
+                            "required": true,
+                            "type": "Schedule"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.heating.schedule/commands/setSchedule"
+                }
+            },
+            "deviceId": "0",
+            "feature": "heating.circuits.1.heating.schedule",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                },
+                "entries": {
+                    "type": "Schedule",
+                    "value": {
+                        "fri": [
+                            {
+                                "end": "23:30",
+                                "mode": "normal",
+                                "position": 0,
+                                "start": "05:00"
+                            }
+                        ],
+                        "mon": [
+                            {
+                                "end": "23:30",
+                                "mode": "normal",
+                                "position": 0,
+                                "start": "05:00"
+                            }
+                        ],
+                        "sat": [
+                            {
+                                "end": "23:30",
+                                "mode": "normal",
+                                "position": 0,
+                                "start": "07:00"
+                            }
+                        ],
+                        "sun": [
+                            {
+                                "end": "23:30",
+                                "mode": "normal",
+                                "position": 0,
+                                "start": "07:00"
+                            }
+                        ],
+                        "thu": [
+                            {
+                                "end": "23:30",
+                                "mode": "normal",
+                                "position": 0,
+                                "start": "05:00"
+                            }
+                        ],
+                        "tue": [
+                            {
+                                "end": "23:30",
+                                "mode": "normal",
+                                "position": 0,
+                                "start": "05:00"
+                            }
+                        ],
+                        "wed": [
+                            {
+                                "end": "23:30",
+                                "mode": "normal",
+                                "position": 0,
+                                "start": "05:00"
+                            }
+                        ]
+                    }
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.heating.schedule"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.gas.consumption.heating",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "day": {
+                    "type": "array",
+                    "unit": "kilowattHour",
+                    "value": [
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0
+                    ]
+                },
+                "dayValueReadAt": {
+                    "type": "string",
+                    "value": "2022-08-25T03:24:25.051Z"
+                },
+                "month": {
+                    "type": "array",
+                    "unit": "kilowattHour",
+                    "value": [
+                        0,
+                        0,
+                        12,
+                        93,
+                        406,
+                        1911,
+                        2564,
+                        3069,
+                        3690,
+                        3945,
+                        2951,
+                        1648,
+                        450
+                    ]
+                },
+                "monthValueReadAt": {
+                    "type": "string",
+                    "value": "2022-09-01T15:24:42.780Z"
+                },
+                "week": {
+                    "type": "array",
+                    "unit": "kilowattHour",
+                    "value": [
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        2,
+                        9,
+                        2,
+                        8,
+                        15,
+                        15,
+                        113,
+                        75,
+                        16,
+                        31,
+                        182,
+                        309,
+                        300,
+                        349,
+                        639,
+                        619,
+                        318,
+                        599,
+                        677,
+                        837,
+                        744,
+                        683,
+                        789,
+                        844,
+                        867,
+                        884,
+                        857,
+                        841,
+                        668,
+                        1145,
+                        662,
+                        956,
+                        894,
+                        806,
+                        669,
+                        627,
+                        590,
+                        408,
+                        418,
+                        458,
+                        293,
+                        156,
+                        165,
+                        95,
+                        46,
+                        82
+                    ]
+                },
+                "weekValueReadAt": {
+                    "type": "string",
+                    "value": "2022-08-29T07:24:31.807Z"
+                },
+                "year": {
+                    "type": "array",
+                    "unit": "kilowattHour",
+                    "value": [
+                        11745,
+                        25945,
+                        22600
+                    ]
+                },
+                "yearValueReadAt": {
+                    "type": "string",
+                    "value": "2022-08-25T03:24:26.002Z"
+                }
+            },
+            "timestamp": "2022-09-02T08:10:49.041Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.gas.consumption.heating"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "activate": {
+                    "isExecutable": true,
+                    "name": "activate",
+                    "params": {
+                        "temperature": {
+                            "constraints": {
+                                "max": 37,
+                                "min": 4,
+                                "stepping": 1
+                            },
+                            "required": false,
+                            "type": "number"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort/commands/activate"
+                },
+                "deactivate": {
+                    "isExecutable": false,
+                    "name": "deactivate",
+                    "params": {},
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort/commands/deactivate"
+                },
+                "setTemperature": {
+                    "isExecutable": true,
+                    "name": "setTemperature",
+                    "params": {
+                        "targetTemperature": {
+                            "constraints": {
+                                "max": 37,
+                                "min": 4,
+                                "stepping": 1
+                            },
+                            "required": true,
+                            "type": "number"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort/commands/setTemperature"
+                }
+            },
+            "deviceId": "0",
+            "feature": "heating.circuits.1.operating.programs.comfort",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                },
+                "demand": {
+                    "type": "string",
+                    "value": "unknown"
+                },
+                "temperature": {
+                    "type": "number",
+                    "unit": "celsius",
+                    "value": 26
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "setSchedule": {
+                    "isExecutable": true,
+                    "name": "setSchedule",
+                    "params": {
+                        "newSchedule": {
+                            "constraints": {
+                                "defaultMode": "reduced",
+                                "maxEntries": 4,
+                                "modes": [
+                                    "normal"
+                                ],
+                                "overlapAllowed": true,
+                                "resolution": 10
+                            },
+                            "required": true,
+                            "type": "Schedule"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule"
+                }
+            },
+            "deviceId": "0",
+            "feature": "heating.circuits.0.heating.schedule",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                },
+                "entries": {
+                    "type": "Schedule",
+                    "value": {
+                        "fri": [
+                            {
+                                "end": "23:30",
+                                "mode": "normal",
+                                "position": 0,
+                                "start": "05:00"
+                            }
+                        ],
+                        "mon": [
+                            {
+                                "end": "23:30",
+                                "mode": "normal",
+                                "position": 0,
+                                "start": "05:00"
+                            }
+                        ],
+                        "sat": [
+                            {
+                                "end": "23:30",
+                                "mode": "normal",
+                                "position": 0,
+                                "start": "05:00"
+                            }
+                        ],
+                        "sun": [
+                            {
+                                "end": "23:30",
+                                "mode": "normal",
+                                "position": 0,
+                                "start": "05:00"
+                            }
+                        ],
+                        "thu": [
+                            {
+                                "end": "23:30",
+                                "mode": "normal",
+                                "position": 0,
+                                "start": "05:00"
+                            }
+                        ],
+                        "tue": [
+                            {
+                                "end": "23:30",
+                                "mode": "normal",
+                                "position": 0,
+                                "start": "05:00"
+                            }
+                        ],
+                        "wed": [
+                            {
+                                "end": "23:30",
+                                "mode": "normal",
+                                "position": 0,
+                                "start": "05:00"
+                            }
+                        ]
+                    }
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.heating.schedule"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "activate": {
+                    "isExecutable": false,
+                    "name": "activate",
+                    "params": {},
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco/commands/activate"
+                },
+                "deactivate": {
+                    "isExecutable": false,
+                    "name": "deactivate",
+                    "params": {},
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco/commands/deactivate"
+                }
+            },
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.programs.eco",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                },
+                "temperature": {
+                    "type": "number",
+                    "unit": "",
+                    "value": 21
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.dhw.pumps.primary",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "off"
+                }
+            },
+            "timestamp": "2022-09-03T19:46:10.677Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.pumps.primary"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.controller.serial",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "################"
+                }
+            },
+            "timestamp": "2022-09-02T08:10:48.780Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.controller.serial"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "setTemperature": {
+                    "isExecutable": true,
+                    "name": "setTemperature",
+                    "params": {
+                        "targetTemperature": {
+                            "constraints": {
+                                "max": 37,
+                                "min": 3,
+                                "stepping": 1
+                            },
+                            "required": true,
+                            "type": "number"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal/commands/setTemperature"
+                }
+            },
+            "deviceId": "0",
+            "feature": "heating.circuits.1.operating.programs.normal",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                },
+                "demand": {
+                    "type": "string",
+                    "value": "unknown"
+                },
+                "temperature": {
+                    "type": "number",
+                    "unit": "celsius",
+                    "value": 21
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "setMode": {
+                    "isExecutable": true,
+                    "name": "setMode",
+                    "params": {
+                        "mode": {
+                            "constraints": {
+                                "enum": [
+                                    "standby",
+                                    "dhw",
+                                    "dhwAndHeating",
+                                    "forcedReduced",
+                                    "forcedNormal"
+                                ]
+                            },
+                            "required": true,
+                            "type": "string"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
+                }
+            },
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.modes.active",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "dhw"
+                }
+            },
+            "timestamp": "2022-09-02T08:10:49.659Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.2",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "device.serial",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "################"
+                }
+            },
+            "timestamp": "2022-09-02T08:10:36.784Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/device.serial"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.2.operating.modes.dhwAndHeating",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeating"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.dhw",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                },
+                "status": {
+                    "type": "string",
+                    "value": "on"
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.modes.dhw",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhw"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.programs.active",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "standby"
+                }
+            },
+            "timestamp": "2022-09-02T08:10:49.517Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.2.operating.modes.dhw",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhw"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.dhw.sensors.temperature.hotWaterStorage",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                },
+                "value": {
+                    "type": "number",
+                    "unit": "celsius",
+                    "value": 55.7
+                }
+            },
+            "timestamp": "2022-09-03T20:34:28.320Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.2.circulation.pump",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:49.481Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.circulation.pump"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.burners.0.statistics",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "hours": {
+                    "type": "number",
+                    "unit": "hour",
+                    "value": 19016.7
+                },
+                "starts": {
+                    "type": "number",
+                    "unit": "",
+                    "value": 41460
+                }
+            },
+            "timestamp": "2022-09-03T20:10:51.030Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.burners.0.statistics"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.1.dhw.schedule",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.dhw.schedule"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.burners.0",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "timestamp": "2022-09-03T19:44:19.039Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.burners.0"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.modes.standby",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.boiler.temperature",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "unit": "celsius",
+                    "value": 5
+                }
+            },
+            "timestamp": "2022-09-03T19:44:10.422Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.boiler.temperature"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "enabled": {
+                    "type": "array",
+                    "value": [
+                        "0",
+                        "1"
+                    ]
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.0.frostprotection",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "off"
+                }
+            },
+            "timestamp": "2022-09-02T08:10:37.001Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.programs.standby",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.burners",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "enabled": {
+                    "type": "array",
+                    "value": [
+                        "0"
+                    ]
+                }
+            },
+            "timestamp": "2022-09-02T08:10:36.821Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.burners"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.modes.heating",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.2.operating.modes.heating",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "changeEndDate": {
+                    "isExecutable": false,
+                    "name": "changeEndDate",
+                    "params": {
+                        "end": {
+                            "constraints": {
+                                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
+                                "sameDayAllowed": false
+                            },
+                            "required": true,
+                            "type": "string"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
+                },
+                "schedule": {
+                    "isExecutable": true,
+                    "name": "schedule",
+                    "params": {
+                        "end": {
+                            "constraints": {
+                                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
+                                "sameDayAllowed": false
+                            },
+                            "required": true,
+                            "type": "string"
+                        },
+                        "start": {
+                            "constraints": {
+                                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$"
+                            },
+                            "required": true,
+                            "type": "string"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/schedule"
+                },
+                "unschedule": {
+                    "isExecutable": true,
+                    "name": "unschedule",
+                    "params": {},
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
+                }
+            },
+            "deviceId": "0",
+            "feature": "heating.operating.programs.holiday",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                },
+                "end": {
+                    "type": "string",
+                    "value": ""
+                },
+                "start": {
+                    "type": "string",
+                    "value": ""
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.operating.programs.holiday"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.1.operating.modes.heating",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.2.operating.programs.external",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.programs.external"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.boiler.sensors.temperature.commonSupply",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:36.760Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.gas.consumption.total",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "day": {
+                    "type": "array",
+                    "unit": "kilowattHour",
+                    "value": [
+                        29,
+                        21,
+                        23,
+                        23,
+                        25,
+                        23,
+                        23,
+                        22
+                    ]
+                },
+                "dayValueReadAt": {
+                    "type": "string",
+                    "value": "2022-09-02T08:10:36.983Z"
+                },
+                "month": {
+                    "type": "array",
+                    "unit": "kilowattHour",
+                    "value": [
+                        44,
+                        597,
+                        795,
+                        924,
+                        1321,
+                        2816,
+                        3622,
+                        4052,
+                        4766,
+                        4961,
+                        3925,
+                        2550,
+                        1290
+                    ]
+                },
+                "monthValueReadAt": {
+                    "type": "string",
+                    "value": "2022-09-02T08:10:42.042Z"
+                },
+                "week": {
+                    "type": "array",
+                    "unit": "kilowattHour",
+                    "value": [
+                        115,
+                        153,
+                        155,
+                        128,
+                        90,
+                        153,
+                        166,
+                        183,
+                        208,
+                        184,
+                        207,
+                        204,
+                        219,
+                        314,
+                        293,
+                        204,
+                        234,
+                        399,
+                        514,
+                        504,
+                        570,
+                        858,
+                        854,
+                        540,
+                        831,
+                        909,
+                        1094,
+                        981,
+                        935,
+                        1043,
+                        1093,
+                        1118,
+                        1124,
+                        1104,
+                        1070,
+                        897,
+                        1367,
+                        897,
+                        1189,
+                        1127,
+                        1055,
+                        896,
+                        847,
+                        797,
+                        604,
+                        632,
+                        679,
+                        485,
+                        351,
+                        354,
+                        307,
+                        235,
+                        270
+                    ]
+                },
+                "weekValueReadAt": {
+                    "type": "string",
+                    "value": "2022-09-02T08:10:37.850Z"
+                },
+                "year": {
+                    "type": "array",
+                    "unit": "kilowattHour",
+                    "value": [
+                        18937,
+                        37176,
+                        34382
+                    ]
+                },
+                "yearValueReadAt": {
+                    "type": "string",
+                    "value": "2022-09-02T08:10:37.933Z"
+                }
+            },
+            "timestamp": "2022-09-03T19:41:26.163Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.gas.consumption.total"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.1.dhw.pumps.circulation.schedule",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.dhw.pumps.circulation.schedule"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.1.frostprotection",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "off"
+                }
+            },
+            "timestamp": "2022-09-02T08:10:37.011Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.solar.power.cumulativeProduced",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:51.155Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.solar.power.cumulativeProduced"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.boiler.serial",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "################"
+                }
+            },
+            "timestamp": "2022-09-02T08:10:36.774Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.boiler.serial"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.1.operating.programs.standby",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.0.dhw.schedule",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.dhw.schedule"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.2.dhw.pumps.circulation.schedule",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.dhw.pumps.circulation.schedule"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.2.operating.programs.normal",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normal"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.sensors.temperature.outside",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                },
+                "value": {
+                    "type": "number",
+                    "unit": "celsius",
+                    "value": 18.9
+                }
+            },
+            "timestamp": "2022-09-03T20:11:30.650Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.sensors.temperature.outside"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.2.operating.programs.reduced",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reduced"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.0.dhw.pumps.circulation.schedule",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.dhw.pumps.circulation.schedule"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.boiler.sensors.temperature.main",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                },
+                "value": {
+                    "type": "number",
+                    "unit": "celsius",
+                    "value": 66
+                }
+            },
+            "timestamp": "2022-09-03T20:33:27.920Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.boiler.sensors.temperature.main"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.1.operating.programs.holiday",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.holiday"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "setCurve": {
+                    "isExecutable": true,
+                    "name": "setCurve",
+                    "params": {
+                        "shift": {
+                            "constraints": {
+                                "max": 40,
+                                "min": -13,
+                                "stepping": 1
+                            },
+                            "required": true,
+                            "type": "number"
+                        },
+                        "slope": {
+                            "constraints": {
+                                "max": 3.5,
+                                "min": 0.2,
+                                "stepping": 0.1
+                            },
+                            "required": true,
+                            "type": "number"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.heating.curve/commands/setCurve"
+                }
+            },
+            "deviceId": "0",
+            "feature": "heating.circuits.2.heating.curve",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "shift": {
+                    "type": "number",
+                    "unit": "",
+                    "value": 0
+                },
+                "slope": {
+                    "type": "number",
+                    "unit": "",
+                    "value": 1.4
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.heating.curve"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "setName": {
+                    "isExecutable": true,
+                    "name": "setName",
+                    "params": {
+                        "name": {
+                            "constraints": {
+                                "maxLength": 20,
+                                "minLength": 1
+                            },
+                            "required": true,
+                            "type": "string"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0/commands/setName"
+                }
+            },
+            "deviceId": "0",
+            "feature": "heating.circuits.0",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                },
+                "name": {
+                    "type": "string",
+                    "value": "Heizk\u00f6rper       \u0000\u0000\u0000"
+                },
+                "type": {
+                    "type": "string",
+                    "value": "heatingCircuit"
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "setTemperature": {
+                    "isExecutable": true,
+                    "name": "setTemperature",
+                    "params": {
+                        "targetTemperature": {
+                            "constraints": {
+                                "max": 37,
+                                "min": 3,
+                                "stepping": 1
+                            },
+                            "required": true,
+                            "type": "number"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced/commands/setTemperature"
+                }
+            },
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.programs.reduced",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                },
+                "demand": {
+                    "type": "string",
+                    "value": "unknown"
+                },
+                "temperature": {
+                    "type": "number",
+                    "unit": "celsius",
+                    "value": 17
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.solar.pumps.circuit",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:51.272Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.solar.pumps.circuit"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.solar.sensors.temperature.dhw",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:49.219Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.solar.sensors.temperature.dhw"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.1.operating.programs.external",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                },
+                "temperature": {
+                    "type": "number",
+                    "unit": "",
+                    "value": 0
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.external"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "setSchedule": {
+                    "isExecutable": true,
+                    "name": "setSchedule",
+                    "params": {
+                        "newSchedule": {
+                            "constraints": {
+                                "defaultMode": "off",
+                                "maxEntries": 4,
+                                "modes": [
+                                    "on"
+                                ],
+                                "overlapAllowed": true,
+                                "resolution": 10
+                            },
+                            "required": true,
+                            "type": "Schedule"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/setSchedule"
+                }
+            },
+            "deviceId": "0",
+            "feature": "heating.dhw.pumps.circulation.schedule",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                },
+                "entries": {
+                    "type": "Schedule",
+                    "value": {
+                        "fri": [
+                            {
+                                "end": "23:30",
+                                "mode": "on",
+                                "position": 0,
+                                "start": "04:30"
+                            }
+                        ],
+                        "mon": [
+                            {
+                                "end": "23:30",
+                                "mode": "on",
+                                "position": 0,
+                                "start": "04:30"
+                            }
+                        ],
+                        "sat": [
+                            {
+                                "end": "23:30",
+                                "mode": "on",
+                                "position": 0,
+                                "start": "04:30"
+                            }
+                        ],
+                        "sun": [
+                            {
+                                "end": "23:30",
+                                "mode": "on",
+                                "position": 0,
+                                "start": "04:30"
+                            }
+                        ],
+                        "thu": [
+                            {
+                                "end": "23:30",
+                                "mode": "on",
+                                "position": 0,
+                                "start": "04:30"
+                            }
+                        ],
+                        "tue": [
+                            {
+                                "end": "23:30",
+                                "mode": "on",
+                                "position": 0,
+                                "start": "04:30"
+                            }
+                        ],
+                        "wed": [
+                            {
+                                "end": "23:30",
+                                "mode": "on",
+                                "position": 0,
+                                "start": "04:30"
+                            }
+                        ]
+                    }
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.2.operating.programs.holiday",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.programs.holiday"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "setName": {
+                    "isExecutable": true,
+                    "name": "setName",
+                    "params": {
+                        "name": {
+                            "constraints": {
+                                "maxLength": 20,
+                                "minLength": 1
+                            },
+                            "required": true,
+                            "type": "string"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1/commands/setName"
+                }
+            },
+            "deviceId": "0",
+            "feature": "heating.circuits.1",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                },
+                "name": {
+                    "type": "string",
+                    "value": "FBH              \u0000\u0000\u0000"
+                },
+                "type": {
+                    "type": "string",
+                    "value": "heatingCircuit"
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.0.sensors.temperature.room",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:47.954Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.dhw.pumps.circulation",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "on"
+                }
+            },
+            "timestamp": "2022-09-03T02:32:28.187Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "setCurve": {
+                    "isExecutable": true,
+                    "name": "setCurve",
+                    "params": {
+                        "shift": {
+                            "constraints": {
+                                "max": 40,
+                                "min": -13,
+                                "stepping": 1
+                            },
+                            "required": true,
+                            "type": "number"
+                        },
+                        "slope": {
+                            "constraints": {
+                                "max": 3.5,
+                                "min": 0.2,
+                                "stepping": 0.1
+                            },
+                            "required": true,
+                            "type": "number"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve"
+                }
+            },
+            "deviceId": "0",
+            "feature": "heating.circuits.0.heating.curve",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "shift": {
+                    "type": "number",
+                    "unit": "",
+                    "value": 0
+                },
+                "slope": {
+                    "type": "number",
+                    "unit": "",
+                    "value": 1.4
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.heating.curve"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.gas.consumption.dhw",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "day": {
+                    "type": "array",
+                    "unit": "kilowattHour",
+                    "value": [
+                        29,
+                        21,
+                        23,
+                        23,
+                        25,
+                        23,
+                        23,
+                        22
+                    ]
+                },
+                "dayValueReadAt": {
+                    "type": "string",
+                    "value": "2022-09-03T19:41:24.502Z"
+                },
+                "month": {
+                    "type": "array",
+                    "unit": "kilowattHour",
+                    "value": [
+                        44,
+                        597,
+                        783,
+                        831,
+                        915,
+                        905,
+                        1058,
+                        983,
+                        1076,
+                        1016,
+                        974,
+                        902,
+                        840
+                    ]
+                },
+                "monthValueReadAt": {
+                    "type": "string",
+                    "value": "2022-09-03T04:10:41.406Z"
+                },
+                "week": {
+                    "type": "array",
+                    "unit": "kilowattHour",
+                    "value": [
+                        115,
+                        153,
+                        155,
+                        128,
+                        90,
+                        153,
+                        166,
+                        181,
+                        199,
+                        182,
+                        199,
+                        189,
+                        204,
+                        201,
+                        218,
+                        188,
+                        203,
+                        217,
+                        205,
+                        204,
+                        221,
+                        219,
+                        235,
+                        222,
+                        232,
+                        232,
+                        257,
+                        237,
+                        252,
+                        254,
+                        249,
+                        251,
+                        240,
+                        247,
+                        229,
+                        229,
+                        222,
+                        235,
+                        233,
+                        233,
+                        249,
+                        227,
+                        220,
+                        207,
+                        196,
+                        214,
+                        221,
+                        192,
+                        195,
+                        189,
+                        212,
+                        189,
+                        188
+                    ]
+                },
+                "weekValueReadAt": {
+                    "type": "string",
+                    "value": "2022-09-03T04:10:41.037Z"
+                },
+                "year": {
+                    "type": "array",
+                    "unit": "kilowattHour",
+                    "value": [
+                        7192,
+                        11231,
+                        11782
+                    ]
+                },
+                "yearValueReadAt": {
+                    "type": "string",
+                    "value": "2022-09-03T04:10:44.486Z"
+                }
+            },
+            "timestamp": "2022-09-03T19:41:26.111Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.gas.consumption.dhw"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "setTemperature": {
+                    "isExecutable": true,
+                    "name": "setTemperature",
+                    "params": {
+                        "targetTemperature": {
+                            "constraints": {
+                                "max": 37,
+                                "min": 3,
+                                "stepping": 1
+                            },
+                            "required": true,
+                            "type": "number"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature"
+                }
+            },
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.programs.normal",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                },
+                "demand": {
+                    "type": "string",
+                    "value": "unknown"
+                },
+                "temperature": {
+                    "type": "number",
+                    "unit": "celsius",
+                    "value": 21
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.programs.holiday",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.holiday"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.power.consumption.total",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "day": {
+                    "type": "array",
+                    "unit": "kilowattHour",
+                    "value": [
+                        0.283,
+                        0.269,
+                        0.272,
+                        0.279,
+                        0.287,
+                        0.271,
+                        0.273,
+                        0.269
+                    ]
+                },
+                "dayValueReadAt": {
+                    "type": "string",
+                    "value": "2022-09-03T20:26:10.217Z"
+                },
+                "month": {
+                    "type": "array",
+                    "unit": "kilowattHour",
+                    "value": [
+                        0.578,
+                        9.728,
+                        14.846,
+                        14.772,
+                        21.143,
+                        27.102,
+                        29.76,
+                        27.708,
+                        31.283,
+                        31.747,
+                        29.102,
+                        27.079,
+                        21.693
+                    ]
+                },
+                "monthValueReadAt": {
+                    "type": "string",
+                    "value": "2022-09-03T04:10:45.409Z"
+                },
+                "week": {
+                    "type": "array",
+                    "unit": "kilowattHour",
+                    "value": [
+                        1.415,
+                        1.866,
+                        2.029,
+                        2.337,
+                        2.659,
+                        3.059,
+                        2.701,
+                        3.338,
+                        4.284,
+                        3.169,
+                        3.104,
+                        3.511,
+                        3.429,
+                        4.693,
+                        5.059,
+                        3.798,
+                        4.074,
+                        5.667,
+                        6.157,
+                        6.067,
+                        6.063,
+                        6.658,
+                        6.779,
+                        6.247,
+                        6.723,
+                        6.879,
+                        7.195,
+                        6.894,
+                        6.75,
+                        6.988,
+                        7.075,
+                        7.111,
+                        7.156,
+                        7.178,
+                        7.034,
+                        6.714,
+                        7.608,
+                        6.778,
+                        7.306,
+                        7.171,
+                        7.077,
+                        6.736,
+                        6.733,
+                        6.5,
+                        6.25,
+                        6.127,
+                        6.4,
+                        5.957,
+                        5.506,
+                        5.327,
+                        5.118,
+                        4.492,
+                        5.032
+                    ]
+                },
+                "weekValueReadAt": {
+                    "type": "string",
+                    "value": "2022-09-03T04:10:42.721Z"
+                },
+                "year": {
+                    "type": "array",
+                    "unit": "kilowattHour",
+                    "value": [
+                        177.167,
+                        314.883,
+                        310.557
+                    ]
+                },
+                "yearValueReadAt": {
+                    "type": "string",
+                    "value": "2022-09-03T20:32:08.145Z"
+                }
+            },
+            "timestamp": "2022-09-03T20:32:10.626Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.power.consumption.total"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "setMode": {
+                    "isExecutable": true,
+                    "name": "setMode",
+                    "params": {
+                        "mode": {
+                            "constraints": {
+                                "enum": [
+                                    "standby",
+                                    "dhw",
+                                    "dhwAndHeating",
+                                    "forcedReduced",
+                                    "forcedNormal"
+                                ]
+                            },
+                            "required": true,
+                            "type": "string"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active/commands/setMode"
+                }
+            },
+            "deviceId": "0",
+            "feature": "heating.circuits.1.operating.modes.active",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "dhw"
+                }
+            },
+            "timestamp": "2022-09-02T08:10:49.975Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.1.circulation.pump",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "off"
+                }
+            },
+            "timestamp": "2022-09-02T08:10:49.455Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.circulation.pump"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.modes.dhwAndHeating",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.2.dhw.schedule",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.dhw.schedule"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "setName": {
+                    "isExecutable": true,
+                    "name": "setName",
+                    "params": {
+                        "name": {
+                            "constraints": {
+                                "maxLength": 20,
+                                "minLength": 1
+                            },
+                            "required": true,
+                            "type": "string"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.name/commands/setName"
+                }
+            },
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.circuits.0.name",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "value": "Heizk\u00f6rper       \u0000\u0000\u0000"
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.name"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "setName": {
+                    "isExecutable": true,
+                    "name": "setName",
+                    "params": {
+                        "name": {
+                            "constraints": {
+                                "maxLength": 20,
+                                "minLength": 1
+                            },
+                            "required": true,
+                            "type": "string"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.name/commands/setName"
+                }
+            },
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.circuits.1.name",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "value": "FBH              \u0000\u0000\u0000"
+                }
+            },
+            "timestamp": "2022-09-02T08:10:32.055Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.name"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.circuits.2.name",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2021-11-30T10:35:46.635Z",
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.name"
+        }
+    ]
+}

--- a/tests/test_TestForMissingProperties.py
+++ b/tests/test_TestForMissingProperties.py
@@ -124,6 +124,6 @@ class TestForMissingProperties(unittest.TestCase):
                     if name not in all_features:
                         all_features[name] = {'files': []}
 
-                    if feature['isEnabled'] and feature['properties'] != {} and feature['components'] == []:
+                    if feature['isEnabled'] and feature['properties'] != {}:
                         all_features[name]['files'].append(response)
         return all_features

--- a/tests/test_TestForMissingProperties.py
+++ b/tests/test_TestForMissingProperties.py
@@ -26,8 +26,13 @@ class TestForMissingProperties(unittest.TestCase):
 
             'heating.circuits.0.temperature.levels',  # hint: command
             'heating.dhw.temperature.hysteresis',  # hint: command
+            'heating.dhw.hygiene',
+            'heating.dhw.temperature',
+            'heating.burners',
+            'heating.solar',
 
             # todo: implement ventilation
+            'ventilation',
             'ventilation.schedule',
             'ventilation.operating.programs',
             'ventilation.operating.programs.eco',

--- a/tests/test_Vitodens200W.py
+++ b/tests/test_Vitodens200W.py
@@ -82,25 +82,25 @@ class Vitodens200W(unittest.TestCase):
             self.assertEqual(
                 self.device.getDomesticHotWaterCirculationMode(), 'off')
 
-    def test_getGasConsumptionHeatingUnit(self):
-        self.assertEqual(
-            self.device.getGasConsumptionHeatingUnit(), "cubicMeter")
+    # def test_getGasConsumptionHeatingUnit(self):
+    #     self.assertEqual(
+    #         self.device.getGasConsumptionHeatingUnit(), "cubicMeter")
 
     def test_getGasConsumptionHeatingToday(self):
         self.assertEqual(
             self.device.getGasConsumptionHeatingToday(), 0)
 
-    def test_getGasConsumptionDomesticHotWaterUnit(self):
-        self.assertEqual(
-            self.device.getGasConsumptionDomesticHotWaterUnit(), "cubicMeter")
+    # def test_getGasConsumptionDomesticHotWaterUnit(self):
+    #     self.assertEqual(
+    #         self.device.getGasConsumptionDomesticHotWaterUnit(), "cubicMeter")
 
     def test_getGasConsumptionDomesticHotWaterToday(self):
         self.assertEqual(
             self.device.getGasConsumptionDomesticHotWaterToday(), 1.3)
 
-    def test_getPowerConsumptionUnit(self):
-        self.assertEqual(
-            self.device.getPowerConsumptionUnit(), "kilowattHour")
+    # def test_getPowerConsumptionUnit(self):
+    #     self.assertEqual(
+    #         self.device.getPowerConsumptionUnit(), "kilowattHour")
 
     def test_getPowerConsumptionToday(self):
         self.assertEqual(

--- a/tests/test_Vitodens200W_2.py
+++ b/tests/test_Vitodens200W_2.py
@@ -1,0 +1,107 @@
+import unittest
+
+from PyViCare.PyViCareGazBoiler import GazBoiler
+from tests.helper import now_is
+from tests.ViCareServiceMock import ViCareServiceMock
+
+
+class Vitodens200W_2(unittest.TestCase):
+    def setUp(self):
+        self.service = ViCareServiceMock('response/Vitodens200W_2.json')
+        self.device = GazBoiler(self.service)
+
+    def test_getSerial(self):
+        self.assertEqual(self.device.getSerial(), '################')
+
+    # def test_getBoilerCommonSupplyTemperature(self):
+    #     self.assertEqual(self.device.getBoilerCommonSupplyTemperature(), 44.4)
+
+    def test_getActive(self):
+        self.assertEqual(self.device.burners[0].getActive(), False)
+
+    def test_getDomesticHotWaterActive(self):
+        self.assertEqual(self.device.getDomesticHotWaterActive(), True)
+
+    def test_getBurnerStarts(self):
+        self.assertEqual(self.device.burners[0].getStarts(), 41460)
+
+    def test_getBurnerHours(self):
+        self.assertEqual(self.device.burners[0].getHours(), 19016.7)
+
+    def test_getBurnerModulation(self):
+        self.assertEqual(self.device.burners[0].getModulation(), 0)
+
+    def test_getPrograms(self):
+        expected_programs = [
+            'active', 'comfort', 'eco', 'external', 'holiday', 'normal', 'reduced', 'standby']
+        self.assertListEqual(
+            self.device.circuits[0].getPrograms(), expected_programs)
+
+    def test_getModes(self):
+        expected_modes = ['standby', 'dhw', 'dhwAndHeating', 'forcedReduced', 'forcedNormal']
+        self.assertListEqual(
+            self.device.circuits[0].getModes(), expected_modes)
+
+    def test_getPowerConsumptionDays(self):
+        expected_days = [0.283, 0.269, 0.272, 0.279, 0.287, 0.271, 0.273, 0.269]
+        self.assertEqual(self.device.getPowerConsumptionDays(), expected_days)
+
+    def test_getDomesticHotWaterMaxTemperature(self):
+        self.assertEqual(self.device.getDomesticHotWaterMaxTemperature(), 60)
+
+    def test_getDomesticHotWaterMinTemperature(self):
+        self.assertEqual(self.device.getDomesticHotWaterMinTemperature(), 10)
+
+    def test_getFrostProtectionActive(self):
+        self.assertEqual(
+            self.device.circuits[0].getFrostProtectionActive(), False)
+
+    def test_getDomesticHotWaterCirculationPumpActive(self):
+        self.assertEqual(
+            self.device.getDomesticHotWaterCirculationPumpActive(), True)
+
+    # def test_getDomesticHotWaterOutletTemperature(self):
+    #     self.assertEqual(
+    #         self.device.getDomesticHotWaterOutletTemperature(), 39.1)
+
+    def test_getDomesticHotWaterConfiguredTemperature(self):
+        self.assertEqual(
+            self.device.getDomesticHotWaterConfiguredTemperature(), 55)
+
+    def test_getDomesticHotWaterCirculationScheduleModes(self):
+        self.assertEqual(
+            self.device.getDomesticHotWaterCirculationScheduleModes(), ['on'])
+
+    def test_getDomesticHotWaterCirculationMode_wed_07_30_time(self):
+        with now_is('2021-09-08 07:30:00'):
+            self.assertEqual(
+                self.device.getDomesticHotWaterCirculationMode(), 'on')
+
+    def test_getDomesticHotWaterCirculationMode_wed_10_10_time(self):
+        with now_is('2021-09-08 10:10:00'):
+            self.assertEqual(
+                self.device.getDomesticHotWaterCirculationMode(), 'on')
+
+    def test_getGasConsumptionHeatingUnit(self):
+        self.assertEqual(
+            self.device.getGasConsumptionHeatingUnit(), "kilowattHour")
+
+    def test_getGasConsumptionHeatingToday(self):
+        self.assertEqual(
+            self.device.getGasConsumptionHeatingToday(), 0)
+
+    def test_getGasConsumptionDomesticHotWaterUnit(self):
+        self.assertEqual(
+            self.device.getGasConsumptionDomesticHotWaterUnit(), "kilowattHour")
+
+    def test_getGasConsumptionDomesticHotWaterToday(self):
+        self.assertEqual(
+            self.device.getGasConsumptionDomesticHotWaterToday(), 29)
+
+    def test_getPowerConsumptionUnit(self):
+        self.assertEqual(
+            self.device.getPowerConsumptionUnit(), "kilowattHour")
+
+    def test_getPowerConsumptionToday(self):
+        self.assertEqual(
+            self.device.getPowerConsumptionToday(), 0.283)

--- a/tests/test_VitovalorPT2.py
+++ b/tests/test_VitovalorPT2.py
@@ -45,19 +45,19 @@ class VitovalorPT2(unittest.TestCase):
         expected_consumption = [0.6, 1.3, 1.3, 1.3, 1.3, 1.3, 1.3, 1.3]
         self.assertListEqual(self.device.getPowerConsumptionDays(), expected_consumption)
 
-    def test_getPowerConsumptionUnit(self):
-        self.assertEqual(self.device.getPowerConsumptionUnit(), "kilowattHour")
+    # def test_getPowerConsumptionUnit(self):
+    #     self.assertEqual(self.device.getPowerConsumptionUnit(), "kilowattHour")
 
     def test_getPowerConsumptionHeatingDays(self):
         expected_consumption = [0.6, 1.3, 1.3, 1.3, 1.3, 1.3, 1.3, 1.3]
         self.assertListEqual(self.device.getPowerConsumptionHeatingDays(), expected_consumption)
 
-    def test_getPowerConsumptionHeatingUnit(self):
-        self.assertEqual(self.device.getPowerConsumptionHeatingUnit(), "kilowattHour")
+    # def test_getPowerConsumptionHeatingUnit(self):
+    #     self.assertEqual(self.device.getPowerConsumptionHeatingUnit(), "kilowattHour")
 
     def test_getGasConsumptionTotalDays(self):
         expected_consumption = [2, 4.1, 4.1, 4.1, 4.1, 4.199999999999999, 4.1, 4.199999999999999]
         self.assertListEqual(self.device.getGasConsumptionTotalDays(), expected_consumption)
 
-    def test_getGasConsumptionUnit(self):
-        self.assertEqual(self.device.getGasConsumptionUnit(), "cubicMeter")
+    # def test_getGasConsumptionUnit(self):
+    #     self.assertEqual(self.device.getGasConsumptionUnit(), "cubicMeter")


### PR DESCRIPTION
The current ``unit`` field isn't available anymore. See https://documentation.viessmann.com/static/changelog under ``Removal of standalone "unit"-properties`` for more information.

Fixes https://github.com/somm15/PyViCare/issues/263
Related HA issue: https://github.com/home-assistant/core/issues/77693

https://github.com/somm15/PyViCare/pull/260 already attempts to fix this but seemingly access non-existing fields(?)

This PR always grabs the unit from the latest ``day``.
(I'm not sure if it would be better to grab the unit from ``week``, ``month``, or ``year``. I guess ``day`` should always exist(?))

Note: All dumps still need to be replaced(?)

<details>
  <summary>Click here to see a bit of the new API output</summary>
  
API output for ``devices/0/features/heating.gas.consumption.dhw``:
  
```json
{
    "data": {
        "properties": {
            "day": {
                "type": "array",
                "value": [
                    0,
                    21,
                    23,
                    23,
                    25,
                    23,
                    23,
                    22
                ],
                "unit": "kilowattHour"
            },
            "week": {
                "type": "array",
                "value": [
                    102,
                    153,
                    155,
                    128,
                    90,
                    153,
                    166,
                    181,
                    199,
                    182,
                    199,
                    189,
                    204,
                    201,
                    218,
                    188,
                    203,
                    217,
                    205,
                    204,
                    221,
                    219,
                    235,
                    222,
                    232,
                    232,
                    257,
                    237,
                    252,
                    254,
                    249,
                    251,
                    240,
                    247,
                    229,
                    229,
                    222,
                    235,
                    233,
                    233,
                    249,
                    227,
                    220,
                    207,
                    196,
                    214,
                    221,
                    192,
                    195,
                    189,
                    212,
                    189,
                    188
                ],
                "unit": "kilowattHour"
            },
            "month": {
                "type": "array",
                "value": [
                    31,
                    597,
                    783,
                    831,
                    915,
                    905,
                    1058,
                    983,
                    1076,
                    1016,
                    974,
                    902,
                    840
                ],
                "unit": "kilowattHour"
            },
            "year": {
                "type": "array",
                "value": [
                    7179,
                    11231,
                    11782
                ],
                "unit": "kilowattHour"
            },
            "dayValueReadAt": {
                "type": "string",
                "value": "2022-09-02T22:10:57.328Z"
            },
            "weekValueReadAt": {
                "type": "string",
                "value": "2022-09-02T08:10:38.943Z"
            },
            "monthValueReadAt": {
                "type": "string",
                "value": "2022-09-02T08:10:39.150Z"
            },
            "yearValueReadAt": {
                "type": "string",
                "value": "2022-09-02T08:10:41.839Z"
            }
        },
        "commands": {},
        "apiVersion": 1,
        "uri": "https://api.viessmann.com/iot/v1/equipment/installations/***/gateways/***/devices/0/features/heating.gas.consumption.dhw",
        "gatewayId": "***",
        "feature": "heating.gas.consumption.dhw",
        "timestamp": "2022-09-02T22:10:59.862Z",
        "isEnabled": true,
        "isReady": true,
        "deviceId": "0"
    }
}
```

</details>

Edit: Confirmed this would fix the issue with a ``Vitodens 200-W (B2HB 2,4-19kW)`` and Home Assistant.