### PR TITLE
Expose device id

### DIFF
--- a/PyViCare/PyViCare.py
+++ b/PyViCare/PyViCare.py
@@ -63,7 +63,7 @@ class PyViCare:
 
                     logger.info(f"Device found: {device.modelId}")
 
-                    yield PyViCareDeviceConfig(service, device.modelId, device.status)
+                    yield PyViCareDeviceConfig(service, device.id, device.modelId, device.status)
 
 
 class DictWrap(object):

--- a/PyViCare/PyViCareDeviceConfig.py
+++ b/PyViCare/PyViCareDeviceConfig.py
@@ -15,8 +15,9 @@ logger.addHandler(logging.NullHandler())
 
 
 class PyViCareDeviceConfig:
-    def __init__(self, service, device_model, status):
+    def __init__(self, service, device_id, device_model, status):
         self.service = service
+        self.device_id = device_id
         self.device_model = device_model
         self.status = status
 
@@ -43,6 +44,9 @@ class PyViCareDeviceConfig:
 
     def getConfig(self):
         return self.service.accessor
+
+    def getId(self):
+        return self.device_id
 
     def getModel(self):
         return self.device_model

--- a/tests/test_PyViCareDeviceConfig.py
+++ b/tests/test_PyViCareDeviceConfig.py
@@ -17,28 +17,28 @@ class PyViCareDeviceConfigTest(unittest.TestCase):
 
     def test_autoDetect_Vitodens_asGazBoiler(self):
         c = PyViCareDeviceConfig(
-            self.service, "E3_Vitodens_200_xxxx/E3_Dictionary", "Online")
+            self.service, "0", "E3_Vitodens_200_xxxx/E3_Dictionary", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("GazBoiler", type(device_type).__name__)
 
     def test_autoDetect_Unknown_asGeneric(self):
-        c = PyViCareDeviceConfig(self.service, "myRobot", "Online")
+        c = PyViCareDeviceConfig(self.service, "0", "myRobot", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("Device", type(device_type).__name__)
 
     def test_autoDetect_VScot_asGazBoiler(self):
-        c = PyViCareDeviceConfig(self.service, "VScotHO1_200", "Online")
+        c = PyViCareDeviceConfig(self.service, "0", "VScotHO1_200", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("GazBoiler", type(device_type).__name__)
 
     def test_autoDetect_RoleBoiler_asGazBoiler(self):
         self.service.hasRoles = has_roles(["type:boiler"])
-        c = PyViCareDeviceConfig(self.service, "Unknown", "Online")
+        c = PyViCareDeviceConfig(self.service, "0", "Unknown", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("GazBoiler", type(device_type).__name__)
 
     def test_autoDetect_RoleHeatpump_asHeatpump(self):
         self.service.hasRoles = has_roles(["type:heatpump"])
-        c = PyViCareDeviceConfig(self.service, "Unknown", "Online")
+        c = PyViCareDeviceConfig(self.service, "0", "Unknown", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("HeatPump", type(device_type).__name__)


### PR DESCRIPTION
To provide unique device ids for multuple devices in Home Assistant we need to have some way to identify them in a stable way.

See https://developers.home-assistant.io/docs/device_registry_index#defining-devices