### PR TITLE
Add more fuel cell functions

### DIFF
--- a/PyViCare/PyViCareFuelCell.py
+++ b/PyViCare/PyViCareFuelCell.py
@@ -146,13 +146,139 @@ class FuelCell(Device):
     def getHydraulicSeparatorTemperature(self):
         return self.service.getProperty("heating.sensors.temperature.hydraulicSeparator")["properties"]["value"]["value"]
 
+    # ---- Actual FuelCell-relevant methods (they require paid "Advanced" API plan):
+
+    # TODO: Implement setFuelCellOperatingMode<...>() methods
+
+    @handleNotSupported
+    def getFuelCellOperatingModeActive(self):
+        # Returns currently active operating mode as string, e.g. "economical"
+        return self.service.getProperty("heating.fuelCell.operating.modes.active")["properties"]["value"]["value"]
+
+    @handleNotSupported
+    def getFuelCellPowerProductionUnit(self):
+        # Returns the unit for the fuel cell's power production statistics, e.g. kilowattHour
+        return self.service.getProperty("heating.fuelCell.power.production")["properties"]["day"]["unit"]
+
+    @handleNotSupported
+    def getFuelCellPowerProductionDays(self):
+        return self.service.getProperty("heating.fuelCell.power.production")["properties"]["day"]["value"]
+
+    @handleNotSupported
+    def getFuelCellPowerProductionToday(self):
+        return self.service.getProperty("heating.fuelCell.power.production")["properties"]["day"]["value"][0]
+
+    @handleNotSupported
+    def getFuelCellPowerProductionWeeks(self):
+        return self.service.getProperty("heating.fuelCell.power.production")["properties"]["week"]["value"]
+
+    @handleNotSupported
+    def getFuelCellPowerProductionThisWeek(self):
+        return self.service.getProperty("heating.fuelCell.power.production")["properties"]["week"]["value"][0]
+
+    @handleNotSupported
+    def getFuelCellPowerProductionMonths(self):
+        return self.service.getProperty("heating.fuelCell.power.production")["properties"]["month"]["value"]
+
+    @handleNotSupported
+    def getFuelCellPowerProductionThisMonth(self):
+        return self.service.getProperty("heating.fuelCell.power.production")["properties"]["month"]["value"][0]
+
+    @handleNotSupported
+    def getFuelCellPowerProductionYears(self):
+        return self.service.getProperty("heating.fuelCell.power.production")["properties"]["year"]["value"]
+
+    @handleNotSupported
+    def getFuelCellPowerProductionThisYear(self):
+        return self.service.getProperty("heating.fuelCell.power.production")["properties"]["year"]["value"][0]
+
     @handleNotSupported
     def getFuelCellOperatingPhase(self):
+        # Returns current operating phase as string, e.g. "standby" or "generation"
         return self.service.getProperty("heating.fuelCell.operating.phase")["properties"]["value"]["value"]
 
     @handleNotSupported
+    def getFuelCellPowerProductionCurrentUnit(self):
+        # Returns current power production unit, e.g. "watt"
+        return self.service.getProperty("heating.power.production.current")["properties"]["value"]["unit"]
+
+    @handleNotSupported
     def getFuelCellPowerProductionCurrent(self):
+        # Returns current power production as integer
         return self.service.getProperty("heating.power.production.current")["properties"]["value"]["value"]
+
+    @handleNotSupported
+    def getFuelCellFlowReturnTemperatureUnit(self):
+        # Returns flow return temperature unit, e.g. "celsius"
+        return self.service.getProperty("heating.fuelCell.sensors.temperature.return")["properties"]["value"]["unit"]
+
+    @handleNotSupported
+    def getFuelCellFlowReturnTemperature(self):
+        # Returns flow return temperature at the fuel cell as float
+        return self.service.getProperty("heating.fuelCell.sensors.temperature.return")["properties"]["value"]["value"]
+
+    @handleNotSupported
+    def getFuelCellFlowSupplyTemperatureUnit(self):
+        # Returns flow supply temperature unit, e.g. "celsius"
+        return self.service.getProperty("heating.fuelCell.sensors.temperature.supply")["properties"]["value"]["unit"]
+
+    @handleNotSupported
+    def getFuelCellFlowSupplyTemperature(self):
+        # Returns flow supply temperature at the fuel cell as float
+        return self.service.getProperty("heating.fuelCell.sensors.temperature.supply")["properties"]["value"]["value"]
+
+    @handleNotSupported
+    def getFuelCellOperationHours(self):
+        # Returns the operation hours of the fuel cell as integer
+        return self.service.getProperty("heating.fuelCell.statistics")["properties"]["operationHours"]["value"]
+
+    @handleNotSupported
+    def getFuelCellProductionHours(self):
+        # Returns the production hours of the fuel cell as integer
+        return self.service.getProperty("heating.fuelCell.statistics")["properties"]["productionHours"]["value"]
+
+    @handleNotSupported
+    def getFuelCellProductionStarts(self):
+        # Returns the number of production starts of the fuel cell as integer
+        return self.service.getProperty("heating.fuelCell.statistics")["properties"]["productionStarts"]["value"]
+
+    @handleNotSupported
+    def getFuelCellGasConsumptionUnit(self):
+        # Returns the unit for the fuel cell's gas consumption statistics, e.g. "cubicMeter"
+        return self.service.getProperty("heating.gas.consumption.fuelCell")["properties"]["day"]["unit"]
+
+    @handleNotSupported
+    def getFuelCellGasConsumptionDays(self):
+        return self.service.getProperty("heating.gas.consumption.fuelCell")["properties"]["day"]["value"]
+
+    @handleNotSupported
+    def getFuelCellGasConsumptionToday(self):
+        return self.service.getProperty("heating.gas.consumption.fuelCell")["properties"]["day"]["value"][0]
+
+    @handleNotSupported
+    def getFuelCellGasConsumptionWeeks(self):
+        return self.service.getProperty("heating.gas.consumption.fuelCell")["properties"]["week"]["value"]
+
+    @handleNotSupported
+    def getFuelCellGasConsumptionThisWeek(self):
+        return self.service.getProperty("heating.gas.consumption.fuelCell")["properties"]["week"]["value"][0]
+
+    @handleNotSupported
+    def getFuelCellGasConsumptionMonths(self):
+        return self.service.getProperty("heating.gas.consumption.fuelCell")["properties"]["month"]["value"]
+
+    @handleNotSupported
+    def getFuelCellGasConsumptionThisMonth(self):
+        return self.service.getProperty("heating.gas.consumption.fuelCell")["properties"]["month"]["value"][0]
+
+    @handleNotSupported
+    def getFuelCellGasConsumptionYears(self):
+        return self.service.getProperty("heating.gas.consumption.fuelCell")["properties"]["year"]["value"]
+
+    @handleNotSupported
+    def getFuelCellGasConsumptionThisYear(self):
+        return self.service.getProperty("heating.gas.consumption.fuelCell")["properties"]["year"]["value"][0]
+
 
 class FuelCellBurner(DeviceWithComponent):
 

--- a/PyViCare/PyViCareFuelCell.py
+++ b/PyViCare/PyViCareFuelCell.py
@@ -132,7 +132,7 @@ class FuelCell(Device):
 
     @handleNotSupported
     def getVolumetricFlowReturn(self):
-        return self.service.getProperty("heating.sensors.volumetricFlow.return")["properties"]["value"]["value"]
+        return self.service.getProperty("heating.sensors.volumetricFlow.allengra")["properties"]["value"]["value"]
 
     @handleNotSupported
     def getDomesticHotWaterMaxTemperatureLevel(self):

--- a/PyViCare/PyViCareFuelCell.py
+++ b/PyViCare/PyViCareFuelCell.py
@@ -150,6 +150,9 @@ class FuelCell(Device):
     def getFuelCellOperatingPhase(self):
         return self.service.getProperty("heating.fuelCell.operating.phase")["properties"]["value"]["value"]
 
+    @handleNotSupported
+    def getFuelCellPowerProductionCurrent(self):
+        return self.service.getProperty("heating.power.production.current")["properties"]["value"]["value"]
 
 class FuelCellBurner(DeviceWithComponent):
 

--- a/PyViCare/PyViCareFuelCell.py
+++ b/PyViCare/PyViCareFuelCell.py
@@ -148,8 +148,6 @@ class FuelCell(Device):
 
     # ---- Actual FuelCell-relevant methods (they require paid "Advanced" API plan):
 
-    # TODO: Implement setFuelCellOperatingMode<...>() methods
-
     @handleNotSupported
     def getFuelCellOperatingModeActive(self):
         # Returns currently active operating mode as string, e.g. "economical"

--- a/PyViCare/PyViCareFuelCell.py
+++ b/PyViCare/PyViCareFuelCell.py
@@ -146,6 +146,10 @@ class FuelCell(Device):
     def getHydraulicSeparatorTemperature(self):
         return self.service.getProperty("heating.sensors.temperature.hydraulicSeparator")["properties"]["value"]["value"]
 
+    @handleNotSupported
+    def getFuelCellOperatingPhase(self):
+        return self.service.getProperty("heating.fuelCell.operating.phase")["properties"]["value"]["value"]
+
 
 class FuelCellBurner(DeviceWithComponent):
 

--- a/tests/response/VitovalorPT2.json
+++ b/tests/response/VitovalorPT2.json
@@ -1,820 +1,925 @@
 {
   "data": [
     {
-      "properties": {},
-      "commands": {},
-      "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.heating.schedule",
-      "gatewayId": "################",
-      "feature": "heating.circuits.3.heating.schedule",
-      "timestamp": "2021-09-30T03:57:02.298Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
       "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reduced",
+      "deviceId": "0",
+      "feature": "heating.power.purchase.current",
       "gatewayId": "################",
-      "feature": "heating.circuits.3.operating.programs.reduced",
-      "timestamp": "2021-09-30T03:57:02.883Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["active", "dhw", "dhwAndHeating", "heating", "standby"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes",
-      "gatewayId": "################",
-      "feature": "heating.circuits.0.operating.modes",
-      "timestamp": "2021-09-30T03:56:58.129Z",
       "isEnabled": true,
       "isReady": true,
-      "deviceId": "0"
+      "properties": {
+        "value": {
+          "type": "number",
+          "unit": "watt",
+          "value": 594
+        }
+      },
+      "timestamp": "2022-11-18T06:56:51.249Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.purchase.current"
     },
     {
-      "properties": {},
-      "commands": {},
-      "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normal",
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.3.operating.modes.active",
       "gatewayId": "################",
-      "feature": "heating.circuits.3.operating.programs.normal",
-      "timestamp": "2021-09-30T03:57:02.739Z",
       "isEnabled": false,
       "isReady": true,
-      "deviceId": "0"
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:58.814Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.active"
     },
     {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.sensors.volumetricFlow.allengra",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
       "properties": {
         "status": {
           "type": "string",
-          "value": "on"
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.circulation.pump",
-      "gatewayId": "################",
-      "feature": "heating.circuits.1.circulation.pump",
-      "timestamp": "2021-09-30T03:57:00.195Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [
-        "boiler",
-        "buffer",
-        "burners",
-        "circuits",
-        "configuration",
-        "device",
-        "dhw",
-        "operating",
-        "sensors"
-      ],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating",
-      "gatewayId": "################",
-      "feature": "heating",
-      "timestamp": "2021-09-30T03:56:58.128Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["multiFamilyHouse"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.configuration",
-      "gatewayId": "################",
-      "feature": "heating.configuration",
-      "timestamp": "2021-09-30T03:56:58.129Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.supply",
-      "gatewayId": "################",
-      "feature": "heating.circuits.3.sensors.temperature.supply",
-      "timestamp": "2021-09-30T03:57:02.326Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
+          "value": "connected"
+        },
         "value": {
-          "type": "string",
-          "value": "################"
+          "type": "number",
+          "unit": "liter",
+          "value": 513
         }
       },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler.serial",
-      "gatewayId": "################",
-      "feature": "heating.boiler.serial",
-      "timestamp": "2021-09-30T03:56:59.437Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
+      "timestamp": "2022-11-18T06:57:07.569Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.volumetricFlow.allengra"
     },
     {
-      "properties": {},
+      "apiVersion": 1,
       "commands": {},
-      "components": ["temperature"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.sensors",
-      "gatewayId": "################",
-      "feature": "heating.circuits.1.sensors",
-      "timestamp": "2021-09-30T03:56:58.130Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "active": {
-          "value": false,
-          "type": "boolean"
-        },
-        "demand": {
-          "value": "unknown",
-          "type": "string"
-        },
-        "temperature": {
-          "value": 20,
-          "unit": "",
-          "type": "number"
-        }
-      },
-      "commands": {
-        "setTemperature": {
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort/commands/setTemperature",
-          "name": "setTemperature",
-          "isExecutable": true,
-          "params": {
-            "targetTemperature": {
-              "type": "number",
-              "required": true,
-              "constraints": {
-                "min": 3,
-                "max": 37,
-                "stepping": 1
-              }
-            }
-          }
-        },
-        "activate": {
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort/commands/activate",
-          "name": "activate",
-          "isExecutable": false,
-          "params": {
-            "temperature": {
-              "type": "number",
-              "required": false,
-              "constraints": {
-                "min": 3,
-                "max": 37,
-                "stepping": 1
-              }
-            }
-          }
-        },
-        "deactivate": {
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort/commands/deactivate",
-          "name": "deactivate",
-          "isExecutable": false,
-          "params": {}
-        }
-      },
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort",
-      "gatewayId": "################",
-      "feature": "heating.circuits.1.operating.programs.comfort",
-      "timestamp": "2021-09-30T03:57:02.720Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [
-        "circulation",
-        "frostprotection",
-        "heating",
-        "operating",
-        "sensors",
-        "temperature"
-      ],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3",
-      "gatewayId": "################",
-      "feature": "heating.circuits.3",
-      "timestamp": "2021-09-30T03:57:00.140Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["time"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.device",
-      "gatewayId": "################",
-      "feature": "heating.device",
-      "timestamp": "2021-09-30T03:56:58.129Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.dhw",
-      "gatewayId": "################",
-      "feature": "heating.circuits.3.operating.modes.dhw",
-      "timestamp": "2021-09-30T03:57:01.602Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active",
-      "gatewayId": "################",
-      "feature": "heating.circuits.2.operating.programs.active",
-      "timestamp": "2021-09-30T03:57:02.401Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room",
-      "gatewayId": "################",
+      "deviceId": "0",
       "feature": "heating.circuits.2.sensors.temperature.room",
-      "timestamp": "2021-09-30T03:57:02.315Z",
+      "gatewayId": "################",
       "isEnabled": false,
       "isReady": true,
