### PR TITLE
Migrate to authentication endpoint v3 and Authlib

### DIFF
--- a/PyViCare/PyViCareAbstractOAuthManager.py
+++ b/PyViCare/PyViCareAbstractOAuthManager.py
@@ -2,8 +2,8 @@ import logging
 from abc import abstractclassmethod
 from typing import Any
 
-from oauthlib.oauth2 import TokenExpiredError  # type: ignore
-from requests_oauthlib.oauth2_session import OAuth2Session
+from authlib.integrations.base_client import TokenExpiredError
+from authlib.integrations.requests_client import OAuth2Session
 
 from PyViCare import Feature
 from PyViCare.PyViCareUtils import (PyViCareCommandError,

--- a/PyViCare/PyViCareBrowserOAuthManager.py
+++ b/PyViCare/PyViCareBrowserOAuthManager.py
@@ -7,7 +7,9 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import pkce
 import requests
-from requests_oauthlib import OAuth2Session
+
+from authlib.integrations.requests_client import OAuth2Session
+from authlib.common.security import generate_token
 
 from PyViCare.PyViCareAbstractOAuthManager import AbstractViCareOAuthManager
 from PyViCare.PyViCareUtils import (PyViCareBrowserOAuthTimeoutReachedError,
@@ -16,8 +18,8 @@ from PyViCare.PyViCareUtils import (PyViCareBrowserOAuthTimeoutReachedError,
 logger = logging.getLogger('ViCare')
 logger.addHandler(logging.NullHandler())
 
-AUTHORIZE_URL = 'https://iam.viessmann.com/idp/v2/authorize'
-TOKEN_URL = 'https://iam.viessmann.com/idp/v2/token'
+AUTHORIZE_URL = 'https://iam.viessmann.com/idp/v3/authorize'
+TOKEN_URL = 'https://iam.viessmann.com/idp/v3/token'
 REDIRECT_PORT = 51125
 VIESSMANN_SCOPE = ["IoT User", "offline_access"]
 API_BASE_URL = 'https://api.viessmann.com/iot/v1'
@@ -52,24 +54,25 @@ class ViCareBrowserOAuthManager(AbstractViCareOAuthManager):
 
     def __execute_browser_authentication(self):
         redirect_uri = f"http://localhost:{REDIRECT_PORT}"
-        oauth = OAuth2Session(
-            self.client_id, redirect_uri=redirect_uri, scope=VIESSMANN_SCOPE)
-        base_authorization_url, state = oauth.authorization_url(AUTHORIZE_URL)
-        code_verifier, code_challenge = pkce.generate_pkce_pair()
-        authorization_url = f'{base_authorization_url}&code_challenge={code_challenge}&code_challenge_method=S256'
+        oauth_session = OAuth2Session(
+            self.client_id, redirect_uri=redirect_uri, scope=VIESSMANN_SCOPE, code_challenge_method='S256')
+        code_verifier = generate_token(48)
+        authorization_url, _ = oauth_session.create_authorization_url(AUTHORIZE_URL, code_verifier=code_verifier)
 
         webbrowser.open(authorization_url)
 
-        code = None
+        location = None
 
         def callback(path):
-            nonlocal code
-            nonlocal state
-            match = re.match(r"(?P<uri>.+?)\?code=(?P<code>.+)&state=(?P<state>.+)", path)
-            if match.group('state') != state:
-                logger.warn("Invalid OAuth state")
-                return (401, "Invalid Oauth state.")
-            code = match.group('code')
+            nonlocal location
+            location = path
+            # nonlocal code
+            # # nonlocal state
+            # match = re.match(r"(?P<uri>.+?)\?code=(?P<code>.+)&state=(?P<state>.+)", path)
+            # if match.group('state') != state:
+            #     logger.warn("Invalid OAuth state")
+            #     return (401, "Invalid Oauth state.")
+            # code = match.group('code')
             return (200, "Success. You can close this browser window now.")
 
         def handlerWithCallbackWrapper(*args):
@@ -80,22 +83,29 @@ class ViCareBrowserOAuthManager(AbstractViCareOAuthManager):
         server.timeout = AUTH_TIMEOUT
         server.handle_request()
 
-        if code is None:
+        if location is None:
             logger.debug("Timeout reached")
             raise PyViCareBrowserOAuthTimeoutReachedError()
 
-        logger.debug(f"Code: {code}")
+        logger.debug(f"Location: {location}")
 
-        result = requests.post(url=TOKEN_URL, data={
-            'grant_type': 'authorization_code',
-            'client_id': self.client_id,
-            'redirect_uri': redirect_uri,
-            'code': code,
-            'code_verifier': code_verifier
-        }
-        ).json()
+        oauth_session.fetch_token(TOKEN_URL, authorization_response=location, code_verifier=code_verifier)
 
-        return self.__build_oauth_session(result, after_redirect=True)
+
+        # result = requests.post(url=TOKEN_URL, data={
+        #     'grant_type': 'authorization_code',
+        #     'client_id': self.client_id,
+        #     'redirect_uri': redirect_uri,
+        #     'code': code,
+        #     'code_verifier': code_verifier
+        # }
+        # ).json()
+        logger.debug(f"Token received: {oauth_session.token}")
+        self.__serialize_token(oauth_session.token, self.token_file)
+        logger.info("New token created")
+        return oauth_session
+
+        # return self.__build_oauth_session(result, after_redirect=True)
 
     def __storeToken(self, token):
         if self.token_file is None:

--- a/PyViCare/PyViCareOAuthManager.py
+++ b/PyViCare/PyViCareOAuthManager.py
@@ -64,8 +64,7 @@ class ViCareOAuthManager(AbstractViCareOAuthManager):
             authorization_url, headers=header, auth=(username, password), allow_redirects=False)
     
         if response.status_code == 401:
-            exception = PyViCareInvalidConfigurationError(response.json())
-            raise exception
+            raise PyViCareInvalidConfigurationError(response.json())
 
         if 'Location' not in response.headers:
             logger.debug(f'Response: {response}')

--- a/PyViCare/PyViCareOAuthManager.py
+++ b/PyViCare/PyViCareOAuthManager.py
@@ -73,6 +73,9 @@ class ViCareOAuthManager(AbstractViCareOAuthManager):
 
         oauth_session.fetch_token(TOKEN_URL, authorization_response=response.headers['Location'], code_verifier=code_verifier)
 
+        if oauth_session.token is None:
+            raise PyViCareInvalidCredentialsError()
+
         logger.debug(f"Token received: {oauth_session.token}")
         self.__serialize_token(oauth_session.token, token_file)
         logger.info("New token created")

--- a/PyViCare/PyViCareUtils.py
+++ b/PyViCare/PyViCareUtils.py
@@ -74,18 +74,23 @@ def handleAPICommandErrors(func: Callable) -> Callable:
 class PyViCareNotSupportedFeatureError(Exception):
     pass
 
+class PyViCareInvalidConfigurationError(Exception):
+    def __init__(self, response):
+        error = response['error']
+        error_description = response['error_description']
+
+        msg = f'Invalid credentials. Error: {error}. Description: {error_description}. Please check your configuration: clientid and redirect uri.'
+        super().__init__(self, msg)
+        self.message = msg
 
 class PyViCareInvalidCredentialsError(Exception):
     pass
 
-
 class PyViCareBrowserOAuthTimeoutReachedError(Exception):
     pass
 
-
 class PyViCareInvalidDataError(Exception):
     pass
-
 
 class PyViCareRateLimitError(Exception):
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/somm15/PyViCare",
     packages=setuptools.find_packages(exclude=["tests"]),
-    install_requires=['requests-oauthlib>=1.1.0', 'pkce'],
+    install_requires=['Authlib>=1.2.0', 'requests-oauthlib>=1.1.0', 'pkce'],
     setup_requires=['setuptools-git-versioning<1.8.0'],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/somm15/PyViCare",
     packages=setuptools.find_packages(exclude=["tests"]),
-    install_requires=['Authlib>=1.2.0', 'requests-oauthlib>=1.1.0', 'pkce'],
+    install_requires=['Authlib>=1.2.0'],
     setup_requires=['setuptools-git-versioning<1.8.0'],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Viessmann created a new authentication endpoint v3:
https://documentation.viessmann.com/static/changelog

This PR migrates the existing auth code to a newer auth library and removes some of the custom code to fetch tokens.

The new implementation enables to differentiate between a authentication configuration error (wrong clientid, redirecturi, etc.) and wrong credentials (username or password is wrong). In the HA component we need to check for ```PyViCareInvalidConfigurationError``` now aswell and can show a better error message to the user .

@woehrl01 It would be great if you could test this branch on your end aswell before merging ;)