### PR TITLE
feat: allow setting sub digit temperature

### DIFF
--- a/PyViCare/PyViCareDevice.py
+++ b/PyViCare/PyViCareDevice.py
@@ -45,7 +45,7 @@ class Device:
     """This class connects to the Viesmann ViCare API.
     The authentication is done through OAuth2.
     Note that currently, a new token is generate for each run.
-    """
+    """ 
 
     def __init__(self, service: ViCareService) -> None:
         self.service = service
@@ -412,8 +412,8 @@ class HeatingCircuit(DeviceWithComponent):
         json representation of the answer
     """
 
-    def setProgramTemperature(self, program: str, temperature: int):
-        return self.service.setProperty(f"heating.circuits.{self.circuit}.operating.programs.{program}", "setTemperature", {'targetTemperature': int(temperature)})
+    def setProgramTemperature(self, program: str, temperature: float):
+        return self.service.setProperty(f"heating.circuits.{self.circuit}.operating.programs.{program}", "setTemperature", {'targetTemperature': float(temperature)})
 
     def setReducedTemperature(self, temperature):
         return self.setProgramTemperature("reduced", temperature)


### PR DESCRIPTION
Fixes #280 

@crazyfx1 I'm a bit concerned about the implications of this. If other integrations are just passing in a float `21.5` in the past it got converted to `21` which every API could handle. If it now passes `21.5` some integrations could now fail, as the API does not allow it. What do you think? Should we take the effort to cast it to the right fraction?