-      "deviceId": "0"
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:58.847Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room"
     },
     {
-      "properties": {},
-      "commands": {},
-      "components": [
-        "active",
-        "comfort",
-        "forcedLastFromSchedule",
-        "normal",
-        "reduced",
-        "standby"
-      ],
       "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs",
+      "commands": {
+        "setSchedule": {
+          "isExecutable": true,
+          "name": "setSchedule",
+          "params": {
+            "newSchedule": {
+              "constraints": {
+                "defaultMode": "reduced",
+                "maxEntries": 4,
+                "modes": [
+                  "normal",
+                  "comfort"
+                ],
+                "overlapAllowed": false,
+                "resolution": 10
+              },
+              "required": true,
+              "type": "Schedule"
+            }
+          },
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule/commands/setSchedule"
+        }
+      },
+      "deviceId": "0",
+      "feature": "heating.circuits.1.heating.schedule",
       "gatewayId": "################",
-      "feature": "heating.circuits.3.operating.programs",
-      "timestamp": "2021-09-30T03:56:58.129Z",
       "isEnabled": true,
       "isReady": true,
-      "deviceId": "0"
-    },
-    {
       "properties": {
         "active": {
-          "value": true,
-          "type": "boolean"
+          "type": "boolean",
+          "value": true
         },
         "entries": {
+          "type": "Schedule",
           "value": {
-            "mon": [
-              {
-                "mode": "on",
-                "start": "00:00",
-                "end": "24:00",
-                "position": 0
-              }
-            ],
-            "tue": [
-              {
-                "mode": "on",
-                "start": "00:00",
-                "end": "24:00",
-                "position": 0
-              }
-            ],
-            "wed": [
-              {
-                "mode": "on",
-                "start": "00:00",
-                "end": "24:00",
-                "position": 0
-              }
-            ],
-            "thu": [
-              {
-                "mode": "on",
-                "start": "00:00",
-                "end": "24:00",
-                "position": 0
-              }
-            ],
             "fri": [
               {
-                "mode": "on",
-                "start": "00:00",
-                "end": "24:00",
-                "position": 0
+                "end": "21:00",
+                "mode": "normal",
+                "position": 0,
+                "start": "05:00"
+              }
+            ],
+            "mon": [
+              {
+                "end": "21:00",
+                "mode": "normal",
+                "position": 0,
+                "start": "05:00"
               }
             ],
             "sat": [
               {
-                "mode": "on",
-                "start": "00:00",
-                "end": "24:00",
-                "position": 0
+                "end": "21:00",
+                "mode": "comfort",
+                "position": 0,
+                "start": "06:00"
               }
             ],
             "sun": [
               {
-                "mode": "on",
-                "start": "00:00",
-                "end": "24:00",
-                "position": 0
+                "end": "21:00",
+                "mode": "comfort",
+                "position": 0,
+                "start": "06:00"
+              }
+            ],
+            "thu": [
+              {
+                "end": "21:00",
+                "mode": "normal",
+                "position": 0,
+                "start": "05:00"
+              }
+            ],
+            "tue": [
+              {
+                "end": "21:00",
+                "mode": "normal",
+                "position": 0,
+                "start": "05:00"
+              }
+            ],
+            "wed": [
+              {
+                "end": "21:00",
+                "mode": "normal",
+                "position": 0,
+                "start": "05:00"
               }
             ]
-          },
-          "type": "Schedule"
-        }
-      },
-      "commands": {
-        "setSchedule": {
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/setSchedule",
-          "name": "setSchedule",
-          "isExecutable": true,
-          "params": {
-            "newSchedule": {
-              "type": "Schedule",
-              "required": true,
-              "constraints": {
-                "modes": ["on"],
-                "maxEntries": 4,
-                "resolution": 10,
-                "defaultMode": "off",
-                "overlapAllowed": false
-              }
-            }
           }
         }
       },
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule",
-      "gatewayId": "################",
-      "feature": "heating.dhw.pumps.circulation.schedule",
-      "timestamp": "2021-09-30T03:57:02.300Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule"
     },
     {
-      "properties": {
-        "status": {
-          "type": "string",
-          "value": "off"
-        }
-      },
-      "commands": {},
-      "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.frostprotection",
-      "gatewayId": "################",
-      "feature": "heating.circuits.1.frostprotection",
-      "timestamp": "2021-09-30T03:57:02.355Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
       "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.temperature",
-      "gatewayId": "################",
-      "feature": "heating.circuits.3.temperature",
-      "timestamp": "2021-09-30T03:57:00.653Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [
-        "circulation",
-        "frostprotection",
-        "heating",
-        "operating",
-        "sensors",
-        "temperature"
-      ],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0",
-      "gatewayId": "################",
-      "feature": "heating.circuits.0",
-      "timestamp": "2021-09-30T03:56:59.981Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.circulation.pump",
-      "gatewayId": "################",
+      "deviceId": "0",
       "feature": "heating.circuits.3.circulation.pump",
-      "timestamp": "2021-09-30T03:57:00.199Z",
+      "gatewayId": "################",
       "isEnabled": false,
       "isReady": true,
-      "deviceId": "0"
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:57.704Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.circulation.pump"
     },
     {
-      "properties": {
-        "active": {
-          "value": false,
-          "type": "boolean"
-        },
-        "start": {
-          "value": "",
-          "type": "string"
-        },
-        "end": {
-          "value": "",
-          "type": "string"
-        }
-      },
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.2.operating.modes.heating",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.3.operating.programs.standby",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.standby"
+    },
+    {
+      "apiVersion": 1,
       "commands": {
         "changeEndDate": {
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/changeEndDate",
-          "name": "changeEndDate",
           "isExecutable": false,
+          "name": "changeEndDate",
           "params": {
             "end": {
-              "type": "string",
-              "required": true,
               "constraints": {
                 "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
                 "sameDayAllowed": true
-              }
+              },
+              "required": true,
+              "type": "string"
             }
-          }
+          },
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/changeEndDate"
         },
         "schedule": {
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/schedule",
-          "name": "schedule",
           "isExecutable": true,
+          "name": "schedule",
           "params": {
-            "start": {
-              "type": "string",
-              "required": true,
-              "constraints": {
-                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$"
-              }
-            },
             "end": {
-              "type": "string",
-              "required": true,
               "constraints": {
                 "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
                 "sameDayAllowed": true
-              }
+              },
+              "required": true,
+              "type": "string"
+            },
+            "start": {
+              "constraints": {
+                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$"
+              },
+              "required": true,
+              "type": "string"
             }
-          }
+          },
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/schedule"
         },
         "unschedule": {
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/unschedule",
+          "isExecutable": true,
           "name": "unschedule",
-          "isExecutable": true,
-          "params": {}
+          "params": {},
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/unschedule"
         }
       },
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome",
-      "gatewayId": "################",
+      "deviceId": "0",
       "feature": "heating.operating.programs.holidayAtHome",
-      "timestamp": "2021-09-30T03:57:02.345Z",
+      "gatewayId": "################",
       "isEnabled": true,
       "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "unit": {
-          "value": "celsius",
-          "type": "string"
-        },
-        "value": {
-          "type": "number",
-          "value": 12.4,
-          "unit": "celsius"
-        },
-        "status": {
-          "type": "string",
-          "value": "connected"
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.sensors.temperature.outside",
-      "gatewayId": "################",
-      "feature": "heating.sensors.temperature.outside",
-      "timestamp": "2021-09-30T09:43:42.187Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "unit": {
-          "value": "celsius",
-          "type": "string"
-        },
-        "value": {
-          "type": "number",
-          "value": 42.9,
-          "unit": "celsius"
-        },
-        "status": {
-          "type": "string",
-          "value": "connected"
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.top",
-      "gatewayId": "################",
-      "feature": "heating.dhw.sensors.temperature.hotWaterStorage.top",
-      "timestamp": "2021-09-30T09:43:01.536Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room",
-      "gatewayId": "################",
-      "feature": "heating.circuits.0.sensors.temperature.room",
-      "timestamp": "2021-09-30T03:57:02.311Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfort",
-      "gatewayId": "################",
-      "feature": "heating.circuits.2.operating.programs.comfort",
-      "timestamp": "2021-09-30T03:57:02.720Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["pump"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.circulation",
-      "gatewayId": "################",
-      "feature": "heating.circuits.1.circulation",
-      "timestamp": "2021-09-30T03:56:58.130Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule",
-      "gatewayId": "################",
-      "feature": "heating.circuits.0.operating.programs.forcedLastFromSchedule",
-      "timestamp": "2021-09-30T03:57:02.346Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
       "properties": {
         "active": {
-          "value": true,
-          "type": "boolean"
+          "type": "boolean",
+          "value": false
         },
-        "entries": {
-          "value": {
-            "mon": [],
-            "tue": [],
-            "wed": [],
-            "thu": [],
-            "fri": [],
-            "sat": [],
-            "sun": []
-          },
-          "type": "Schedule"
+        "end": {
+          "type": "string",
+          "value": ""
+        },
+        "start": {
+          "type": "string",
+          "value": ""
         }
       },
-      "commands": {
-        "setSchedule": {
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule",
-          "name": "setSchedule",
-          "isExecutable": true,
-          "params": {
-            "newSchedule": {
-              "type": "Schedule",
-              "required": true,
-              "constraints": {
-                "modes": ["on"],
-                "maxEntries": 4,
-                "resolution": 10,
-                "defaultMode": "off",
-                "overlapAllowed": false
-              }
-            }
-          }
-        }
-      },
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.schedule",
-      "gatewayId": "################",
-      "feature": "heating.dhw.schedule",
-      "timestamp": "2021-09-30T03:57:02.302Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome"
     },
     {
-      "properties": {},
-      "commands": {},
-      "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating",
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.1.operating.modes.dhwAndHeating",
       "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": true
+        }
+      },
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.dhw.sensors.temperature.hotWaterStorage",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "status": {
+          "type": "string",
+          "value": "connected"
+        },
+        "value": {
+          "type": "number",
+          "unit": "celsius",
+          "value": 50.1
+        }
+      },
+      "timestamp": "2022-11-18T06:54:52.735Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
       "feature": "heating.circuits.0.operating.modes.heating",
-      "timestamp": "2021-09-30T03:57:01.692Z",
+      "gatewayId": "################",
       "isEnabled": false,
       "isReady": true,
-      "deviceId": "0"
-    },
-    {
       "properties": {},
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
+    },
+    {
+      "apiVersion": 1,
       "commands": {},
-      "components": ["hygiene", "levels", "main"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.temperature",
+      "deviceId": "0",
+      "feature": "heating.buffer.sensors.temperature.main",
       "gatewayId": "################",
-      "feature": "heating.dhw.temperature",
-      "timestamp": "2021-09-30T03:56:58.129Z",
-      "isEnabled": true,
+      "isEnabled": false,
       "isReady": true,
-      "deviceId": "0"
+      "properties": {},
+      "timestamp": "2022-11-18T06:52:46.561Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.buffer.sensors.temperature.main"
     },
     {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.dhw.sensors.temperature.hotWaterStorage.bottom",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
       "properties": {
-        "active": {
-          "value": false,
-          "type": "boolean"
+        "status": {
+          "type": "string",
+          "value": "connected"
         },
-        "demand": {
-          "value": "unknown",
-          "type": "string"
-        },
-        "temperature": {
-          "value": 18,
-          "unit": "",
-          "type": "number"
+        "value": {
+          "type": "number",
+          "unit": "celsius",
+          "value": 50.1
         }
       },
+      "timestamp": "2022-11-18T06:51:16.055Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.bottom"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.burners.0.modulation",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "value": {
+          "type": "number",
+          "unit": "percent",
+          "value": 0
+        }
+      },
+      "timestamp": "2022-11-18T04:27:57.635Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners.0.modulation"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.3.operating.programs.reduced",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:28:01.289Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reduced"
+    },
+    {
+      "apiVersion": 1,
       "commands": {
-        "setTemperature": {
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced/commands/setTemperature",
-          "name": "setTemperature",
+        "activate": {
           "isExecutable": true,
-          "params": {
-            "targetTemperature": {
-              "type": "number",
-              "required": true,
-              "constraints": {
-                "min": 3,
-                "max": 37,
-                "stepping": 1
-              }
-            }
-          }
+          "name": "activate",
+          "params": {},
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/activate"
+        },
+        "disable": {
+          "isExecutable": true,
+          "name": "disable",
+          "params": {},
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/disable"
+        },
+        "enable": {
+          "isExecutable": false,
+          "name": "enable",
+          "params": {},
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/enable"
         }
       },
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced",
+      "deviceId": "0",
+      "feature": "heating.dhw.hygiene",
       "gatewayId": "################",
-      "feature": "heating.circuits.1.operating.programs.reduced",
-      "timestamp": "2021-09-30T03:57:02.883Z",
       "isEnabled": true,
       "isReady": true,
-      "deviceId": "0"
-    },
-    {
       "properties": {
         "active": {
-          "value": true,
-          "type": "boolean"
+          "type": "boolean",
+          "value": false
         },
-        "name": {
-          "value": "Heizk\u00f6rper",
-          "type": "string"
-        },
-        "type": {
-          "value": "heatingCircuit",
-          "type": "string"
+        "enabled": {
+          "type": "boolean",
+          "value": true
         }
       },
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.0.operating.programs.standby",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {
+        "setCurve": {
+          "isExecutable": true,
+          "name": "setCurve",
+          "params": {
+            "shift": {
+              "constraints": {
+                "max": 40,
+                "min": -13,
+                "stepping": 1
+              },
+              "required": true,
+              "type": "number"
+            },
+            "slope": {
+              "constraints": {
+                "max": 3.5,
+                "min": 0.2,
+                "stepping": 0.1
+              },
+              "required": true,
+              "type": "number"
+            }
+          },
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve/commands/setCurve"
+        }
+      },
+      "deviceId": "0",
+      "feature": "heating.circuits.1.heating.curve",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "shift": {
+          "type": "number",
+          "unit": "",
+          "value": 2
+        },
+        "slope": {
+          "type": "number",
+          "unit": "",
+          "value": 0.5
+        }
+      },
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.2.operating.programs.standby",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "enabled": {
+          "type": "array",
+          "value": [
+            "1"
+          ]
+        }
+      },
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits"
+    },
+    {
+      "apiVersion": 1,
       "commands": {
         "setName": {
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1/commands/setName",
-          "name": "setName",
           "isExecutable": true,
+          "name": "setName",
           "params": {
             "name": {
-              "type": "string",
-              "required": true,
               "constraints": {
-                "minLength": 1,
-                "maxLength": 20
-              }
+                "maxLength": 20,
+                "minLength": 1
+              },
+              "required": true,
+              "type": "string"
             }
-          }
+          },
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1/commands/setName"
         }
       },
-      "components": [
-        "circulation",
-        "frostprotection",
-        "heating",
-        "operating",
-        "sensors",
-        "temperature"
-      ],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1",
-      "gatewayId": "################",
+      "deviceId": "0",
       "feature": "heating.circuits.1",
-      "timestamp": "2021-09-30T03:57:00.029Z",
+      "gatewayId": "################",
       "isEnabled": true,
       "isReady": true,
