### PR TITLE
feat: add burner volumetricFlow sensor to gas devices

### DIFF
--- a/PyViCare/PyViCareGazBoiler.py
+++ b/PyViCare/PyViCareGazBoiler.py
@@ -142,6 +142,10 @@ class GazBoiler(Device):
     def getPowerConsumptionThisYear(self):
         return self.service.getProperty("heating.power.consumption.total")["properties"]["year"]["value"][0]
 
+    @handleNotSupported
+    def getVolumetricFlowReturn(self):
+        return self.service.getProperty("heating.sensors.volumetricFlow.allengra")["properties"]["value"]["value"]
+
     # For Vitodens-100W new "summary" api methods
     # Gas consumption for Heating data:
     @handleNotSupported


### PR DESCRIPTION
Add sensor for volumetric flow on the return.

Measurement can also be viewed in the menu of device via "Information > Burner > Flow sensor".

See also https://github.com/somm15/PyViCare/issues/283.