### PR TITLE
Added a timeout for requests.get()

### DIFF
--- a/PyViCare/PyViCareAbstractOAuthManager.py
+++ b/PyViCare/PyViCareAbstractOAuthManager.py
@@ -34,7 +34,7 @@ class AbstractViCareOAuthManager:
     def get(self, url: str) -> Any:
         try:
             logger.debug(self.__oauth)
-            response = self.__oauth.get(f"{API_BASE_URL}{url}").json()
+            response = self.__oauth.get(f"{API_BASE_URL}{url}", timeout=31).json()
             logger.debug(f"Response to get request: {response}")
             self.__handle_expired_token(response)
             self.__handle_rate_limit(response)


### PR DESCRIPTION
(31 seconds hard-coded for now) - this should avoid hanging in case network or server go down during a request.

Should we handle the exception and do a retry within PyViCare, or leave that up to the user of PyViCare? I didn't add any handling of TimeoutError, urllib3.exceptions.ReadTimeoutError or requests.exceptions.ReadTimeout for now.