-      "deviceId": "0"
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": true
+        },
+        "name": {
+          "type": "string",
+          "value": "Fußbodenheizung"
+        },
+        "type": {
+          "type": "string",
+          "value": "heatingCircuit"
+        }
+      },
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1"
     },
     {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.power.production.cumulative",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "value": {
+          "type": "number",
+          "unit": "kilowattHour",
+          "value": 4537
+        }
+      },
+      "timestamp": "2022-11-18T04:27:57.716Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.production.cumulative"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.2.heating.schedule",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.schedule"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.2.operating.modes.dhwAndHeating",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeating"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {
+        "changeEndDate": {
+          "isExecutable": false,
+          "name": "changeEndDate",
+          "params": {
+            "end": {
+              "constraints": {
+                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
+                "sameDayAllowed": true
+              },
+              "required": true,
+              "type": "string"
+            }
+          },
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
+        },
+        "schedule": {
+          "isExecutable": true,
+          "name": "schedule",
+          "params": {
+            "end": {
+              "constraints": {
+                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
+                "sameDayAllowed": true
+              },
+              "required": true,
+              "type": "string"
+            },
+            "start": {
+              "constraints": {
+                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$"
+              },
+              "required": true,
+              "type": "string"
+            }
+          },
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/schedule"
+        },
+        "unschedule": {
+          "isExecutable": true,
+          "name": "unschedule",
+          "params": {},
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
+        }
+      },
+      "deviceId": "0",
+      "feature": "heating.operating.programs.holiday",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": false
+        },
+        "end": {
+          "type": "string",
+          "value": "2022-06-17"
+        },
+        "start": {
+          "type": "string",
+          "value": "2022-06-16"
+        }
+      },
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.dhw.sensors.temperature.hotWaterStorage.top",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "status": {
+          "type": "string",
+          "value": "connected"
+        },
+        "value": {
+          "type": "number",
+          "unit": "celsius",
+          "value": 50.1
+        }
+      },
+      "timestamp": "2022-11-18T06:54:52.860Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.top"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.sensors.temperature.hydraulicSeparator",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "status": {
+          "type": "string",
+          "value": "connected"
+        },
+        "value": {
+          "type": "number",
+          "unit": "celsius",
+          "value": 22.3
+        }
+      },
+      "timestamp": "2022-11-18T06:52:46.507Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.hydraulicSeparator"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.fuelCell.operating.modes.ecological",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": false
+        }
+      },
+      "timestamp": "2022-11-18T04:27:57.800Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.operating.modes.ecological"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.boiler.sensors.temperature.commonSupply",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "status": {
+          "type": "string",
+          "value": "connected"
+        },
+        "value": {
+          "type": "number",
+          "unit": "celsius",
+          "value": 22.2
+        }
+      },
+      "timestamp": "2022-11-18T06:41:13.934Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.burners",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "enabled": {
+          "type": "array",
+          "value": [
+            "0"
+          ]
+        }
+      },
+      "timestamp": "2022-11-18T04:27:58.860Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.0.circulation.pump",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:57.702Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.circulation.pump"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.power.consumption.summary.heating",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "currentDay": {
+          "type": "number",
+          "unit": "kilowattHour",
+          "value": 0.5
+        },
+        "currentMonth": {
+          "type": "number",
+          "unit": "kilowattHour",
+          "value": 23.9
+        },
+        "currentYear": {
+          "type": "number",
+          "unit": "kilowattHour",
+          "value": 338
+        },
+        "lastMonth": {
+          "type": "number",
+          "unit": "kilowattHour",
+          "value": 27
+        },
+        "lastSevenDays": {
+          "type": "number",
+          "unit": "kilowattHour",
+          "value": 9.8
+        },
+        "lastYear": {
+          "type": "number",
+          "unit": "kilowattHour",
+          "value": 199.6
+        }
+      },
+      "timestamp": "2022-11-18T06:39:44.018Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.heating"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.3.operating.programs.comfort",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:28:01.278Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfort"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {
+        "setTargetTemperature": {
+          "isExecutable": true,
+          "name": "setTargetTemperature",
+          "params": {
+            "temperature": {
+              "constraints": {
+                "efficientLowerBorder": 10,
+                "efficientUpperBorder": 60,
+                "max": 60,
+                "min": 10,
+                "stepping": 1
+              },
+              "required": true,
+              "type": "number"
+            }
+          },
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
+        }
+      },
+      "deviceId": "0",
+      "feature": "heating.dhw.temperature.main",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "value": {
+          "type": "number",
+          "unit": "celsius",
+          "value": 45
+        }
+      },
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.0.operating.modes.standby",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {
+        "setCurve": {
+          "isExecutable": true,
+          "name": "setCurve",
+          "params": {
+            "shift": {
+              "constraints": {
+                "max": 40,
+                "min": -13,
+                "stepping": 1
+              },
+              "required": true,
+              "type": "number"
+            },
+            "slope": {
+              "constraints": {
+                "max": 3.5,
+                "min": 0.2,
+                "stepping": 0.1
+              },
+              "required": true,
+              "type": "number"
+            }
+          },
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve"
+        }
+      },
+      "deviceId": "0",
+      "feature": "heating.circuits.0.heating.curve",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
       "properties": {
         "shift": {
           "type": "number",
@@ -827,2504 +932,2851 @@
           "value": 1.4
         }
       },
-      "commands": {
-        "setCurve": {
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.heating.curve/commands/setCurve",
-          "name": "setCurve",
-          "isExecutable": true,
-          "params": {
-            "slope": {
-              "type": "number",
-              "required": true,
-              "constraints": {
-                "min": 0.2,
-                "max": 3.5,
-                "stepping": 0.1
-              }
-            },
-            "shift": {
-              "type": "number",
-              "required": true,
-              "constraints": {
-                "min": -13,
-                "max": 40,
-                "stepping": 1
-              }
-            }
-          }
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.0.temperature",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:57.712Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.gas.consumption.summary.heating",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "currentDay": {
+          "type": "number",
+          "unit": "cubicMeter",
+          "value": 0
+        },
+        "currentMonth": {
+          "type": "number",
+          "unit": "cubicMeter",
+          "value": 1
+        },
+        "currentYear": {
+          "type": "number",
+          "unit": "cubicMeter",
+          "value": 67.6
+        },
+        "lastMonth": {
+          "type": "number",
+          "unit": "cubicMeter",
+          "value": 0.9
+        },
+        "lastSevenDays": {
+          "type": "number",
+          "unit": "cubicMeter",
+          "value": 0.6
+        },
+        "lastYear": {
+          "type": "number",
+          "unit": "cubicMeter",
+          "value": 95.3
         }
       },
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.heating.curve",
-      "gatewayId": "################",
-      "feature": "heating.circuits.2.heating.curve",
-      "timestamp": "2021-09-30T03:57:02.331Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
+      "timestamp": "2022-11-18T04:27:58.875Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.summary.heating"
     },
     {
-      "properties": {},
+      "apiVersion": 1,
       "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.sensors",
+      "deviceId": "0",
+      "feature": "heating.power.consumption.heating",
       "gatewayId": "################",
-      "feature": "heating.dhw.sensors",
-      "timestamp": "2021-09-30T03:56:58.129Z",
       "isEnabled": true,
       "isReady": true,
-      "deviceId": "0"
+      "properties": {
+        "day": {
+          "type": "array",
+          "unit": "kilowattHour",
+          "value": [
+            0.5,
+            1.5,
+            1.5,
+            1.5,
+            1.5,
+            1.5,
+            1.5,
+            1.5
+          ]
+        },
+        "dayValueReadAt": {
+          "type": "string",
+          "value": "2022-11-18T06:39:14.292Z"
+        },
+        "month": {
+          "type": "array",
+          "unit": "kilowattHour",
+          "value": [
+            23.9,
+            27,
+            23.1,
+            20.8,
+            21.1,
+            20.7,
+            21.2,
+            45.4,
+            46.6,
+            41.9,
+            45.9,
+            45.6,
+            44.4
+          ]
+        },
+        "monthValueReadAt": {
+          "type": "string",
+          "value": "2022-11-18T06:39:14.292Z"
+        },
+        "week": {
+          "type": "array",
+          "unit": "kilowattHour",
+          "value": [
+            6.5,
+            10.5,
+            6.499999999999999,
+            4.2,
+            4.2,
+            4.2,
+            9.1
+          ]
+        },
+        "weekValueReadAt": {
+          "type": "string",
+          "value": "2022-11-18T05:07:09.802Z"
+        },
+        "year": {
+          "type": "array",
+          "unit": "kilowattHour",
+          "value": [
+            338,
+            199.6
+          ]
+        },
+        "yearValueReadAt": {
+          "type": "string",
+          "value": "2022-11-18T06:39:14.292Z"
+        }
+      },
+      "timestamp": "2022-11-18T06:39:43.880Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.heating"
     },
     {
+      "apiVersion": 1,
+      "commands": {
+        "setTemperature": {
+          "isExecutable": true,
+          "name": "setTemperature",
+          "params": {
+            "targetTemperature": {
+              "constraints": {
+                "max": 85,
+                "min": 10,
+                "stepping": 1
+              },
+              "required": true,
+              "type": "number"
+            }
+          },
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hygiene/commands/setTemperature"
+        }
+      },
+      "deviceId": "0",
+      "feature": "heating.dhw.temperature.hygiene",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
       "properties": {
         "value": {
           "type": "number",
-          "value": 113,
-          "unit": ""
+          "unit": "celsius",
+          "value": 65
         }
       },
-      "commands": {},
-      "components": [],
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hygiene"
+    },
+    {
       "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.device.time.offset",
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.3.sensors.temperature.supply",
       "gatewayId": "################",
-      "feature": "heating.device.time.offset",
-      "timestamp": "2021-09-30T03:56:59.929Z",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:58.853Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.supply"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.burners.0.statistics",
+      "gatewayId": "################",
       "isEnabled": true,
       "isReady": true,
-      "deviceId": "0"
+      "properties": {
+        "hours": {
+          "type": "number",
+          "unit": "hour",
+          "value": 282
+        },
+        "starts": {
+          "type": "number",
+          "unit": "",
+          "value": 3862
+        }
+      },
+      "timestamp": "2022-11-18T04:27:57.634Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners.0.statistics"
     },
     {
-      "properties": {},
-      "commands": {},
-      "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeating",
+      "commands": {
+        "triggerDaily": {
+          "isExecutable": false,
+          "name": "triggerDaily",
+          "params": {
+            "startHour": {
+              "constraints": {
+                "max": 23,
+                "min": 0,
+                "stepping": 1
+              },
+              "required": true,
+              "type": "number"
+            },
+            "startMinute": {
+              "constraints": {
+                "max": 50,
+                "min": 0,
+                "stepping": 10
+              },
+              "required": true,
+              "type": "number"
+            }
+          },
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene.trigger/commands/triggerDaily"
+        },
+        "triggerOncePerWeek": {
+          "isExecutable": true,
+          "name": "triggerOncePerWeek",
+          "params": {
+            "startHour": {
+              "constraints": {
+                "max": 23,
+                "min": 0,
+                "stepping": 1
+              },
+              "required": true,
+              "type": "number"
+            },
+            "startMinute": {
+              "constraints": {
+                "max": 50,
+                "min": 0,
+                "stepping": 10
+              },
+              "required": true,
+              "type": "number"
+            },
+            "weekday": {
+              "constraints": {
+                "enum": [
+                  "Mon",
+                  "Tue",
+                  "Wed",
+                  "Thu",
+                  "Fri",
+                  "Sat",
+                  "Sun"
+                ]
+              },
+              "required": true,
+              "type": "string"
+            }
+          },
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene.trigger/commands/triggerOncePerWeek"
+        }
+      },
+      "deviceId": "0",
+      "feature": "heating.dhw.hygiene.trigger",
       "gatewayId": "################",
-      "feature": "heating.circuits.2.operating.modes.dhwAndHeating",
-      "timestamp": "2021-09-30T03:57:01.654Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["temperature"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.sensors",
-      "gatewayId": "################",
-      "feature": "heating.circuits.0.sensors",
-      "timestamp": "2021-09-30T03:56:58.130Z",
       "isEnabled": true,
       "isReady": true,
-      "deviceId": "0"
+      "properties": {
+        "startHour": {
+          "type": "number",
+          "unit": "hour",
+          "value": 1
+        },
+        "startMinute": {
+          "type": "number",
+          "unit": "minute",
+          "value": 30
+        },
+        "weekdays": {
+          "type": "array",
+          "value": [
+            "Sat"
+          ]
+        }
+      },
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene.trigger"
     },
     {
-      "properties": {},
-      "commands": {},
-      "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.heating.schedule",
+      "commands": {
+        "setMode": {
+          "isExecutable": false,
+          "name": "setMode",
+          "params": {
+            "mode": {
+              "constraints": {
+                "enum": [
+                  "standby",
+                  "maintenance",
+                  "heatControlled",
+                  "economical",
+                  "ecological"
+                ]
+              },
+              "required": true,
+              "type": "string"
+            }
+          },
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.operating.modes.active/commands/setMode"
+        }
+      },
+      "deviceId": "0",
+      "feature": "heating.fuelCell.operating.modes.active",
       "gatewayId": "################",
-      "feature": "heating.circuits.2.heating.schedule",
-      "timestamp": "2021-09-30T03:57:02.296Z",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "value": {
+          "type": "string",
+          "value": "economical"
+        }
+      },
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.operating.modes.active"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.3",
+      "gatewayId": "################",
       "isEnabled": false,
       "isReady": true,
