### PR TITLE
handle InvalidTokenError and fix setProperty

### DIFF
--- a/PyViCare/PyViCareAbstractOAuthManager.py
+++ b/PyViCare/PyViCareAbstractOAuthManager.py
@@ -2,7 +2,7 @@ import logging
 from abc import abstractclassmethod
 from typing import Any
 
-from authlib.integrations.base_client import TokenExpiredError
+from authlib.integrations.base_client import TokenExpiredError, InvalidTokenError
 from authlib.integrations.requests_client import OAuth2Session
 
 from PyViCare import Feature
@@ -43,6 +43,9 @@ class AbstractViCareOAuthManager:
         except TokenExpiredError:
             self.renewToken()
             return self.get(url)
+        except InvalidTokenError:
+            self.renewToken()
+            return self.get(url)          
 
     def __handle_expired_token(self, response):
         if ("error" in response and response["error"] == "EXPIRED TOKEN"):
@@ -93,3 +96,6 @@ class AbstractViCareOAuthManager:
         except TokenExpiredError:
             self.renewToken()
             return self.post(url, data)
+        except InvalidTokenError:
+            self.renewToken()
+            return self.get(url)          

--- a/PyViCare/PyViCareService.py
+++ b/PyViCare/PyViCareService.py
@@ -24,7 +24,7 @@ def hasRoles(requested_roles: List[str], existing_roles: List[str]) -> bool:
 
 
 def buildSetPropertyUrl(accessor, property_name, action):
-    return f'/features/installations/{accessor.id}/gateways/{accessor.serial}/devices/{accessor.device_id}/features/{property_name}/{action}'
+    return f'/features/installations/{accessor.id}/gateways/{accessor.serial}/devices/{accessor.device_id}/features/{property_name}/commands/{action}'
 
 
 def buildGetPropertyUrl(accessor, property_name):

--- a/tests/test_PyViCareCachedService.py
+++ b/tests/test_PyViCareCachedService.py
@@ -32,7 +32,7 @@ class PyViCareCachedServiceTest(unittest.TestCase):
     def test_setProperty_works(self):
         self.service.setProperty("someotherprop", "doaction", {'name': 'abc'})
         self.oauth_mock.post.assert_called_once_with(
-            '/features/installations/[id]/gateways/[serial]/devices/[device]/features/someotherprop/doaction', '{"name": "abc"}')
+            '/features/installations/[id]/gateways/[serial]/devices/[device]/features/someotherprop/commands/doaction', '{"name": "abc"}')
 
     def test_getProperty_existing_cached(self):
         # time+0 seconds

--- a/tests/test_PyViCareService.py
+++ b/tests/test_PyViCareService.py
@@ -19,9 +19,9 @@ class PyViCareServiceTest(unittest.TestCase):
     def test_setProperty_object(self):
         self.service.setProperty("someprop", "doaction", {'name': 'abc'})
         self.oauth_mock.post.assert_called_once_with(
-            '/features/installations/[id]/gateways/[serial]/devices/[device]/features/someprop/doaction', '{"name": "abc"}')
+            '/features/installations/[id]/gateways/[serial]/devices/[device]/features/someprop/commands/doaction', '{"name": "abc"}')
 
     def test_setProperty_string(self):
         self.service.setProperty("someprop", "doaction", '{}')
         self.oauth_mock.post.assert_called_once_with(
-            '/features/installations/[id]/gateways/[serial]/devices/[device]/features/someprop/doaction', '{}')
+            '/features/installations/[id]/gateways/[serial]/devices/[device]/features/someprop/commands/doaction', '{}')


### PR DESCRIPTION
After installing the latest release I discovered that after some time I always get an InvalidTokenError.
And I no longer can set any property