-      "deviceId": "0"
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3"
     },
     {
-      "properties": {},
-      "commands": {},
-      "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby",
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.dhw.pumps.secondary",
       "gatewayId": "################",
-      "feature": "heating.circuits.0.operating.modes.standby",
-      "timestamp": "2021-09-30T03:57:00.950Z",
       "isEnabled": false,
       "isReady": true,
-      "deviceId": "0"
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:57.652Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.secondary"
     },
     {
-      "properties": {},
-      "commands": {},
-      "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.frostprotection",
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.0.sensors.temperature.supply",
       "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T06:57:05.438Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.3.operating.programs.active",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:59.634Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.active"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.fuelCell.operating.modes.heatControlled",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": false
+        }
+      },
+      "timestamp": "2022-11-18T04:27:57.799Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.operating.modes.heatControlled"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.solar.statistics",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:59.619Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.statistics"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.sensors.temperature.outside",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "status": {
+          "type": "string",
+          "value": "connected"
+        },
+        "value": {
+          "type": "number",
+          "unit": "celsius",
+          "value": 12
+        }
+      },
+      "timestamp": "2022-11-18T06:57:00.381Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.outside"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.burners.0",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": false
+        }
+      },
+      "timestamp": "2022-11-18T04:27:58.862Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners.0"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.gas.consumption.fuelCell",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "day": {
+          "type": "array",
+          "unit": "cubicMeter",
+          "value": [
+            1.5,
+            0.2,
+            0.2,
+            0.2,
+            0.2,
+            0.2,
+            0.2,
+            0.2
+          ]
+        },
+        "dayValueReadAt": {
+          "type": "string",
+          "value": "2022-11-17T23:00:56.829Z"
+        },
+        "month": {
+          "type": "array",
+          "unit": "cubicMeter",
+          "value": [
+            4.9,
+            55.5,
+            50.9,
+            35.1,
+            10.9,
+            0,
+            49.4,
+            85.4,
+            108.5,
+            118,
+            132.5,
+            120.7,
+            111.5
+          ]
+        },
+        "monthValueReadAt": {
+          "type": "string",
+          "value": "2022-11-17T23:00:56.717Z"
+        },
+        "week": {
+          "type": "array",
+          "unit": "cubicMeter",
+          "value": [
+            2.3000000000000003,
+            1.4,
+            1.4,
+            1.4,
+            1.4,
+            1.4,
+            1.4
+          ]
+        },
+        "weekValueReadAt": {
+          "type": "string",
+          "value": "2022-11-17T23:00:56.829Z"
+        },
+        "year": {
+          "type": "array",
+          "unit": "cubicMeter",
+          "value": [
+            651.1,
+            416.6
+          ]
+        },
+        "yearValueReadAt": {
+          "type": "string",
+          "value": "2022-11-17T23:00:56.829Z"
+        }
+      },
+      "timestamp": "2022-11-18T04:27:57.665Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.fuelCell"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.3.operating.modes.standby",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.standby"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.0.operating.programs.forcedLastFromSchedule",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.gas.consumption.summary.dhw",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "currentDay": {
+          "type": "number",
+          "unit": "cubicMeter",
+          "value": 0
+        },
+        "currentMonth": {
+          "type": "number",
+          "unit": "cubicMeter",
+          "value": 3.4
+        },
+        "currentYear": {
+          "type": "number",
+          "unit": "cubicMeter",
+          "value": 73.2
+        },
+        "lastMonth": {
+          "type": "number",
+          "unit": "cubicMeter",
+          "value": 3.6
+        },
+        "lastSevenDays": {
+          "type": "number",
+          "unit": "cubicMeter",
+          "value": 1.6
+        },
+        "lastYear": {
+          "type": "number",
+          "unit": "cubicMeter",
+          "value": 90.5
+        }
+      },
+      "timestamp": "2022-11-18T04:27:58.877Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.summary.dhw"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.power.consumption.total",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "day": {
+          "type": "array",
+          "unit": "kilowattHour",
+          "value": [
+            0.5,
+            1.5,
+            1.5,
+            1.5,
+            1.5,
+            1.5,
+            1.5,
+            1.5
+          ]
+        },
+        "dayValueReadAt": {
+          "type": "string",
+          "value": "2022-11-18T06:39:14.292Z"
+        },
+        "month": {
+          "type": "array",
+          "unit": "kilowattHour",
+          "value": [
+            24,
+            27.1,
+            23.200000000000003,
+            20.900000000000002,
+            21.200000000000003,
+            20.9,
+            21.3,
+            45.5,
+            46.9,
+            42.4,
+            46.8,
+            46.4,
+            45.199999999999996
+          ]
+        },
+        "monthValueReadAt": {
+          "type": "string",
+          "value": "2022-11-18T06:39:14.292Z"
+        },
+        "week": {
+          "type": "array",
+          "unit": "kilowattHour",
+          "value": [
+            6.5,
+            10.5,
+            6.499999999999999,
+            4.2,
+            4.2,
+            4.2,
+            9.1
+          ]
+        },
+        "weekValueReadAt": {
+          "type": "string",
+          "value": "2022-11-18T05:07:09.802Z"
+        },
+        "year": {
+          "type": "array",
+          "unit": "kilowattHour",
+          "value": [
+            341.2,
+            204.9
+          ]
+        },
+        "yearValueReadAt": {
+          "type": "string",
+          "value": "2022-11-18T06:39:14.292Z"
+        }
+      },
+      "timestamp": "2022-11-18T06:39:43.954Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.total"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.solar.power.production",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:59.618Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.power.production"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.0.operating.programs.active",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:59.630Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.2.operating.modes.active",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:58.793Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.fuelCell.sensors.temperature.return",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "status": {
+          "type": "string",
+          "value": "connected"
+        },
+        "value": {
+          "type": "number",
+          "unit": "celsius",
+          "value": 33.9
+        }
+      },
+      "timestamp": "2022-11-18T06:55:53.994Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.sensors.temperature.return"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.1.frostprotection",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "status": {
+          "type": "string",
+          "value": "off"
+        }
+      },
+      "timestamp": "2022-11-18T04:27:58.869Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.solar.rechargeSuppression",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:59.622Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.rechargeSuppression"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.2.operating.programs.normal",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:28:01.283Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normal"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "device.serial",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "value": {
+          "type": "string",
+          "value": "################"
+        }
+      },
+      "timestamp": "2022-11-18T04:27:57.629Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/device.serial"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.3.sensors.temperature.room",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:58.848Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.room"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.power.consumption.dhw",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "day": {
+          "type": "array",
+          "unit": "kilowattHour",
+          "value": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+          ]
+        },
+        "dayValueReadAt": {
+          "type": "string",
+          "value": "2022-11-17T17:34:03.217Z"
+        },
+        "month": {
+          "type": "array",
+          "unit": "kilowattHour",
+          "value": [
+            0.1,
+            0.1,
+            0.1,
+            0.1,
+            0.1,
+            0.2,
+            0.1,
+            0.1,
+            0.3,
+            0.5,
+            0.9,
+            0.8,
+            0.8
+          ]
+        },
+        "monthValueReadAt": {
+          "type": "string",
+          "value": "2022-11-17T17:34:03.217Z"
+        },
+        "week": {
+          "type": "array",
+          "unit": "kilowattHour",
+          "value": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+          ]
+        },
+        "weekValueReadAt": {
+          "type": "string",
+          "value": "2022-11-17T17:34:03.273Z"
+        },
+        "year": {
+          "type": "array",
+          "unit": "kilowattHour",
+          "value": [
+            3.2,
+            5.3
+          ]
+        },
+        "yearValueReadAt": {
+          "type": "string",
+          "value": "2022-11-17T17:34:03.217Z"
+        }
+      },
+      "timestamp": "2022-11-18T04:27:57.676Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.dhw"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.solar.sensors.temperature.dhw",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:59.620Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.dhw"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {
+        "setCurve": {
+          "isExecutable": true,
+          "name": "setCurve",
+          "params": {
+            "shift": {
+              "constraints": {
+                "max": 40,
+                "min": -13,
+                "stepping": 1
+              },
+              "required": true,
+              "type": "number"
+            },
+            "slope": {
+              "constraints": {
+                "max": 3.5,
+                "min": 0.2,
+                "stepping": 0.1
+              },
+              "required": true,
+              "type": "number"
+            }
+          },
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.heating.curve/commands/setCurve"
+        }
+      },
+      "deviceId": "0",
+      "feature": "heating.circuits.3.heating.curve",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "shift": {
+          "type": "number",
+          "unit": "",
+          "value": 0
+        },
+        "slope": {
+          "type": "number",
+          "unit": "",
+          "value": 1.4
+        }
+      },
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.heating.curve"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.3.operating.programs.forcedLastFromSchedule",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.forcedLastFromSchedule"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.2.temperature",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:57.714Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.temperature"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.dhw.pumps.primary",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:57.651Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.primary"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.sensors.pressure.supply",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "status": {
+          "type": "string",
+          "value": "connected"
+        },
+        "value": {
+          "type": "number",
+          "unit": "bar",
+          "value": 1.7
+        }
+      },
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.pressure.supply"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.0.operating.programs.normal",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:28:01.283Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.boiler.serial",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "value": {
+          "type": "string",
+          "value": "################"
+        }
+      },
+      "timestamp": "2022-11-18T04:27:57.486Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.1.temperature",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T05:06:28.908Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.solar",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:59.610Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.3.heating.schedule",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.heating.schedule"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.3.operating.modes.dhwAndHeating",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.dhwAndHeating"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.1.sensors.temperature.supply",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "status": {
+          "type": "string",
+          "value": "connected"
+        },
+        "value": {
+          "type": "number",
+          "unit": "celsius",
+          "value": 22.3
+        }
+      },
+      "timestamp": "2022-11-18T06:57:05.481Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.0.operating.modes.dhwAndHeating",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.3.operating.programs.normal",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:28:01.284Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normal"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.2.circulation.pump",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:57.704Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.circulation.pump"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.0.operating.programs.reduced",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:28:01.289Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.3.frostprotection",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:58.871Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.frostprotection"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.gas.consumption.dhw",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "day": {
+          "type": "array",
+          "unit": "cubicMeter",
+          "value": [
+            0,
+            0,
+            0.1,
+            0,
+            0.2,
+            0.4,
+            0.9,
+            0
+          ]
+        },
+        "dayValueReadAt": {
+          "type": "string",
+          "value": "2022-11-17T17:34:03.217Z"
+        },
+        "month": {
+          "type": "array",
+          "unit": "cubicMeter",
+          "value": [
+            3.4,
+            3.6,
+            2.5,
+            3.1,
+            4,
+            4.9,
+            3.3,
+            4.9,
+            9.3,
+            13.2,
+            20.9,
+            21.3,
+            19.1
+          ]
+        },
+        "monthValueReadAt": {
+          "type": "string",
+          "value": "2022-11-17T17:34:03.217Z"
+        },
+        "week": {
+          "type": "array",
+          "unit": "cubicMeter",
+          "value": [
+            0.30000000000000004,
+            1.4000000000000001,
+            1.7,
+            1.0999999999999999,
+            0.6000000000000001,
+            0.6000000000000001,
+            0.6
+          ]
+        },
+        "weekValueReadAt": {
+          "type": "string",
+          "value": "2022-11-17T17:34:03.281Z"
+        },
+        "year": {
+          "type": "array",
+          "unit": "cubicMeter",
+          "value": [
+            73.2,
+            90.5
+          ]
+        },
+        "yearValueReadAt": {
+          "type": "string",
+          "value": "2022-11-17T17:34:03.217Z"
+        }
+      },
+      "timestamp": "2022-11-18T04:27:57.664Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.dhw"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.0.sensors.temperature.room",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:58.844Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.fuelCell.operating.modes.economical",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": true
+        }
+      },
+      "timestamp": "2022-11-18T04:27:57.801Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.operating.modes.economical"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.solar.pumps.circuit",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:59.621Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.pumps.circuit"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.2.operating.modes.dhw",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhw"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.2",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.1.operating.modes.dhw",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": false
+        }
+      },
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhw"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {
+        "setSchedule": {
+          "isExecutable": true,
+          "name": "setSchedule",
+          "params": {
+            "newSchedule": {
+              "constraints": {
+                "defaultMode": "off",
+                "maxEntries": 4,
+                "modes": [
+                  "on"
+                ],
+                "overlapAllowed": false,
+                "resolution": 10
+              },
+              "required": true,
+              "type": "Schedule"
+            }
+          },
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule"
+        }
+      },
+      "deviceId": "0",
+      "feature": "heating.dhw.schedule",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": true
+        },
+        "entries": {
+          "type": "Schedule",
+          "value": {
+            "fri": [
+              {
+                "end": "22:00",
+                "mode": "on",
+                "position": 0,
+                "start": "06:30"
+              }
+            ],
+            "mon": [
+              {
+                "end": "22:00",
+                "mode": "on",
+                "position": 0,
+                "start": "06:30"
+              }
+            ],
+            "sat": [
+              {
+                "end": "23:00",
+                "mode": "on",
+                "position": 0,
+                "start": "07:30"
+              }
+            ],
+            "sun": [
+              {
+                "end": "23:00",
+                "mode": "on",
+                "position": 0,
+                "start": "07:30"
+              }
+            ],
+            "thu": [
+              {
+                "end": "22:00",
+                "mode": "on",
+                "position": 0,
+                "start": "06:30"
+              }
+            ],
+            "tue": [
+              {
+                "end": "22:00",
+                "mode": "on",
+                "position": 0,
+                "start": "06:30"
+              }
+            ],
+            "wed": [
+              {
+                "end": "22:00",
+                "mode": "on",
+                "position": 0,
+                "start": "06:30"
+              }
+            ]
+          }
+        }
+      },
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.gas.consumption.heating",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "day": {
+          "type": "array",
+          "unit": "cubicMeter",
+          "value": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0.6,
+            0
+          ]
+        },
+        "dayValueReadAt": {
+          "type": "string",
+          "value": "2022-11-17T17:34:03.216Z"
+        },
+        "month": {
+          "type": "array",
+          "unit": "cubicMeter",
+          "value": [
+            1,
+            0.9,
+            0,
+            0,
+            0,
+            0,
+            0,
+            8.9,
+            14.8,
+            12.8,
+            29.2,
+            42.4,
+            29.3
+          ]
+        },
+        "monthValueReadAt": {
+          "type": "string",
+          "value": "2022-11-17T17:34:03.216Z"
+        },
+        "week": {
+          "type": "array",
+          "unit": "cubicMeter",
+          "value": [
+            0,
+            0.6,
+            0.4,
+            0,
+            0,
+            0,
+            0.1
+          ]
+        },
+        "weekValueReadAt": {
+          "type": "string",
+          "value": "2022-11-17T17:34:03.277Z"
+        },
+        "year": {
+          "type": "array",
+          "unit": "cubicMeter",
+          "value": [
+            67.6,
+            95.3
+          ]
+        },
+        "yearValueReadAt": {
+          "type": "string",
+          "value": "2022-11-17T17:34:03.216Z"
+        }
+      },
+      "timestamp": "2022-11-18T04:27:57.663Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.heating"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.fuelCell.sensors.temperature.supply",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "status": {
+          "type": "string",
+          "value": "connected"
+        },
+        "value": {
+          "type": "number",
+          "unit": "celsius",
+          "value": 39
+        }
+      },
+      "timestamp": "2022-11-18T06:56:51.275Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.sensors.temperature.supply"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.0",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.sensors.temperature.allengra",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "status": {
+          "type": "string",
+          "value": "connected"
+        },
+        "value": {
+          "type": "number",
+          "unit": "celsius",
+          "value": 22.3
+        }
+      },
+      "timestamp": "2022-11-18T06:42:45.885Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.allengra"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.1.operating.programs.standby",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": false
+        }
+      },
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {
+        "activate": {
+          "isExecutable": true,
+          "name": "activate",
+          "params": {},
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/activate"
+        },
+        "deactivate": {
+          "isExecutable": false,
+          "name": "deactivate",
+          "params": {},
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate"
+        }
+      },
+      "deviceId": "0",
+      "feature": "heating.dhw.oneTimeCharge",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": false
+        }
+      },
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.fuelCell.operating.modes.standby",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": false
+        }
+      },
+      "timestamp": "2022-11-18T04:27:57.797Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.operating.modes.standby"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.power.purchase.cumulative",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "value": {
+          "type": "number",
+          "unit": "kilowattHour",
+          "value": 3767.1
+        }
+      },
+      "timestamp": "2022-11-18T06:52:34.117Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.purchase.cumulative"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.3.temperature",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:57.715Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.temperature"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.2.operating.programs.active",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:59.632Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.2.operating.modes.standby",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.1.operating.modes.heating",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": false
+        }
+      },
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.3.operating.modes.dhw",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.dhw"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.sensors.temperature.return",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "status": {
+          "type": "string",
+          "value": "connected"
+        },
+        "value": {
+          "type": "number",
+          "unit": "celsius",
+          "value": 22.2
+        }
+      },
+      "timestamp": "2022-11-18T06:56:34.985Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.return"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {
+        "activate": {
+          "isExecutable": false,
+          "name": "activate",
+          "params": {
+            "temperature": {
+              "constraints": {
+                "max": 37,
+                "min": 3,
+                "stepping": 1
+              },
+              "required": false,
+              "type": "number"
+            }
+          },
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort/commands/activate"
+        },
+        "deactivate": {
+          "isExecutable": false,
+          "name": "deactivate",
+          "params": {},
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort/commands/deactivate"
+        },
+        "setTemperature": {
+          "isExecutable": true,
+          "name": "setTemperature",
+          "params": {
+            "targetTemperature": {
+              "constraints": {
+                "max": 37,
+                "min": 3,
+                "stepping": 1
+              },
+              "required": true,
+              "type": "number"
+            }
+          },
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort/commands/setTemperature"
+        }
+      },
+      "deviceId": "0",
+      "feature": "heating.circuits.1.operating.programs.comfort",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": false
+        },
+        "demand": {
+          "type": "string",
+          "value": "unknown"
+        },
+        "temperature": {
+          "type": "number",
+          "unit": "celsius",
+          "value": 21
+        }
+      },
+      "timestamp": "2022-11-18T04:28:01.278Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.dhw.pumps.circulation",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "status": {
+          "type": "string",
+          "value": "on"
+        }
+      },
+      "timestamp": "2022-11-18T05:01:11.793Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.0.frostprotection",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:58.868Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
       "feature": "heating.circuits.2.frostprotection",
-      "timestamp": "2021-09-30T03:57:02.361Z",
+      "gatewayId": "################",
       "isEnabled": false,
       "isReady": true,
-      "deviceId": "0"
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:58.870Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.frostprotection"
     },
     {
-      "properties": {},
-      "commands": {},
-      "components": ["curve", "schedule"],
       "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.heating",
+      "commands": {
+        "setSchedule": {
+          "isExecutable": true,
+          "name": "setSchedule",
+          "params": {
+            "newSchedule": {
+              "constraints": {
+                "defaultMode": "off",
+                "maxEntries": 4,
+                "modes": [
+                  "on"
+                ],
+                "overlapAllowed": false,
+                "resolution": 10
+              },
+              "required": true,
+              "type": "Schedule"
+            }
+          },
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/setSchedule"
+        }
+      },
+      "deviceId": "0",
+      "feature": "heating.dhw.pumps.circulation.schedule",
       "gatewayId": "################",
-      "feature": "heating.circuits.2.heating",
-      "timestamp": "2021-09-30T03:56:58.129Z",
       "isEnabled": true,
       "isReady": true,
-      "deviceId": "0"
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": true
+        },
+        "entries": {
+          "type": "Schedule",
+          "value": {
+            "fri": [
+              {
+                "end": "23:00",
+                "mode": "on",
+                "position": 0,
+                "start": "06:00"
+              }
+            ],
+            "mon": [
+              {
+                "end": "23:00",
+                "mode": "on",
+                "position": 0,
+                "start": "06:00"
+              }
+            ],
+            "sat": [
+              {
+                "end": "23:00",
+                "mode": "on",
+                "position": 0,
+                "start": "06:00"
+              }
+            ],
+            "sun": [
+              {
+                "end": "23:00",
+                "mode": "on",
+                "position": 0,
+                "start": "06:00"
+              }
+            ],
+            "thu": [
+              {
+                "end": "23:00",
+                "mode": "on",
+                "position": 0,
+                "start": "06:00"
+              }
+            ],
+            "tue": [
+              {
+                "end": "23:00",
+                "mode": "on",
+                "position": 0,
+                "start": "06:00"
+              }
+            ],
+            "wed": [
+              {
+                "end": "23:00",
+                "mode": "on",
+                "position": 0,
+                "start": "06:00"
+              }
+            ]
+          }
+        }
+      },
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
     },
     {
-      "properties": {},
-      "commands": {},
-      "components": [
-        "active",
-        "comfort",
-        "forcedLastFromSchedule",
-        "normal",
-        "reduced",
-        "standby"
-      ],
       "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs",
+      "commands": {
+        "setMode": {
+          "isExecutable": true,
+          "name": "setMode",
+          "params": {
+            "mode": {
+              "constraints": {
+                "enum": [
+                  "standby",
+                  "heating",
+                  "dhw",
+                  "dhwAndHeating"
+                ]
+              },
+              "required": true,
+              "type": "string"
+            }
+          },
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active/commands/setMode"
+        }
+      },
+      "deviceId": "0",
+      "feature": "heating.circuits.1.operating.modes.active",
       "gatewayId": "################",
-      "feature": "heating.circuits.2.operating.programs",
-      "timestamp": "2021-09-30T03:56:58.129Z",
       "isEnabled": true,
       "isReady": true,
-      "deviceId": "0"
+      "properties": {
+        "value": {
+          "type": "string",
+          "value": "dhwAndHeating"
+        }
+      },
+      "timestamp": "2022-11-18T04:27:58.772Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
     },
     {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.flue.sensors.temperature.main",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "status": {
+          "type": "string",
+          "value": "connected"
+        },
+        "value": {
+          "type": "number",
+          "unit": "celsius",
+          "value": 24.6
+        }
+      },
+      "timestamp": "2022-11-18T06:54:52.906Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.flue.sensors.temperature.main"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.dhw",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": true
+        },
+        "status": {
+          "type": "string",
+          "value": "on"
+        }
+      },
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.power.production.current",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "status": {
+          "type": "string",
+          "value": "connected"
+        },
+        "value": {
+          "type": "number",
+          "unit": "watt",
+          "value": 0
+        }
+      },
+      "timestamp": "2022-11-18T04:27:57.669Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.production.current"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.2.operating.programs.comfort",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:28:01.278Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfort"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.1.sensors.temperature.room",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:58.846Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {
+        "activate": {
+          "isExecutable": true,
+          "name": "activate",
+          "params": {},
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule/commands/activate"
+        },
+        "deactivate": {
+          "isExecutable": false,
+          "name": "deactivate",
+          "params": {},
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule/commands/deactivate"
+        }
+      },
+      "deviceId": "0",
+      "feature": "heating.circuits.1.operating.programs.forcedLastFromSchedule",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": false
+        }
+      },
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.2.operating.programs.forcedLastFromSchedule",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.forcedLastFromSchedule"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.fuelCell.statistics",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "operationHours": {
+          "type": "number",
+          "unit": "hour",
+          "value": 11594
+        },
+        "productionHours": {
+          "type": "number",
+          "unit": "hour",
+          "value": 5980
+        },
+        "productionStarts": {
+          "type": "number",
+          "unit": "",
+          "value": 383
+        }
+      },
+      "timestamp": "2022-11-18T06:36:22.222Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.statistics"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.gas.consumption.total",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "day": {
+          "type": "array",
+          "unit": "cubicMeter",
+          "value": [
+            1.5,
+            0.2,
+            0.30000000000000004,
+            0.2,
+            0.4,
+            0.6000000000000001,
+            1.7,
+            0.2
+          ]
+        },
+        "dayValueReadAt": {
+          "type": "string",
+          "value": "2022-11-17T17:34:03.217Z"
+        },
+        "month": {
+          "type": "array",
+          "unit": "cubicMeter",
+          "value": [
+            9.3,
+            60,
+            53.4,
+            38.2,
+            14.9,
+            4.9,
+            52.699999999999996,
+            99.2,
+            132.6,
+            144,
+            182.6,
+            184.4,
+            159.9
+          ]
+        },
+        "monthValueReadAt": {
+          "type": "string",
+          "value": "2022-11-17T17:34:03.217Z"
+        },
+        "week": {
+          "type": "array",
+          "unit": "cubicMeter",
+          "value": [
+            2.6,
+            3.4000000000000004,
+            3.5000000000000004,
+            2.5,
+            2,
+            2,
+            2.0999999999999996
+          ]
+        },
+        "weekValueReadAt": {
+          "type": "string",
+          "value": "2022-11-17T17:34:03.281Z"
+        },
+        "year": {
+          "type": "array",
+          "unit": "cubicMeter",
+          "value": [
+            791.9000000000001,
+            602.4000000000001
+          ]
+        },
+        "yearValueReadAt": {
+          "type": "string",
+          "value": "2022-11-17T17:34:03.217Z"
+        }
+      },
+      "timestamp": "2022-11-18T04:27:59.626Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.total"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.power.sold.cumulative",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "value": {
+          "type": "number",
+          "unit": "kilowattHour",
+          "value": 1822.1
+        }
+      },
+      "timestamp": "2022-11-18T04:27:57.721Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.sold.cumulative"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.0.operating.programs.comfort",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:28:01.277Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.2.operating.programs.reduced",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:28:01.289Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reduced"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.fuelCell.power.production",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "day": {
+          "type": "array",
+          "unit": "kilowattHour",
+          "value": [
+            0.8,
+            18.3,
+            13,
+            15.1,
+            16.5,
+            18.3,
+            8.6,
+            18.3
+          ]
+        },
+        "dayValueReadAt": {
+          "type": "string",
+          "value": "2022-11-18T00:02:58.996Z"
+        },
+        "month": {
+          "type": "array",
+          "unit": "kilowattHour",
+          "value": [
+            212.6,
+            206.7,
+            190,
+            130.4,
+            39.9,
+            0,
+            187.4,
+            327.2,
+            411.3,
+            441.2,
+            500.7,
+            460.5,
+            431.4
+          ]
+        },
+        "monthValueReadAt": {
+          "type": "string",
+          "value": "2022-11-18T00:02:58.996Z"
+        },
+        "week": {
+          "type": "array",
+          "unit": "kilowattHour",
+          "value": [
+            63.7,
+            95.80000000000001,
+            60.9,
+            40.2,
+            41.300000000000004,
+            40.6,
+            58.699999999999996
+          ]
+        },
+        "weekValueReadAt": {
+          "type": "string",
+          "value": "2022-11-18T00:02:58.903Z"
+        },
+        "year": {
+          "type": "array",
+          "unit": "kilowattHour",
+          "value": [
+            2647.4,
+            1609.2
+          ]
+        },
+        "yearValueReadAt": {
+          "type": "string",
+          "value": "2022-11-18T00:02:58.996Z"
+        }
+      },
+      "timestamp": "2022-11-18T04:27:57.666Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.power.production"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.dhw.operating.modes.off",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": false
+        }
+      },
+      "timestamp": "2022-11-18T04:27:57.638Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.off"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {
+        "setCurve": {
+          "isExecutable": true,
+          "name": "setCurve",
+          "params": {
+            "shift": {
+              "constraints": {
+                "max": 40,
+                "min": -13,
+                "stepping": 1
+              },
+              "required": true,
+              "type": "number"
+            },
+            "slope": {
+              "constraints": {
+                "max": 3.5,
+                "min": 0.2,
+                "stepping": 0.1
+              },
+              "required": true,
+              "type": "number"
+            }
+          },
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.curve/commands/setCurve"
+        }
+      },
+      "deviceId": "0",
+      "feature": "heating.circuits.2.heating.curve",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "shift": {
+          "type": "number",
+          "unit": "",
+          "value": 0
+        },
+        "slope": {
+          "type": "number",
+          "unit": "",
+          "value": 1.4
+        }
+      },
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.curve"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.co2.saving",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:57.673Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.co2.saving"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.0.heating.schedule",
+      "gatewayId": "################",
+      "isEnabled": false,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.fuelCell.operating.phase",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "value": {
+          "type": "string",
+          "value": "standby"
+        }
+      },
+      "timestamp": "2022-11-18T04:27:57.796Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.operating.phase"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.1.operating.programs.active",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
       "properties": {
         "value": {
           "type": "string",
           "value": "normal"
         }
       },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active",
-      "gatewayId": "################",
-      "feature": "heating.circuits.1.operating.programs.active",
-      "timestamp": "2021-09-30T03:57:02.399Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
+      "timestamp": "2022-11-18T04:27:59.631Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
     },
     {
-      "properties": {
-        "active": {
-          "type": "boolean",
-          "value": false
-        }
-      },
+      "apiVersion": 1,
       "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating",
+      "deviceId": "0",
+      "feature": "heating.circuits.0.operating.modes.active",
       "gatewayId": "################",
-      "feature": "heating.circuits.1.operating.modes.heating",
-      "timestamp": "2021-09-30T03:57:02.233Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "active": {
-          "value": false,
-          "type": "boolean"
-        },
-        "start": {
-          "value": "",
-          "type": "string"
-        },
-        "end": {
-          "value": "",
-          "type": "string"
-        }
-      },
-      "commands": {
-        "changeEndDate": {
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate",
-          "name": "changeEndDate",
-          "isExecutable": false,
-          "params": {
-            "end": {
-              "type": "string",
-              "required": true,
-              "constraints": {
-                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
-                "sameDayAllowed": true
-              }
-            }
-          }
-        },
-        "schedule": {
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/schedule",
-          "name": "schedule",
-          "isExecutable": true,
-          "params": {
-            "start": {
-              "type": "string",
-              "required": true,
-              "constraints": {
-                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$"
-              }
-            },
-            "end": {
-              "type": "string",
-              "required": true,
-              "constraints": {
-                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
-                "sameDayAllowed": true
-              }
-            }
-          }
-        },
-        "unschedule": {
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/unschedule",
-          "name": "unschedule",
-          "isExecutable": true,
-          "params": {}
-        }
-      },
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holiday",
-      "gatewayId": "################",
-      "feature": "heating.operating.programs.holiday",
-      "timestamp": "2021-09-30T03:57:02.340Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active",
-      "gatewayId": "################",
-      "feature": "heating.circuits.0.operating.programs.active",
-      "timestamp": "2021-09-30T03:57:02.397Z",
       "isEnabled": false,
       "isReady": true,
-      "deviceId": "0"
-    },
-    {
       "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply",
-      "gatewayId": "################",
-      "feature": "heating.circuits.2.sensors.temperature.supply",
-      "timestamp": "2021-09-30T03:57:02.324Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
+      "timestamp": "2022-11-18T04:27:58.752Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
     },
     {
-      "properties": {
-        "enabled": {
-          "value": false,
-          "type": "boolean"
-        }
-      },
-      "commands": {
-        "activate": {
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/activate",
-          "name": "activate",
-          "isExecutable": false,
-          "params": {}
-        },
-        "enable": {
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/enable",
-          "name": "enable",
-          "isExecutable": true,
-          "params": {}
-        },
-        "disable": {
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/disable",
-          "name": "disable",
-          "isExecutable": false,
-          "params": {}
-        }
-      },
-      "components": ["trigger"],
       "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.hygiene",
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.1.circulation.pump",
       "gatewayId": "################",
-      "feature": "heating.dhw.hygiene",
-      "timestamp": "2021-09-30T03:57:02.366Z",
       "isEnabled": true,
       "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "active": {
-          "type": "boolean",
-          "value": false
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby",
-      "gatewayId": "################",
-      "feature": "heating.circuits.1.operating.modes.standby",
-      "timestamp": "2021-09-30T03:57:00.966Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhw",
-      "gatewayId": "################",
-      "feature": "heating.circuits.2.operating.modes.dhw",
-      "timestamp": "2021-09-30T03:57:01.586Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "hours": {
-          "type": "number",
-          "value": 1688,
-          "unit": ""
-        },
-        "starts": {
-          "type": "number",
-          "value": 6218,
-          "unit": ""
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners.0.statistics",
-      "gatewayId": "################",
-      "feature": "heating.burners.0.statistics",
-      "timestamp": "2021-09-30T03:56:59.891Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "active": {
-          "value": true,
-          "type": "boolean"
-        },
-        "demand": {
-          "value": "unknown",
-          "type": "string"
-        },
-        "temperature": {
-          "value": 14,
-          "unit": "",
-          "type": "number"
-        }
-      },
-      "commands": {
-        "setTemperature": {
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal/commands/setTemperature",
-          "name": "setTemperature",
-          "isExecutable": true,
-          "params": {
-            "targetTemperature": {
-              "type": "number",
-              "required": true,
-              "constraints": {
-                "min": 3,
-                "max": 37,
-                "stepping": 1
-              }
-            }
-          }
-        }
-      },
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal",
-      "gatewayId": "################",
-      "feature": "heating.circuits.1.operating.programs.normal",
-      "timestamp": "2021-09-30T09:24:11.419Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfort",
-      "gatewayId": "################",
-      "feature": "heating.circuits.3.operating.programs.comfort",
-      "timestamp": "2021-09-30T03:57:02.721Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "status": {
-          "type": "string",
-          "value": "connected"
-        },
-        "unit": {
-          "value": "liter",
-          "type": "string"
-        },
-        "value": {
-          "type": "number",
-          "value": 412,
-          "unit": "liter"
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.sensors.volumetricFlow.return",
-      "gatewayId": "################",
-      "feature": "heating.sensors.volumetricFlow.return",
-      "timestamp": "2021-09-30T09:43:42.102Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.heating",
-      "gatewayId": "################",
-      "feature": "heating.circuits.3.operating.modes.heating",
-      "timestamp": "2021-09-30T03:57:02.277Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["modes", "programs"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating",
-      "gatewayId": "################",
-      "feature": "heating.circuits.0.operating",
-      "timestamp": "2021-09-30T03:56:58.129Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [
-        "active",
-        "comfort",
-        "forcedLastFromSchedule",
-        "normal",
-        "reduced",
-        "standby"
-      ],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs",
-      "gatewayId": "################",
-      "feature": "heating.circuits.0.operating.programs",
-      "timestamp": "2021-09-30T03:56:58.129Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhw",
-      "gatewayId": "################",
-      "feature": "heating.circuits.0.operating.modes.dhw",
-      "timestamp": "2021-09-30T03:57:01.555Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.buffer.sensors.temperature.main",
-      "gatewayId": "################",
-      "feature": "heating.buffer.sensors.temperature.main",
-      "timestamp": "2021-09-30T03:56:59.977Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "shift": {
-          "type": "number",
-          "unit": "",
-          "value": 0
-        },
-        "slope": {
-          "type": "number",
-          "unit": "",
-          "value": 1.4
-        }
-      },
-      "commands": {
-        "setCurve": {
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.heating.curve/commands/setCurve",
-          "name": "setCurve",
-          "isExecutable": true,
-          "params": {
-            "slope": {
-              "type": "number",
-              "required": true,
-              "constraints": {
-                "min": 0.2,
-                "max": 3.5,
-                "stepping": 0.1
-              }
-            },
-            "shift": {
-              "type": "number",
-              "required": true,
-              "constraints": {
-                "min": -13,
-                "max": 40,
-                "stepping": 1
-              }
-            }
-          }
-        }
-      },
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.heating.curve",
-      "gatewayId": "################",
-      "feature": "heating.circuits.3.heating.curve",
-      "timestamp": "2021-09-30T03:57:02.333Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal",
-      "gatewayId": "################",
-      "feature": "heating.circuits.0.operating.programs.normal",
-      "timestamp": "2021-09-30T03:57:02.738Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["temperature"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.sensors",
-      "gatewayId": "################",
-      "feature": "heating.circuits.3.sensors",
-      "timestamp": "2021-09-30T03:56:58.130Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "enabled": {
-          "value": ["1"],
-          "type": "array"
-        }
-      },
-      "commands": {},
-      "components": ["0", "1", "2", "3"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits",
-      "gatewayId": "################",
-      "feature": "heating.circuits",
-      "timestamp": "2021-09-30T03:57:00.141Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
       "properties": {
         "status": {
           "type": "string",
           "value": "on"
         }
       },
-      "commands": {},
-      "components": ["schedule"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.pumps.circulation",
-      "gatewayId": "################",
-      "feature": "heating.dhw.pumps.circulation",
-      "timestamp": "2021-09-30T03:57:00.692Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
+      "timestamp": "2022-11-18T04:27:57.703Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.circulation.pump"
     },
     {
-      "properties": {
-        "active": {
-          "value": false,
-          "type": "boolean"
-        }
-      },
+      "apiVersion": 1,
       "commands": {
-        "activate": {
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule/commands/activate",
-          "name": "activate",
+        "setTemperature": {
           "isExecutable": true,
-          "params": {}
-        },
-        "deactivate": {
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule/commands/deactivate",
-          "name": "deactivate",
-          "isExecutable": false,
-          "params": {}
+          "name": "setTemperature",
+          "params": {
+            "targetTemperature": {
+              "constraints": {
+                "max": 37,
+                "min": 3,
+                "stepping": 1
+              },
+              "required": true,
+              "type": "number"
+            }
+          },
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal/commands/setTemperature"
         }
       },
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule",
+      "deviceId": "0",
+      "feature": "heating.circuits.1.operating.programs.normal",
       "gatewayId": "################",
-      "feature": "heating.circuits.1.operating.programs.forcedLastFromSchedule",
-      "timestamp": "2021-09-30T03:57:02.346Z",
       "isEnabled": true,
       "isReady": true,
-      "deviceId": "0"
-    },
-    {
       "properties": {
         "active": {
           "type": "boolean",
           "value": true
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating",
-      "gatewayId": "################",
-      "feature": "heating.circuits.1.operating.modes.dhwAndHeating",
-      "timestamp": "2021-09-30T03:57:01.639Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["curve", "schedule"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.heating",
-      "gatewayId": "################",
-      "feature": "heating.circuits.1.heating",
-      "timestamp": "2021-09-30T03:56:58.129Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "active": {
-          "type": "boolean",
-          "value": false
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.configuration.multiFamilyHouse",
-      "gatewayId": "################",
-      "feature": "heating.configuration.multiFamilyHouse",
-      "timestamp": "2021-09-30T03:57:02.299Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "unit": {
-          "value": "celsius",
-          "type": "string"
         },
-        "value": {
-          "type": "number",
-          "value": 46.1,
-          "unit": "celsius"
-        },
-        "status": {
+        "demand": {
           "type": "string",
-          "value": "connected"
+          "value": "unknown"
+        },
+        "temperature": {
+          "type": "number",
+          "unit": "celsius",
+          "value": 19
         }
       },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.sensors.temperature.return",
-      "gatewayId": "################",
-      "feature": "heating.sensors.temperature.return",
-      "timestamp": "2021-09-30T09:43:24.009Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
+      "timestamp": "2022-11-18T04:28:01.283Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal"
     },
     {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.power.sold.current",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
       "properties": {
         "value": {
-          "value": 47,
-          "unit": "",
-          "type": "number"
-        }
-      },
-      "commands": {
-        "setTargetTemperature": {
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature",
-          "name": "setTargetTemperature",
-          "isExecutable": true,
-          "params": {
-            "temperature": {
-              "type": "number",
-              "required": true,
-              "constraints": {
-                "min": 10,
-                "efficientLowerBorder": 10,
-                "efficientUpperBorder": 60,
-                "max": 60,
-                "stepping": 1
-              }
-            }
-          }
-        }
-      },
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.temperature.main",
-      "gatewayId": "################",
-      "feature": "heating.dhw.temperature.main",
-      "timestamp": "2021-09-30T03:57:02.395Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["curve", "schedule"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.heating",
-      "gatewayId": "################",
-      "feature": "heating.circuits.3.heating",
-      "timestamp": "2021-09-30T03:56:58.129Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active",
-      "gatewayId": "################",
-      "feature": "heating.circuits.0.operating.modes.active",
-      "timestamp": "2021-09-30T03:57:01.695Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.temperature",
-      "gatewayId": "################",
-      "feature": "heating.circuits.2.temperature",
-      "timestamp": "2021-09-30T03:57:00.588Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "unit": {
-          "value": "celsius",
-          "type": "string"
-        },
-        "value": {
           "type": "number",
-          "value": 42.6,
-          "unit": "celsius"
-        },
-        "status": {
-          "type": "string",
-          "value": "connected"
+          "unit": "watt",
+          "value": 0
         }
       },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.bottom",
-      "gatewayId": "################",
-      "feature": "heating.dhw.sensors.temperature.hotWaterStorage.bottom",
-      "timestamp": "2021-09-30T09:42:20.122Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
+      "timestamp": "2022-11-18T04:27:57.672Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.sold.current"
     },
     {
-      "properties": {},
-      "commands": {},
-      "components": ["hydraulicSeparator", "outside", "return"],
       "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.sensors.temperature",
-      "gatewayId": "################",
-      "feature": "heating.sensors.temperature",
-      "timestamp": "2021-09-30T03:56:58.130Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
       "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.circulation.pump",
+      "deviceId": "0",
+      "feature": "heating.circuits.0.operating.modes.dhw",
       "gatewayId": "################",
-      "feature": "heating.circuits.0.circulation.pump",
-      "timestamp": "2021-09-30T03:57:00.193Z",
       "isEnabled": false,
       "isReady": true,
-      "deviceId": "0"
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhw"
     },
     {
-      "properties": {},
-      "commands": {},
-      "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating",
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.solar.sensors.temperature.collector",
       "gatewayId": "################",
-      "feature": "heating.circuits.0.operating.modes.dhwAndHeating",
-      "timestamp": "2021-09-30T03:57:01.617Z",
       "isEnabled": false,
       "isReady": true,
-      "deviceId": "0"
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:59.611Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.collector"
     },
     {
-      "properties": {},
-      "commands": {},
-      "components": ["curve", "schedule"],
       "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating",
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.dhw.temperature.levels",
       "gatewayId": "################",
-      "feature": "heating.circuits.0.heating",
-      "timestamp": "2021-09-30T03:56:58.129Z",
       "isEnabled": true,
       "isReady": true,
-      "deviceId": "0"
-    },
-    {
       "properties": {
-        "unit": {
-          "value": "percent",
-          "type": "string"
-        },
-        "value": {
+        "default": {
           "type": "number",
-          "value": 0,
-          "unit": "percent"
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners.0.modulation",
-      "gatewayId": "################",
-      "feature": "heating.burners.0.modulation",
-      "timestamp": "2021-09-30T03:56:59.893Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.standby",
-      "gatewayId": "################",
-      "feature": "heating.circuits.3.operating.programs.standby",
-      "timestamp": "2021-09-30T03:57:00.776Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["temperature"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.sensors",
-      "gatewayId": "################",
-      "feature": "heating.circuits.2.sensors",
-      "timestamp": "2021-09-30T03:56:58.130Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["return"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.sensors.volumetricFlow",
-      "gatewayId": "################",
-      "feature": "heating.sensors.volumetricFlow",
-      "timestamp": "2021-09-30T03:56:58.130Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "min": {
-          "type": "number",
-          "value": 10,
-          "unit": ""
+          "unit": "celsius",
+          "value": 50
         },
         "max": {
           "type": "number",
-          "value": 10,
-          "unit": ""
+          "unit": "celsius",
+          "value": 10
         },
-        "default": {
+        "min": {
           "type": "number",
-          "value": 50,
-          "unit": ""
+          "unit": "celsius",
+          "value": 10
         }
       },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.temperature.levels",
-      "gatewayId": "################",
-      "feature": "heating.dhw.temperature.levels",
-      "timestamp": "2021-09-30T03:57:00.735Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
+      "timestamp": "2022-11-18T04:27:57.794Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.levels"
     },
     {
-      "properties": {},
+      "apiVersion": 1,
       "commands": {},
-      "components": ["modes", "programs"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating",
+      "deviceId": "0",
+      "feature": "heating.circuits.2.sensors.temperature.supply",
       "gatewayId": "################",
-      "feature": "heating.circuits.3.operating",
-      "timestamp": "2021-09-30T03:56:58.129Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "shift": {
-          "type": "number",
-          "unit": "",
-          "value": 0
-        },
-        "slope": {
-          "type": "number",
-          "unit": "",
-          "value": 1.4
-        }
-      },
-      "commands": {
-        "setCurve": {
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.heating.curve/commands/setCurve",
-          "name": "setCurve",
-          "isExecutable": true,
-          "params": {
-            "slope": {
-              "type": "number",
-              "required": true,
-              "constraints": {
-                "min": 0.2,
-                "max": 3.5,
-                "stepping": 0.1
-              }
-            },
-            "shift": {
-              "type": "number",
-              "required": true,
-              "constraints": {
-                "min": -13,
-                "max": 40,
-                "stepping": 1
-              }
-            }
-          }
-        }
-      },
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.heating.curve",
-      "gatewayId": "################",
-      "feature": "heating.circuits.1.heating.curve",
-      "timestamp": "2021-09-30T03:57:02.330Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.circulation.pump",
-      "gatewayId": "################",
-      "feature": "heating.circuits.2.circulation.pump",
-      "timestamp": "2021-09-30T03:57:00.197Z",
       "isEnabled": false,
       "isReady": true,
-      "deviceId": "0"
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:58.852Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply"
     },
     {
-      "properties": {},
-      "commands": {},
-      "components": ["sensors", "serial"],
       "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler",
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.1.operating.modes.standby",
       "gatewayId": "################",
-      "feature": "heating.boiler",
-      "timestamp": "2021-09-30T03:56:58.129Z",
       "isEnabled": true,
       "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active",
-      "gatewayId": "################",
-      "feature": "heating.circuits.2.operating.modes.active",
-      "timestamp": "2021-09-30T03:57:02.263Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normal",
-      "gatewayId": "################",
-      "feature": "heating.circuits.2.operating.programs.normal",
-      "timestamp": "2021-09-30T03:57:02.738Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "unit": {
-          "value": "cubicMeter",
-          "type": "string"
-        },
-        "day": {
-          "type": "array",
-          "value": [0, 0, 0, 0, 0, 0, 0, 0]
-        },
-        "week": {
-          "type": "array",
-          "value": [0, 0, 0, 0.3, 0, 0, 0.1, 0.2, 0]
-        },
-        "month": {
-          "type": "array",
-          "value": [0.3, 0.3, 8.2, 5, 24.4, 36.7, 37, 31.7, 42.4, 27.1, 0, 0, 0]
-        },
-        "year": {
-          "type": "array",
-          "value": [186.1, 27.1]
-        },
-        "dayValueReadAt": {
-          "type": "string",
-          "value": "2021-09-20T22:46:13.607Z"
-        },
-        "weekValueReadAt": {
-          "type": "string",
-          "value": "2021-09-20T22:46:13.672Z"
-        },
-        "monthValueReadAt": {
-          "type": "string",
-          "value": "2021-09-20T22:46:13.607Z"
-        },
-        "yearValueReadAt": {
-          "type": "string",
-          "value": "2021-09-20T22:46:13.607Z"
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.gas.consumption.dhw",
-      "gatewayId": "################",
-      "feature": "heating.gas.consumption.dhw",
-      "timestamp": "2021-09-30T03:56:59.943Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "value": {
-          "type": "string",
-          "value": "################"
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/device.serial",
-      "gatewayId": "################",
-      "feature": "device.serial",
-      "timestamp": "2021-09-30T03:56:59.873Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.standby",
-      "gatewayId": "################",
-      "feature": "heating.circuits.3.operating.modes.standby",
-      "timestamp": "2021-09-30T03:57:01.505Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.dhwAndHeating",
-      "gatewayId": "################",
-      "feature": "heating.circuits.3.operating.modes.dhwAndHeating",
-      "timestamp": "2021-09-30T03:57:01.671Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
       "properties": {
         "active": {
-          "value": true,
-          "type": "boolean"
-        },
-        "entries": {
-          "value": {
-            "mon": [
-              {
-                "mode": "normal",
-                "start": "00:00",
-                "end": "24:00",
-                "position": 0
-              }
-            ],
-            "tue": [
-              {
-                "mode": "normal",
-                "start": "00:00",
-                "end": "24:00",
-                "position": 0
-              }
-            ],
-            "wed": [
-              {
-                "mode": "normal",
-                "start": "00:00",
-                "end": "24:00",
-                "position": 0
-              }
-            ],
-            "thu": [
-              {
-                "mode": "normal",
-                "start": "00:00",
-                "end": "24:00",
-                "position": 0
-              }
-            ],
-            "fri": [
-              {
-                "mode": "normal",
-                "start": "00:00",
-                "end": "24:00",
-                "position": 0
-              }
-            ],
-            "sat": [
-              {
-                "mode": "normal",
-                "start": "00:00",
-                "end": "24:00",
-                "position": 0
-              }
-            ],
-            "sun": [
-              {
-                "mode": "normal",
-                "start": "00:00",
-                "end": "24:00",
-                "position": 0
-              }
-            ]
+          "type": "boolean",
+          "value": false
+        }
+      },
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {
+        "setTemperature": {
+          "isExecutable": true,
+          "name": "setTemperature",
+          "params": {
+            "targetTemperature": {
+              "constraints": {
+                "max": 37,
+                "min": 3,
+                "stepping": 1
+              },
+              "required": true,
+              "type": "number"
+            }
           },
-          "type": "Schedule"
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced/commands/setTemperature"
         }
       },
-      "commands": {
-        "setSchedule": {
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule/commands/setSchedule",
-          "name": "setSchedule",
-          "isExecutable": true,
-          "params": {
-            "newSchedule": {
-              "type": "Schedule",
-              "required": true,
-              "constraints": {
-                "modes": ["normal", "comfort"],
-                "maxEntries": 4,
-                "resolution": 10,
-                "defaultMode": "reduced",
-                "overlapAllowed": false
-              }
-            }
-          }
-        }
-      },
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule",
+      "deviceId": "0",
+      "feature": "heating.circuits.1.operating.programs.reduced",
       "gatewayId": "################",
-      "feature": "heating.circuits.1.heating.schedule",
-      "timestamp": "2021-09-30T03:57:02.295Z",
       "isEnabled": true,
       "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["holiday", "holidayAtHome"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs",
-      "gatewayId": "################",
-      "feature": "heating.operating.programs",
-      "timestamp": "2021-09-30T03:56:58.129Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["serial"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/device",
-      "gatewayId": "################",
-      "feature": "device",
-      "timestamp": "2021-09-30T03:56:58.128Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "unit": {
-          "value": "cubicMeter",
-          "type": "string"
-        },
-        "day": {
-          "type": "array",
-          "value": [0, 0, 0, 0, 0, 0.1, 0, 0.1]
-        },
-        "week": {
-          "type": "array",
-          "value": [0, 0.2, 0, 0.1, 0, 0, 0, 0.1, 0]
-        },
-        "month": {
-          "type": "array",
-          "value": [
-            0.3, 0.1, 2.1, 1.6, 51.7, 144.5, 184.6, 198.1, 277.7, 101.5, 0, 0, 0
-          ]
-        },
-        "year": {
-          "type": "array",
-          "value": [860.9, 101.5]
-        },
-        "dayValueReadAt": {
-          "type": "string",
-          "value": "2021-09-29T22:08:04.638Z"
-        },
-        "weekValueReadAt": {
-          "type": "string",
-          "value": "2021-09-25T06:05:08.569Z"
-        },
-        "monthValueReadAt": {
-          "type": "string",
-          "value": "2021-09-29T22:08:04.638Z"
-        },
-        "yearValueReadAt": {
-          "type": "string",
-          "value": "2021-09-29T22:08:04.638Z"
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.gas.consumption.heating",
-      "gatewayId": "################",
-      "feature": "heating.gas.consumption.heating",
-      "timestamp": "2021-09-30T03:56:59.941Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.forcedLastFromSchedule",
-      "gatewayId": "################",
-      "feature": "heating.circuits.2.operating.programs.forcedLastFromSchedule",
-      "timestamp": "2021-09-30T03:57:02.347Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "active": {
-          "value": false,
-          "type": "boolean"
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby",
-      "gatewayId": "################",
-      "feature": "heating.circuits.1.operating.programs.standby",
-      "timestamp": "2021-09-30T03:57:00.772Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["room", "supply"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature",
-      "gatewayId": "################",
-      "feature": "heating.circuits.2.sensors.temperature",
-      "timestamp": "2021-09-30T03:56:58.130Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["modes", "programs"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating",
-      "gatewayId": "################",
-      "feature": "heating.circuits.1.operating",
-      "timestamp": "2021-09-30T03:56:58.129Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "active": {
-          "value": false,
-          "type": "boolean"
-        }
-      },
-      "commands": {
-        "activate": {
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/activate",
-          "name": "activate",
-          "isExecutable": true,
-          "params": {}
-        },
-        "deactivate": {
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate",
-          "name": "deactivate",
-          "isExecutable": false,
-          "params": {}
-        }
-      },
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge",
-      "gatewayId": "################",
-      "feature": "heating.dhw.oneTimeCharge",
-      "timestamp": "2021-09-30T03:57:02.306Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.active",
-      "gatewayId": "################",
-      "feature": "heating.circuits.3.operating.modes.active",
-      "timestamp": "2021-09-30T03:57:02.278Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "status": {
-          "type": "string",
-          "value": "off"
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.pumps.primary",
-      "gatewayId": "################",
-      "feature": "heating.dhw.pumps.primary",
-      "timestamp": "2021-09-30T03:56:59.914Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.temperature",
-      "gatewayId": "################",
-      "feature": "heating.circuits.0.temperature",
-      "timestamp": "2021-09-30T03:57:00.390Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
       "properties": {
         "active": {
           "type": "boolean",
           "value": false
-        }
-      },
-      "commands": {},
-      "components": ["modulation", "statistics"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners.0",
-      "gatewayId": "################",
-      "feature": "heating.burners.0",
-      "timestamp": "2021-09-30T03:57:02.336Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["programs"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating",
-      "gatewayId": "################",
-      "feature": "heating.operating",
-      "timestamp": "2021-09-30T03:56:58.129Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["offset"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.device.time",
-      "gatewayId": "################",
-      "feature": "heating.device.time",
-      "timestamp": "2021-09-30T03:56:58.129Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.room",
-      "gatewayId": "################",
-      "feature": "heating.circuits.3.sensors.temperature.room",
-      "timestamp": "2021-09-30T03:57:02.319Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["room", "supply"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature",
-      "gatewayId": "################",
-      "feature": "heating.circuits.3.sensors.temperature",
-      "timestamp": "2021-09-30T03:56:58.130Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["room", "supply"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature",
-      "gatewayId": "################",
-      "feature": "heating.circuits.0.sensors.temperature",
-      "timestamp": "2021-09-30T03:56:58.130Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler.sensors",
-      "gatewayId": "################",
-      "feature": "heating.boiler.sensors",
-      "timestamp": "2021-09-30T03:56:58.129Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating",
-      "gatewayId": "################",
-      "feature": "heating.circuits.2.operating.modes.heating",
-      "timestamp": "2021-09-30T03:57:02.262Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "unit": {
-          "value": "celsius",
-          "type": "string"
         },
-        "value": {
+        "demand": {
+          "type": "string",
+          "value": "unknown"
+        },
+        "temperature": {
           "type": "number",
-          "value": 46,
-          "unit": "celsius"
-        },
-        "status": {
-          "type": "string",
-          "value": "connected"
+          "unit": "celsius",
+          "value": 18
         }
       },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply",
-      "gatewayId": "################",
-      "feature": "heating.boiler.sensors.temperature.commonSupply",
-      "timestamp": "2021-09-30T09:43:44.181Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
+      "timestamp": "2022-11-18T04:28:01.289Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced"
     },
     {
-      "properties": {
-        "active": {
-          "type": "boolean",
-          "value": false
-        }
-      },
-      "commands": {},
-      "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhw",
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.power.consumption.summary.dhw",
       "gatewayId": "################",
-      "feature": "heating.circuits.1.operating.modes.dhw",
-      "timestamp": "2021-09-30T03:57:01.571Z",
       "isEnabled": true,
       "isReady": true,
-      "deviceId": "0"
-    },
-    {
       "properties": {
-        "unit": {
-          "value": "kilowattHour",
-          "type": "string"
-        },
-        "day": {
-          "type": "array",
-          "value": [0.6, 1.3, 1.3, 1.3, 1.3, 1.3, 1.3, 1.3]
-        },
-        "week": {
-          "type": "array",
-          "value": [
-            4.5, 9.1, 9, 8.8, 8.899999999999999, 9, 8.700000000000001,
-            7.300000000000001, 7.500000000000001
-          ]
-        },
-        "month": {
-          "type": "array",
-          "value": [
-            38.5, 37.2, 36, 34.2, 39.9, 36.9, 37.2, 33, 36, 22.8, 0, 0, 0
-          ]
-        },
-        "year": {
-          "type": "array",
-          "value": [329.7, 22.8]
-        },
-        "dayValueReadAt": {
-          "type": "string",
-          "value": "2021-09-30T09:04:44.252Z"
-        },
-        "weekValueReadAt": {
-          "type": "string",
-          "value": "2021-09-30T07:14:37.875Z"
-        },
-        "monthValueReadAt": {
-          "type": "string",
-          "value": "2021-09-30T09:04:44.252Z"
-        },
-        "yearValueReadAt": {
-          "type": "string",
-          "value": "2021-09-30T09:04:44.252Z"
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.power.consumption.total",
-      "gatewayId": "################",
-      "feature": "heating.power.consumption.total",
-      "timestamp": "2021-09-30T09:05:30.179Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "shift": {
+        "currentDay": {
           "type": "number",
-          "unit": "",
+          "unit": "kilowattHour",
           "value": 0
         },
-        "slope": {
+        "currentMonth": {
           "type": "number",
-          "unit": "",
-          "value": 1.4
-        }
-      },
-      "commands": {
-        "setCurve": {
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve",
-          "name": "setCurve",
-          "isExecutable": true,
-          "params": {
-            "slope": {
-              "type": "number",
-              "required": true,
-              "constraints": {
-                "min": 0.2,
-                "max": 3.5,
-                "stepping": 0.1
-              }
-            },
-            "shift": {
-              "type": "number",
-              "required": true,
-              "constraints": {
-                "min": -13,
-                "max": 40,
-                "stepping": 1
-              }
-            }
-          }
-        }
-      },
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.curve",
-      "gatewayId": "################",
-      "feature": "heating.circuits.0.heating.curve",
-      "timestamp": "2021-09-30T03:57:02.328Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "unit": {
-          "value": "celsius",
-          "type": "string"
+          "unit": "kilowattHour",
+          "value": 0.1
         },
-        "value": {
+        "currentYear": {
           "type": "number",
-          "value": 21.4,
-          "unit": "celsius"
+          "unit": "kilowattHour",
+          "value": 3.2
         },
-        "status": {
-          "type": "string",
-          "value": "connected"
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply",
-      "gatewayId": "################",
-      "feature": "heating.circuits.1.sensors.temperature.supply",
-      "timestamp": "2021-09-30T09:43:31.445Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort",
-      "gatewayId": "################",
-      "feature": "heating.circuits.0.operating.programs.comfort",
-      "timestamp": "2021-09-30T03:57:02.719Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby",
-      "gatewayId": "################",
-      "feature": "heating.circuits.2.operating.modes.standby",
-      "timestamp": "2021-09-30T03:57:00.982Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule",
-      "gatewayId": "################",
-      "feature": "heating.circuits.0.heating.schedule",
-      "timestamp": "2021-09-30T03:57:02.293Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "unit": {
-          "value": "cubicMeter",
-          "type": "string"
-        },
-        "day": {
-          "type": "array",
-          "value": [
-            2, 4.1, 4.1, 4.1, 4.1, 4.199999999999999, 4.1, 4.199999999999999
-          ]
-        },
-        "week": {
-          "type": "array",
-          "value": [
-            14.299999999999999, 28.9, 28.700000000000003, 29.1,
-            28.700000000000003, 28.700000000000003, 28.800000000000004,
-            28.999999999999993, 28.700000000000003
-          ]
-        },
-        "month": {
-          "type": "array",
-          "value": [
-            121.5, 133.3, 145.4, 122.1, 209.4, 188.5, 221.6, 229.79999999999998,
-            322.79999999999995, 128.6, 0, 0, 0
-          ]
-        },
-        "year": {
-          "type": "array",
-          "value": [1694.7, 128.6]
-        },
-        "dayValueReadAt": {
-          "type": "string",
-          "value": "2021-09-29T22:08:04.638Z"
-        },
-        "weekValueReadAt": {
-          "type": "string",
-          "value": "2021-09-25T06:05:08.569Z"
-        },
-        "monthValueReadAt": {
-          "type": "string",
-          "value": "2021-09-29T22:08:04.638Z"
-        },
-        "yearValueReadAt": {
-          "type": "string",
-          "value": "2021-09-29T22:08:04.638Z"
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.gas.consumption.total",
-      "gatewayId": "################",
-      "feature": "heating.gas.consumption.total",
-      "timestamp": "2021-09-30T03:57:02.390Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [
-        "active",
-        "comfort",
-        "forcedLastFromSchedule",
-        "normal",
-        "reduced",
-        "standby"
-      ],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs",
-      "gatewayId": "################",
-      "feature": "heating.circuits.1.operating.programs",
-      "timestamp": "2021-09-30T03:56:58.129Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["active", "dhw", "dhwAndHeating", "heating", "standby"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes",
-      "gatewayId": "################",
-      "feature": "heating.circuits.1.operating.modes",
-      "timestamp": "2021-09-30T03:56:58.129Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["temperature", "volumetricFlow"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.sensors",
-      "gatewayId": "################",
-      "feature": "heating.sensors",
-      "timestamp": "2021-09-30T03:56:58.129Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.frostprotection",
-      "gatewayId": "################",
-      "feature": "heating.circuits.3.frostprotection",
-      "timestamp": "2021-09-30T03:57:02.362Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room",
-      "gatewayId": "################",
-      "feature": "heating.circuits.1.sensors.temperature.room",
-      "timestamp": "2021-09-30T03:57:02.313Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.frostprotection",
-      "gatewayId": "################",
-      "feature": "heating.circuits.0.frostprotection",
-      "timestamp": "2021-09-30T03:57:02.353Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.hygiene.trigger",
-      "gatewayId": "################",
-      "feature": "heating.dhw.hygiene.trigger",
-      "timestamp": "2021-09-30T03:57:02.393Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["dhw", "heating", "total"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.power.consumption",
-      "gatewayId": "################",
-      "feature": "heating.power.consumption",
-      "timestamp": "2021-09-30T03:56:58.130Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby",
-      "gatewayId": "################",
-      "feature": "heating.circuits.2.operating.programs.standby",
-      "timestamp": "2021-09-30T03:57:00.774Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [
-        "circulation",
-        "frostprotection",
-        "heating",
-        "operating",
-        "sensors",
-        "temperature"
-      ],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2",
-      "gatewayId": "################",
-      "feature": "heating.circuits.2",
-      "timestamp": "2021-09-30T03:57:00.085Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "unit": {
-          "value": "celsius",
-          "type": "string"
-        },
-        "value": {
+        "lastMonth": {
           "type": "number",
-          "value": 42.9,
-          "unit": "celsius"
+          "unit": "kilowattHour",
+          "value": 0.1
         },
-        "status": {
-          "type": "string",
-          "value": "connected"
-        }
-      },
-      "commands": {},
-      "components": ["bottom", "top"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage",
-      "gatewayId": "################",
-      "feature": "heating.dhw.sensors.temperature.hotWaterStorage",
-      "timestamp": "2021-09-30T09:43:01.447Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "unit": {
-          "value": "celsius",
-          "type": "string"
-        },
-        "value": {
+        "lastSevenDays": {
           "type": "number",
-          "value": 46.8,
-          "unit": "celsius"
+          "unit": "kilowattHour",
+          "value": 0
         },
-        "status": {
-          "type": "string",
-          "value": "connected"
+        "lastYear": {
+          "type": "number",
+          "unit": "kilowattHour",
+          "value": 5.3
         }
       },
-      "commands": {},
-      "components": [],
+      "timestamp": "2022-11-18T04:27:58.881Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.dhw"
+    },
+    {
       "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.sensors.temperature.hydraulicSeparator",
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.fuelCell.operating.modes.maintenance",
       "gatewayId": "################",
-      "feature": "heating.sensors.temperature.hydraulicSeparator",
-      "timestamp": "2021-09-30T09:43:36.316Z",
       "isEnabled": true,
       "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "value": {
-          "value": "dhwAndHeating",
-          "type": "string"
-        }
-      },
-      "commands": {
-        "setMode": {
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active/commands/setMode",
-          "name": "setMode",
-          "isExecutable": true,
-          "params": {
-            "mode": {
-              "type": "string",
-              "required": true,
-              "constraints": {
-                "enum": ["standby", "heating", "dhw", "dhwAndHeating"]
-              }
-            }
-          }
-        }
-      },
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active",
-      "gatewayId": "################",
-      "feature": "heating.circuits.1.operating.modes.active",
-      "timestamp": "2021-09-30T03:57:02.245Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["0"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners",
-      "gatewayId": "################",
-      "feature": "heating.burners",
-      "timestamp": "2021-09-30T03:56:58.129Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.active",
-      "gatewayId": "################",
-      "feature": "heating.circuits.3.operating.programs.active",
-      "timestamp": "2021-09-30T03:57:02.403Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.forcedLastFromSchedule",
-      "gatewayId": "################",
-      "feature": "heating.circuits.3.operating.programs.forcedLastFromSchedule",
-      "timestamp": "2021-09-30T03:57:02.347Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.temperature.hygiene",
-      "gatewayId": "################",
-      "feature": "heating.dhw.temperature.hygiene",
-      "timestamp": "2021-09-30T03:57:02.364Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["pump"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.circulation",
-      "gatewayId": "################",
-      "feature": "heating.circuits.2.circulation",
-      "timestamp": "2021-09-30T03:56:58.130Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.buffer",
-      "gatewayId": "################",
-      "feature": "heating.buffer",
-      "timestamp": "2021-09-30T03:56:58.130Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced",
-      "gatewayId": "################",
-      "feature": "heating.circuits.0.operating.programs.reduced",
-      "timestamp": "2021-09-30T03:57:02.882Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["modes", "programs"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating",
-      "gatewayId": "################",
-      "feature": "heating.circuits.2.operating",
-      "timestamp": "2021-09-30T03:56:58.129Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "unit": {
-          "value": "kilowattHour",
-          "type": "string"
-        },
-        "day": {
-          "type": "array",
-          "value": [0.6, 1.3, 1.3, 1.3, 1.3, 1.3, 1.3, 1.3]
-        },
-        "week": {
-          "type": "array",
-          "value": [
-            4.5, 9.1, 9, 8.8, 8.899999999999999, 9, 8.700000000000001,
-            7.300000000000001, 7.500000000000001
-          ]
-        },
-        "month": {
-          "type": "array",
-          "value": [
-            38.5, 37.2, 35.6, 34, 38.8, 35.3, 35.5, 31.6, 34.1, 21.3, 0, 0, 0
-          ]
-        },
-        "year": {
-          "type": "array",
-          "value": [321, 21.3]
-        },
-        "dayValueReadAt": {
-          "type": "string",
-          "value": "2021-09-30T09:04:44.252Z"
-        },
-        "weekValueReadAt": {
-          "type": "string",
-          "value": "2021-09-30T07:14:37.875Z"
-        },
-        "monthValueReadAt": {
-          "type": "string",
-          "value": "2021-09-30T09:04:44.252Z"
-        },
-        "yearValueReadAt": {
-          "type": "string",
-          "value": "2021-09-30T09:04:44.252Z"
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.power.consumption.heating",
-      "gatewayId": "################",
-      "feature": "heating.power.consumption.heating",
-      "timestamp": "2021-09-30T09:05:30.138Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": ["room", "supply"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature",
-      "gatewayId": "################",
-      "feature": "heating.circuits.1.sensors.temperature",
-      "timestamp": "2021-09-30T03:56:58.130Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reduced",
-      "gatewayId": "################",
-      "feature": "heating.circuits.2.operating.programs.reduced",
-      "timestamp": "2021-09-30T03:57:02.883Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby",
-      "gatewayId": "################",
-      "feature": "heating.circuits.0.operating.programs.standby",
-      "timestamp": "2021-09-30T03:57:00.769Z",
-      "isEnabled": false,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {
-        "unit": {
-          "value": "kilowattHour",
-          "type": "string"
-        },
-        "day": {
-          "type": "array",
-          "value": [0, 0, 0, 0, 0, 0, 0, 0]
-        },
-        "week": {
-          "type": "array",
-          "value": [0, 0, 0, 0, 0, 0, 0, 0, 0]
-        },
-        "month": {
-          "type": "array",
-          "value": [0, 0, 0.4, 0.2, 1.1, 1.6, 1.7, 1.4, 1.9, 1.5, 0, 0, 0]
-        },
-        "year": {
-          "type": "array",
-          "value": [8.7, 1.5]
-        },
-        "dayValueReadAt": {
-          "type": "string",
-          "value": "2021-09-20T22:46:13.608Z"
-        },
-        "weekValueReadAt": {
-          "type": "string",
-          "value": "2021-09-20T22:46:13.664Z"
-        },
-        "monthValueReadAt": {
-          "type": "string",
-          "value": "2021-09-20T22:46:13.608Z"
-        },
-        "yearValueReadAt": {
-          "type": "string",
-          "value": "2021-09-20T22:46:13.608Z"
-        }
-      },
-      "commands": {},
-      "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.power.consumption.dhw",
-      "gatewayId": "################",
-      "feature": "heating.power.consumption.dhw",
-      "timestamp": "2021-09-30T03:56:59.956Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
       "properties": {
         "active": {
           "type": "boolean",
-          "value": true
-        },
-        "status": {
-          "type": "string",
-          "value": "on"
+          "value": false
         }
       },
-      "commands": {},
-      "components": [
-        "hygiene",
-        "oneTimeCharge",
-        "schedule",
-        "sensors",
-        "temperature"
-      ],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw",
-      "gatewayId": "################",
-      "feature": "heating.dhw",
-      "timestamp": "2021-09-30T03:57:00.714Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
+      "timestamp": "2022-11-18T04:27:57.798Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.operating.modes.maintenance"
     },
     {
-      "properties": {},
-      "commands": {},
-      "components": [],
       "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.temperature",
+      "commands": {},
+      "deviceId": "0",
+      "feature": "heating.circuits.3.operating.modes.heating",
       "gatewayId": "################",
-      "feature": "heating.circuits.1.temperature",
-      "timestamp": "2021-09-30T03:57:00.452Z",
       "isEnabled": false,
       "isReady": true,
-      "deviceId": "0"
+      "properties": {},
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.heating"
     },
     {
-      "properties": {},
+      "apiVersion": 1,
       "commands": {},
       "components": [],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply",
+      "deviceId": "0",
+      "feature": "heating.circuits.0.name",
       "gatewayId": "################",
-      "feature": "heating.circuits.0.sensors.temperature.supply",
-      "timestamp": "2021-09-30T03:57:02.321Z",
       "isEnabled": false,
       "isReady": true,
-      "deviceId": "0"
+      "properties": {},
+      "timestamp": "2021-11-30T07:47:28.956Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name"
     },
     {
-      "properties": {},
-      "commands": {},
-      "components": ["active", "dhw", "dhwAndHeating", "heating", "standby"],
       "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.modes",
+      "commands": {
+        "setName": {
+          "isExecutable": true,
+          "name": "setName",
+          "params": {
+            "name": {
+              "constraints": {
+                "maxLength": 20,
+                "minLength": 1
+              },
+              "required": true,
+              "type": "string"
+            }
+          },
+          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.name/commands/setName"
+        }
+      },
+      "components": [],
+      "deviceId": "0",
+      "feature": "heating.circuits.1.name",
       "gatewayId": "################",
-      "feature": "heating.circuits.3.operating.modes",
-      "timestamp": "2021-09-30T03:56:58.129Z",
       "isEnabled": true,
       "isReady": true,
-      "deviceId": "0"
+      "properties": {
+        "name": {
+          "type": "string",
+          "value": "Fußbodenheizung"
+        }
+      },
+      "timestamp": "2022-11-18T04:27:55.360Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.name"
     },
     {
-      "properties": {},
-      "commands": {},
-      "components": ["active", "dhw", "dhwAndHeating", "heating", "standby"],
       "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes",
+      "commands": {},
+      "components": [],
+      "deviceId": "0",
+      "feature": "heating.circuits.2.name",
       "gatewayId": "################",
-      "feature": "heating.circuits.2.operating.modes",
-      "timestamp": "2021-09-30T03:56:58.129Z",
-      "isEnabled": true,
+      "isEnabled": false,
       "isReady": true,
-      "deviceId": "0"
+      "properties": {},
+      "timestamp": "2021-11-30T07:47:29.309Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.name"
     },
     {
-      "properties": {},
-      "commands": {},
-      "components": ["pump"],
       "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.circulation",
-      "gatewayId": "################",
-      "feature": "heating.circuits.3.circulation",
-      "timestamp": "2021-09-30T03:56:58.130Z",
-      "isEnabled": true,
-      "isReady": true,
-      "deviceId": "0"
-    },
-    {
-      "properties": {},
       "commands": {},
-      "components": ["pump"],
-      "apiVersion": 1,
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.circulation",
+      "components": [],
+      "deviceId": "0",
+      "feature": "heating.circuits.3.name",
       "gatewayId": "################",
-      "feature": "heating.circuits.0.circulation",
-      "timestamp": "2021-09-30T03:56:58.129Z",
-      "isEnabled": true,
+      "isEnabled": false,
       "isReady": true,
-      "deviceId": "0"
+      "properties": {},
+      "timestamp": "2021-11-30T07:47:29.373Z",
+      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.name"
     }
   ]
 }

--- a/tests/test_TestForMissingProperties.py
+++ b/tests/test_TestForMissingProperties.py
@@ -31,6 +31,17 @@ class TestForMissingProperties(unittest.TestCase):
             'heating.burners',
             'heating.solar',
 
+            'heating.dhw.hygiene.trigger',
+            'heating.dhw.operating.modes.off',
+            'heating.dhw.temperature.hygiene',
+            'heating.power.production.cumulative',
+            'heating.power.purchase.cumulative',
+            'heating.power.purchase.current',
+            'heating.power.sold.cumulative',
+            'heating.power.sold.current',
+            'heating.sensors.pressure.supply',
+            'heating.sensors.temperature.allengra',
+
             # todo: implement ventilation
             'ventilation',
             'ventilation.schedule',

--- a/tests/test_VitovalorPT2.py
+++ b/tests/test_VitovalorPT2.py
@@ -52,3 +52,91 @@ class VitovalorPT2(unittest.TestCase):
     def test_getGasConsumptionTotalDays(self):
         expected_consumption = [1.5, 0.2, 0.30000000000000004, 0.2, 0.4, 0.6000000000000001, 1.7, 0.2]
         self.assertListEqual(self.device.getGasConsumptionTotalDays(), expected_consumption)
+
+    def test_getFuelCellOperatingModeActive(self):
+        self.assertEqual(self.device.getFuelCellOperatingModeActive(), "economical")
+
+    def test_getFuelCellPowerProductionUnit(self):
+        # Returns the unit for the fuel cell's power production statistics, e.g. kilowattHour
+        self.assertEqual(self.device.getFuelCellPowerProductionUnit(), "kilowattHour")
+
+    def test_getFuelCellPowerProductionDays(self):
+        self.assertEqual(self.device.getFuelCellPowerProductionDays(), [0.8, 18.3, 13, 15.1, 16.5, 18.3, 8.6, 18.3])
+
+    def test_getFuelCellPowerProductionToday(self):
+        self.assertEqual(self.device.getFuelCellPowerProductionToday(), 0.8)
+
+    def test_getFuelCellPowerProductionWeeks(self):
+        self.assertEqual(self.device.getFuelCellPowerProductionWeeks(), [63.7, 95.80000000000001, 60.9, 40.2, 41.300000000000004, 40.6, 58.699999999999996])
+
+    def test_getFuelCellPowerProductionThisWeek(self):
+        self.assertEqual(self.device.getFuelCellPowerProductionThisWeek(), 63.7)
+
+    def test_getFuelCellPowerProductionMonths(self):
+        self.assertEqual(self.device.getFuelCellPowerProductionMonths(), [212.6, 206.7, 190, 130.4, 39.9, 0, 187.4, 327.2, 411.3, 441.2, 500.7, 460.5, 431.4])
+
+    def test_getFuelCellPowerProductionThisMonth(self):
+        self.assertEqual(self.device.getFuelCellPowerProductionThisMonth(), 212.6)
+
+    def test_getFuelCellPowerProductionYears(self):
+        self.assertEqual(self.device.getFuelCellPowerProductionYears(), [2647.4, 1609.2])
+
+    def test_getFuelCellPowerProductionThisYear(self):
+        self.assertEqual(self.device.getFuelCellPowerProductionThisYear(), 2647.4)
+
+    def test_getFuelCellOperatingPhase(self):
+        self.assertEqual(self.device.getFuelCellOperatingPhase(), "standby")
+
+    def test_getFuelCellPowerProductionCurrentUnit(self):
+        self.assertEqual(self.device.getFuelCellPowerProductionCurrentUnit(), "watt")
+
+    def test_getFuelCellPowerProductionCurrent(self):
+        self.assertEqual(self.device.getFuelCellPowerProductionCurrent(), 0)
+
+    def test_getFuelCellFlowReturnTemperatureUnit(self):
+        self.assertEqual(self.device.getFuelCellFlowReturnTemperatureUnit(), "celsius")
+
+    def test_getFuelCellFlowReturnTemperature(self):
+        self.assertEqual(self.device.getFuelCellFlowReturnTemperature(), 33.9)
+
+    def test_getFuelCellFlowSupplyTemperatureUnit(self):
+        self.assertEqual(self.device.getFuelCellFlowSupplyTemperatureUnit(), "celsius")
+
+    def test_getFuelCellFlowSupplyTemperature(self):
+        self.assertEqual(self.device.getFuelCellFlowSupplyTemperature(), 39)
+
+    def test_getFuelCellOperationHours(self):
+        self.assertEqual(self.device.getFuelCellOperationHours(), 11594)
+
+    def test_getFuelCellProductionHours(self):
+        self.assertEqual(self.device.getFuelCellProductionHours(), 5980)
+
+    def test_getFuelCellProductionStarts(self):
+        self.assertEqual(self.device.getFuelCellProductionStarts(), 383)
+
+    def test_getFuelCellGasConsumptionUnit(self):
+        self.assertEqual(self.device.getFuelCellGasConsumptionUnit(), "cubicMeter")
+
+    def test_getFuelCellGasConsumptionDays(self):
+        self.assertEqual(self.device.getFuelCellGasConsumptionDays(), [1.5, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2])
+
+    def test_getFuelCellGasConsumptionToday(self):
+        self.assertEqual(self.device.getFuelCellGasConsumptionToday(), 1.5)
+
+    def test_getFuelCellGasConsumptionWeeks(self):
+        self.assertEqual(self.device.getFuelCellGasConsumptionWeeks(), [2.3000000000000003, 1.4, 1.4, 1.4, 1.4, 1.4, 1.4])
+
+    def test_getFuelCellGasConsumptionThisWeek(self):
+        self.assertEqual(self.device.getFuelCellGasConsumptionThisWeek(), 2.3000000000000003)
+
+    def test_getFuelCellGasConsumptionMonths(self):
+        self.assertEqual(self.device.getFuelCellGasConsumptionMonths(), [4.9, 55.5, 50.9, 35.1, 10.9, 0, 49.4, 85.4, 108.5, 118, 132.5, 120.7, 111.5])
+
+    def test_getFuelCellGasConsumptionThisMonth(self):
+        self.assertEqual(self.device.getFuelCellGasConsumptionThisMonth(), 4.9)
+
+    def test_getFuelCellGasConsumptionYears(self):
+        self.assertEqual(self.device.getFuelCellGasConsumptionYears(), [651.1, 416.6])
+
+    def test_getFuelCellGasConsumptionThisYear(self):
+        self.assertEqual(self.device.getFuelCellGasConsumptionThisYear(), 651.1)

--- a/tests/test_VitovalorPT2.py
+++ b/tests/test_VitovalorPT2.py
@@ -11,26 +11,26 @@ class VitovalorPT2(unittest.TestCase):
 
     def test_getDomesticHotWaterConfiguredTemperature(self):
         self.assertEqual(
-            self.device.getDomesticHotWaterConfiguredTemperature(), 47)
+            self.device.getDomesticHotWaterConfiguredTemperature(), 45)
 
     def test_getReturnTemperature(self):
         self.assertEqual(
-            self.device.getReturnTemperature(), 46.1)
+            self.device.getReturnTemperature(), 22.2)
 
     def test_getActive(self):
         self.assertEqual(self.device.burners[0].getActive(), False)
 
     def test_getBurnerStarts(self):
-        self.assertEqual(self.device.burners[0].getStarts(), 6218)
+        self.assertEqual(self.device.burners[0].getStarts(), 3862)
 
     def test_getBurnerHours(self):
-        self.assertEqual(self.device.burners[0].getHours(), 1688)
+        self.assertEqual(self.device.burners[0].getHours(), 282)
 
     def test_getBurnerModulation(self):
         self.assertEqual(self.device.burners[0].getModulation(), 0)
 
     def test_getVolumetricFlowReturn(self):
-        self.assertEqual(self.device.getVolumetricFlowReturn(), 412)
+        self.assertEqual(self.device.getVolumetricFlowReturn(), 513)
 
     def test_getDomesticHotWaterMaxTemperatureLevel(self):
         self.assertEqual(self.device.getDomesticHotWaterMaxTemperatureLevel(), 10)
@@ -39,16 +39,16 @@ class VitovalorPT2(unittest.TestCase):
         self.assertEqual(self.device.getDomesticHotWaterMinTemperatureLevel(), 10)
 
     def test_getHydraulicSeparatorTemperature(self):
-        self.assertEqual(self.device.getHydraulicSeparatorTemperature(), 46.8)
+        self.assertEqual(self.device.getHydraulicSeparatorTemperature(), 22.3)
 
     def test_getPowerConsumptionDays(self):
-        expected_consumption = [0.6, 1.3, 1.3, 1.3, 1.3, 1.3, 1.3, 1.3]
+        expected_consumption = [0.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5]
         self.assertListEqual(self.device.getPowerConsumptionDays(), expected_consumption)
 
     def test_getPowerConsumptionHeatingDays(self):
-        expected_consumption = [0.6, 1.3, 1.3, 1.3, 1.3, 1.3, 1.3, 1.3]
+        expected_consumption = [0.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5]
         self.assertListEqual(self.device.getPowerConsumptionHeatingDays(), expected_consumption)
 
     def test_getGasConsumptionTotalDays(self):
-        expected_consumption = [2, 4.1, 4.1, 4.1, 4.1, 4.199999999999999, 4.1, 4.199999999999999]
+        expected_consumption = [1.5, 0.2, 0.30000000000000004, 0.2, 0.4, 0.6000000000000001, 1.7, 0.2]
         self.assertListEqual(self.device.getGasConsumptionTotalDays(), expected_consumption)


### PR DESCRIPTION
I've now added most Fuel Cell data points as getFuelCell... methods. However they're all only available in the paid "Advanced" API plan - currently I've only marked them as such with a single comment. New users who don't see that comment might be confused why get errors when they call these methods, even though others work...