### PR TITLE
Add Support for HEMS, VX3 and other EES Devices

### DIFF
--- a/PyViCare/PyViCare.py
+++ b/PyViCare/PyViCare.py
@@ -54,11 +54,20 @@ class PyViCare:
         for installation in self.installations:
             for gateway in installation.gateways:
                 for device in gateway.devices:
-                    if device.deviceType != "heating" and device.deviceType != "zigbee" and device.deviceType != "vitoconnect":
+                    if device.deviceType != "heating" and device.deviceType != "zigbee" and device.deviceType != "vitoconnect" and device.deviceType != "electricityStorage" and device.deviceType != "EEBus" and device.deviceType != "hems" and device.deviceType != "tcu":
                         continue  # we are not interested in non heating devices
 
                     if device.id == "gateway" and device.deviceType == "vitoconnect":
                         device.id = "0"  # vitoconnect has no device id, so we use 0
+                    
+                    if device.id == "gateway" and device.deviceType == "tcu":
+                        device.id = "0"  # vitoconnect has no device id, so we use 0
+
+                    if device.id == "HEMS" and device.deviceType == "hems":
+                        device.id = "0"  # vitoconnect has no device id, so we use 0
+
+                    if device.id == "EEBUS" and device.deviceType == "EEBus":
+                        device.id = "0" # vitoconnect has no device id,
 
                     accessor = ViCareDeviceAccessor(
                         installation.id, gateway.serial, device.id)

--- a/PyViCare/PyViCare.py
+++ b/PyViCare/PyViCare.py
@@ -55,19 +55,19 @@ class PyViCare:
             for gateway in installation.gateways:
                 for device in gateway.devices:
                     if device.deviceType != "heating" and device.deviceType != "zigbee" and device.deviceType != "vitoconnect" and device.deviceType != "electricityStorage" and device.deviceType != "EEBus" and device.deviceType != "hems" and device.deviceType != "tcu":
-                        continue  # we are not interested in non heating devices
+                        continue  # we are only interested in heating, photovoltaic, electricityStorage and hems devices
 
                     if device.id == "gateway" and device.deviceType == "vitoconnect":
                         device.id = "0"  # vitoconnect has no device id, so we use 0
                     
                     if device.id == "gateway" and device.deviceType == "tcu":
-                        device.id = "0"  # vitoconnect has no device id, so we use 0
+                        device.id = "0"  # tcu has no device id, so we use 0
 
                     if device.id == "HEMS" and device.deviceType == "hems":
-                        device.id = "0"  # vitoconnect has no device id, so we use 0
+                        device.id = "0"  # hems has no device id, so we use 0
 
                     if device.id == "EEBUS" and device.deviceType == "EEBus":
-                        device.id = "0" # vitoconnect has no device id,
+                        device.id = "0" # EEBus has no device id,
 
                     accessor = ViCareDeviceAccessor(
                         installation.id, gateway.serial, device.id)

--- a/PyViCare/PyViCareDeviceConfig.py
+++ b/PyViCare/PyViCareDeviceConfig.py
@@ -11,6 +11,7 @@ from PyViCare.PyViCareOilBoiler import OilBoiler
 from PyViCare.PyViCarePelletsBoiler import PelletsBoiler
 from PyViCare.PyViCareRadiatorActuator import RadiatorActuator
 from PyViCare.PyViCareRoomSensor import RoomSensor
+from PyViCare.PyViCareElectricalEnergySystem import ElectricalEnergySystem
 
 logger = logging.getLogger('ViCare')
 logger.addHandler(logging.NullHandler())
@@ -49,6 +50,9 @@ class PyViCareDeviceConfig:
 
     def asRoomSensor(self):
         return RoomSensor(self.service)
+    
+    def asElectricalEnergySystem(self):
+        return ElectricalEnergySystem(self.service)
 
     def getConfig(self):
         return self.service.accessor
@@ -71,7 +75,11 @@ class PyViCareDeviceConfig:
             (self.asOilBoiler, r"Vitoladens|Vitoradial|Vitorondens|VPlusH|V200KW2_6", []),
             (self.asPelletsBoiler, r"Vitoligno|Ecotronic|VBC550P", []),
             (self.asRadiatorActuator, r"E3_RadiatorActuator", ["type:radiator"]),
-            (self.asRoomSensor, r"E3_RoomSensor", ["type:climateSensor"])
+            (self.asRoomSensor, r"E3_RoomSensor", ["type:climateSensor"]),
+            (self.asElectricalEnergySystem, r"E3_HEMS", ["type:hems"]),
+            (self.asElectricalEnergySystem, r"E3_TCU10_x07", ["type:tcu"]),
+            (self.asElectricalEnergySystem, r"E3_EEBus", ["type:eebus"]),
+            (self.asElectricalEnergySystem, r"E3_VitoCharge_03", ["type:energy_storage"])
         ]
 
         for (creator_method, type_name, roles) in device_types:

--- a/PyViCare/PyViCareElectricalEnergySystem.py
+++ b/PyViCare/PyViCareElectricalEnergySystem.py
@@ -1,111 +1,156 @@
 from typing import Any, List
 
-from PyViCare.PyViCareHeatingDevice import (HeatingDevice,
-                                            get_available_burners)
+from PyViCare.PyViCareHeatingDevice import HeatingDevice, get_available_burners
 from PyViCare.PyViCareUtils import handleNotSupported
 
-class ElectricalEnergySystem(HeatingDevice):
 
+class ElectricalEnergySystem(HeatingDevice):
     @handleNotSupported
     def getSerial(self):
         return self.service.getProperty("device.serial")["properties"]["value"]["value"]
 
     @handleNotSupported
     def getPointOfCommonCouplingTransferPowerExchange(self):
-        return self.service.getProperty("pcc.transfer.power.exchange")["properties"]["value"]["value"]
-    
+        return self.service.getProperty("pcc.transfer.power.exchange")["properties"][
+            "value"
+        ]["value"]
+
     @handleNotSupported
     def getPhotovoltaicProductionCumulatedUnit(self):
-        return self.service.getProperty("photovoltaic.production.cumulated")["properties"]["currentDay"]["unit"]
-    
+        return self.service.getProperty("photovoltaic.production.cumulated")[
+            "properties"
+        ]["currentDay"]["unit"]
+
     @handleNotSupported
     def getPhotovoltaicProductionCumulatedCurrentDay(self):
-        return self.service.getProperty("photovoltaic.production.cumulated")["properties"]["currentDay"]["value"]
-    
+        return self.service.getProperty("photovoltaic.production.cumulated")[
+            "properties"
+        ]["currentDay"]["value"]
+
     @handleNotSupported
     def getPhotovoltaicProductionCumulatedCurrentWeek(self):
-        return self.service.getProperty("photovoltaic.production.cumulated")["properties"]["currentWeek"]["value"]
-    
+        return self.service.getProperty("photovoltaic.production.cumulated")[
+            "properties"
+        ]["currentWeek"]["value"]
+
     @handleNotSupported
     def getPhotovoltaicProductionCumulatedCurrentMonth(self):
-        return self.service.getProperty("photovoltaic.production.cumulated")["properties"]["currentMonth"]["value"]
-    
+        return self.service.getProperty("photovoltaic.production.cumulated")[
+            "properties"
+        ]["currentMonth"]["value"]
+
     @handleNotSupported
     def getPhotovoltaicProductionCumulatedCurrentYear(self):
-        return self.service.getProperty("photovoltaic.production.cumulated")["properties"]["currentYear"]["value"]
-    
+        return self.service.getProperty("photovoltaic.production.cumulated")[
+            "properties"
+        ]["currentYear"]["value"]
+
     @handleNotSupported
     def getPhotovoltaicProductionCumulatedLifeCycle(self):
-        return self.service.getProperty("photovoltaic.production.cumulated")["properties"]["lifeCycle"]["value"]
-    
+        return self.service.getProperty("photovoltaic.production.cumulated")[
+            "properties"
+        ]["lifeCycle"]["value"]
+
     @handleNotSupported
     def getPhotovoltaicStatus(self):
-        return self.service.getProperty("photovoltaic.status")["properties"]["status"]["value"]
-    
+        return self.service.getProperty("photovoltaic.status")["properties"]["status"][
+            "value"
+        ]
+
     @handleNotSupported
     def getPhotovoltaicProductionCurrent(self):
-        return self.service.getProperty("photovoltaic.production.current")["properties"]["value"]["value"]
+        return self.service.getProperty("photovoltaic.production.current")[
+            "properties"
+        ]["value"]["value"]
     
-    
+    @handleNotSupported
+    def getPhotovoltaicProductionCurrentUnit(self):
+        return self.service.getProperty("photovoltaic.production.current")[
+            "properties"
+        ]["value"]["unit"]
+
     @handleNotSupported
     def getPointOfCommonCouplingTransferConsumptionTotal(self):
-        return self.service.getProperty("pcc.transfer.consumption.total")["properties"]["value"]["value"]
-    
+        return self.service.getProperty("pcc.transfer.consumption.total")["properties"][
+            "value"
+        ]["value"]
+
     @handleNotSupported
     def getPointOfCommonCouplingTransferConsumptionTotalUnit(self):
-        return self.service.getProperty("pcc.transfer.consumption.total")["properties"]["value"]["unit"]
-    
+        return self.service.getProperty("pcc.transfer.consumption.total")["properties"][
+            "value"
+        ]["unit"]
+
     @handleNotSupported
     def getPointOfCommonCouplingTransferFeedInTotal(self):
-        return self.service.getProperty("pcc.transfer.feedIn.total")["properties"]["value"]["value"]
-    
+        return self.service.getProperty("pcc.transfer.feedIn.total")["properties"][
+            "value"
+        ]["value"]
+
     @handleNotSupported
     def getPointOfCommonCouplingTransferFeedInTotalUnit(self):
-        return self.service.getProperty("pcc.transfer.feedIn.total")["properties"]["value"]["unit"]
-    
+        return self.service.getProperty("pcc.transfer.feedIn.total")["properties"][
+            "value"
+        ]["unit"]
+
     @handleNotSupported
     def getElectricalEnergySystemTransferDischargeCumulatedUnit(self):
-        return self.service.getProperty("ess.transfer.discharge.cumulated")["properties"]["currentDay"]["unit"]
-    
+        return self.service.getProperty("ess.transfer.discharge.cumulated")[
+            "properties"
+        ]["currentDay"]["unit"]
+
     @handleNotSupported
     def getElectricalEnergySystemTransferDischargeCumulatedCurrentDay(self):
-        return self.service.getProperty("ess.transfer.discharge.cumulated")["properties"]["currentDay"]["value"]
-    
+        return self.service.getProperty("ess.transfer.discharge.cumulated")[
+            "properties"
+        ]["currentDay"]["value"]
+
     @handleNotSupported
     def getElectricalEnergySystemTransferDischargeCumulatedCurrentWeek(self):
-        return self.service.getProperty("ess.transfer.discharge.cumulated")["properties"]["currentWeek"]["value"]
-    
+        return self.service.getProperty("ess.transfer.discharge.cumulated")[
+            "properties"
+        ]["currentWeek"]["value"]
+
     @handleNotSupported
     def getElectricalEnergySystemTransferDischargeCumulatedCurrentMonth(self):
-        return self.service.getProperty("ess.transfer.discharge.cumulated")["properties"]["currentMonth"]["value"]
-    
+        return self.service.getProperty("ess.transfer.discharge.cumulated")[
+            "properties"
+        ]["currentMonth"]["value"]
+
     @handleNotSupported
     def getElectricalEnergySystemTransferDischargeCumulatedCurrentYear(self):
-        return self.service.getProperty("ess.transfer.discharge.cumulated")["properties"]["currentYear"]["value"]
-    
+        return self.service.getProperty("ess.transfer.discharge.cumulated")[
+            "properties"
+        ]["currentYear"]["value"]
+
     @handleNotSupported
     def getElectricalEnergySystemTransferDischargeCumulatedLifeCycle(self):
-        return self.service.getProperty("ess.transfer.discharge.cumulated")["properties"]["lifeCycle"]["value"]
-    
+        return self.service.getProperty("ess.transfer.discharge.cumulated")[
+            "properties"
+        ]["lifeCycle"]["value"]
+
     @handleNotSupported
     def getElectricalEnergySystemSOC(self):
-        return self.service.getProperty("ess.stateOfCharge")["properties"]["value"]["value"]
-    
+        return self.service.getProperty("ess.stateOfCharge")["properties"]["value"][
+            "value"
+        ]
+
     @handleNotSupported
     def getElectricalEnergySystemSOCUnit(self):
-        return self.service.getProperty("ess.stateOfCharge")["properties"]["value"]["unit"]
-    
+        return self.service.getProperty("ess.stateOfCharge")["properties"]["value"][
+            "unit"
+        ]
+
     @handleNotSupported
     def getElectricalEnergySystemPower(self):
         return self.service.getProperty("ess.power")["properties"]["value"]["value"]
-    
+
     @handleNotSupported
     def getElectricalEnergySystemPowerUnit(self):
         return self.service.getProperty("ess.power")["properties"]["value"]["value"]
-    
+
     @handleNotSupported
     def getElectricalEnergySystemOperationState(self):
-        return self.service.getProperty("ess.operationState")["properties"]["value"]["value"]
-    
-
-    
+        return self.service.getProperty("ess.operationState")["properties"]["value"][
+            "value"
+        ]

--- a/PyViCare/PyViCareElectricalEnergySystem.py
+++ b/PyViCare/PyViCareElectricalEnergySystem.py
@@ -1,14 +1,9 @@
 from typing import Any, List
-
-from PyViCare.PyViCareHeatingDevice import HeatingDevice, get_available_burners
+from PyViCare.PyViCareDevice import Device
 from PyViCare.PyViCareUtils import handleNotSupported
 
 
-class ElectricalEnergySystem(HeatingDevice):
-    @handleNotSupported
-    def getSerial(self):
-        return self.service.getProperty("device.serial")["properties"]["value"]["value"]
-
+class ElectricalEnergySystem(Device):
     @handleNotSupported
     def getPointOfCommonCouplingTransferPowerExchange(self):
         return self.service.getProperty("pcc.transfer.power.exchange")["properties"][

--- a/PyViCare/PyViCareElectricalEnergySystem.py
+++ b/PyViCare/PyViCareElectricalEnergySystem.py
@@ -6,9 +6,106 @@ from PyViCare.PyViCareUtils import handleNotSupported
 
 class ElectricalEnergySystem(HeatingDevice):
 
-    @property
     @handleNotSupported
-    def getTransferPowerExchange(self):
+    def getSerial(self):
+        return self.service.getProperty("device.serial")["properties"]["value"]["value"]
+
+    @handleNotSupported
+    def getPointOfCommonCouplingTransferPowerExchange(self):
         return self.service.getProperty("pcc.transfer.power.exchange")["properties"]["value"]["value"]
+    
+    @handleNotSupported
+    def getPhotovoltaicProductionCumulatedUnit(self):
+        return self.service.getProperty("photovoltaic.production.cumulated")["properties"]["currentDay"]["unit"]
+    
+    @handleNotSupported
+    def getPhotovoltaicProductionCumulatedCurrentDay(self):
+        return self.service.getProperty("photovoltaic.production.cumulated")["properties"]["currentDay"]["value"]
+    
+    @handleNotSupported
+    def getPhotovoltaicProductionCumulatedCurrentWeek(self):
+        return self.service.getProperty("photovoltaic.production.cumulated")["properties"]["currentWeek"]["value"]
+    
+    @handleNotSupported
+    def getPhotovoltaicProductionCumulatedCurrentMonth(self):
+        return self.service.getProperty("photovoltaic.production.cumulated")["properties"]["currentMonth"]["value"]
+    
+    @handleNotSupported
+    def getPhotovoltaicProductionCumulatedCurrentYear(self):
+        return self.service.getProperty("photovoltaic.production.cumulated")["properties"]["currentYear"]["value"]
+    
+    @handleNotSupported
+    def getPhotovoltaicProductionCumulatedLifeCycle(self):
+        return self.service.getProperty("photovoltaic.production.cumulated")["properties"]["lifeCycle"]["value"]
+    
+    @handleNotSupported
+    def getPhotovoltaicStatus(self):
+        return self.service.getProperty("photovoltaic.status")["properties"]["status"]["value"]
+    
+    @handleNotSupported
+    def getPhotovoltaicProductionCurrent(self):
+        return self.service.getProperty("photovoltaic.production.current")["properties"]["value"]["value"]
+    
+    
+    @handleNotSupported
+    def getPointOfCommonCouplingTransferConsumptionTotal(self):
+        return self.service.getProperty("pcc.transfer.consumption.total")["properties"]["value"]["value"]
+    
+    @handleNotSupported
+    def getPointOfCommonCouplingTransferConsumptionTotalUnit(self):
+        return self.service.getProperty("pcc.transfer.consumption.total")["properties"]["value"]["unit"]
+    
+    @handleNotSupported
+    def getPointOfCommonCouplingTransferFeedInTotal(self):
+        return self.service.getProperty("pcc.transfer.feedIn.total")["properties"]["value"]["value"]
+    
+    @handleNotSupported
+    def getPointOfCommonCouplingTransferFeedInTotalUnit(self):
+        return self.service.getProperty("pcc.transfer.feedIn.total")["properties"]["value"]["unit"]
+    
+    @handleNotSupported
+    def getElectricalEnergySystemTransferDischargeCumulatedUnit(self):
+        return self.service.getProperty("ess.transfer.discharge.cumulated")["properties"]["currentDay"]["unit"]
+    
+    @handleNotSupported
+    def getElectricalEnergySystemTransferDischargeCumulatedCurrentDay(self):
+        return self.service.getProperty("ess.transfer.discharge.cumulated")["properties"]["currentDay"]["value"]
+    
+    @handleNotSupported
+    def getElectricalEnergySystemTransferDischargeCumulatedCurrentWeek(self):
+        return self.service.getProperty("ess.transfer.discharge.cumulated")["properties"]["currentWeek"]["value"]
+    
+    @handleNotSupported
+    def getElectricalEnergySystemTransferDischargeCumulatedCurrentMonth(self):
+        return self.service.getProperty("ess.transfer.discharge.cumulated")["properties"]["currentMonth"]["value"]
+    
+    @handleNotSupported
+    def getElectricalEnergySystemTransferDischargeCumulatedCurrentYear(self):
+        return self.service.getProperty("ess.transfer.discharge.cumulated")["properties"]["currentYear"]["value"]
+    
+    @handleNotSupported
+    def getElectricalEnergySystemTransferDischargeCumulatedLifeCycle(self):
+        return self.service.getProperty("ess.transfer.discharge.cumulated")["properties"]["lifeCycle"]["value"]
+    
+    @handleNotSupported
+    def getElectricalEnergySystemSOC(self):
+        return self.service.getProperty("ess.stateOfCharge")["properties"]["value"]["value"]
+    
+    @handleNotSupported
+    def getElectricalEnergySystemSOCUnit(self):
+        return self.service.getProperty("ess.stateOfCharge")["properties"]["value"]["unit"]
+    
+    @handleNotSupported
+    def getElectricalEnergySystemPower(self):
+        return self.service.getProperty("ess.power")["properties"]["value"]["value"]
+    
+    @handleNotSupported
+    def getElectricalEnergySystemPowerUnit(self):
+        return self.service.getProperty("ess.power")["properties"]["value"]["value"]
+    
+    @handleNotSupported
+    def getElectricalEnergySystemOperationState(self):
+        return self.service.getProperty("ess.operationState")["properties"]["value"]["value"]
+    
 
     

--- a/PyViCare/PyViCareElectricalEnergySystem.py
+++ b/PyViCare/PyViCareElectricalEnergySystem.py
@@ -1,0 +1,14 @@
+from typing import Any, List
+
+from PyViCare.PyViCareHeatingDevice import (HeatingDevice,
+                                            get_available_burners)
+from PyViCare.PyViCareUtils import handleNotSupported
+
+class ElectricalEnergySystem(HeatingDevice):
+
+    @property
+    @handleNotSupported
+    def getTransferPowerExchange(self):
+        return self.service.getProperty("pcc.transfer.power.exchange")["properties"]["value"]["value"]
+
+    

--- a/PyViCare/PyViCareElectricalEnergySystem.py
+++ b/PyViCare/PyViCareElectricalEnergySystem.py
@@ -1,9 +1,14 @@
 from typing import Any, List
 from PyViCare.PyViCareDevice import Device
 from PyViCare.PyViCareUtils import handleNotSupported
+from PyViCare.PyViCareService import ViCareService
 
 
 class ElectricalEnergySystem(Device):
+
+    def __init__(self, service: ViCareService) -> None:
+        self.service = service
+
     @handleNotSupported
     def getPointOfCommonCouplingTransferPowerExchange(self):
         return self.service.getProperty("pcc.transfer.power.exchange")["properties"][
@@ -142,7 +147,7 @@ class ElectricalEnergySystem(Device):
 
     @handleNotSupported
     def getElectricalEnergySystemPowerUnit(self):
-        return self.service.getProperty("ess.power")["properties"]["value"]["value"]
+        return self.service.getProperty("ess.power")["properties"]["value"]["unit"]
 
     @handleNotSupported
     def getElectricalEnergySystemOperationState(self):

--- a/tests/response/VitochargeVX3.json
+++ b/tests/response/VitochargeVX3.json
@@ -1,0 +1,256 @@
+{
+    "data": [
+        {
+            "properties": {
+                "currentDay": {
+                    "type": "number",
+                    "value": 47440,
+                    "unit": "wattHour"
+                },
+                "currentWeek": {
+                    "type": "number",
+                    "value": 208436,
+                    "unit": "wattHour"
+                },
+                "currentMonth": {
+                    "type": "number",
+                    "value": 487670,
+                    "unit": "wattHour"
+                },
+                "currentYear": {
+                    "type": "number",
+                    "value": 487670,
+                    "unit": "wattHour"
+                },
+                "lifeCycle": {
+                    "type": "number",
+                    "value": 487670,
+                    "unit": "wattHour"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/photovoltaic.production.cumulated",
+            "gatewayId": "################",
+            "feature": "photovoltaic.production.cumulated",
+            "timestamp": "2023-05-26T19:22:09.055Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "################"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/device.serial",
+            "gatewayId": "################",
+            "feature": "device.serial",
+            "timestamp": "2023-05-25T14:43:26.622Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 7700,
+                    "unit": "wattHour"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/pcc.transfer.consumption.total",
+            "gatewayId": "################",
+            "feature": "pcc.transfer.consumption.total",
+            "timestamp": "2023-05-25T16:55:44.150Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "currentDay": {
+                    "type": "number",
+                    "value": 4751,
+                    "unit": "wattHour"
+                },
+                "currentWeek": {
+                    "type": "number",
+                    "value": 29820,
+                    "unit": "wattHour"
+                },
+                "currentMonth": {
+                    "type": "number",
+                    "value": 66926,
+                    "unit": "wattHour"
+                },
+                "currentYear": {
+                    "type": "number",
+                    "value": 66926,
+                    "unit": "wattHour"
+                },
+                "lifeCycle": {
+                    "type": "number",
+                    "value": 66926,
+                    "unit": "wattHour"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/ess.transfer.discharge.cumulated",
+            "gatewayId": "################",
+            "feature": "ess.transfer.discharge.cumulated",
+            "timestamp": "2023-05-26T20:21:05.602Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 298900,
+                    "unit": "wattHour"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/pcc.transfer.feedIn.total",
+            "gatewayId": "################",
+            "feature": "pcc.transfer.feedIn.total",
+            "timestamp": "2023-05-26T18:19:16.330Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 91,
+                    "unit": "percent"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/ess.stateOfCharge",
+            "gatewayId": "################",
+            "feature": "ess.stateOfCharge",
+            "timestamp": "2023-05-26T20:20:30.651Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 0,
+                    "unit": "watt"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/pcc.transfer.power.exchange",
+            "gatewayId": "################",
+            "feature": "pcc.transfer.power.exchange",
+            "timestamp": "2023-05-26T20:21:05.602Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "################"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.serial",
+            "gatewayId": "################",
+            "feature": "heating.boiler.serial",
+            "timestamp": "2023-05-25T14:43:26.623Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "ready"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/photovoltaic.status",
+            "gatewayId": "################",
+            "feature": "photovoltaic.status",
+            "timestamp": "2023-05-26T19:10:36.637Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 700,
+                    "unit": "watt"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/ess.power",
+            "gatewayId": "################",
+            "feature": "ess.power",
+            "timestamp": "2023-05-26T20:21:12.542Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 0,
+                    "unit": "kilowatt"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/photovoltaic.production.current",
+            "gatewayId": "################",
+            "feature": "photovoltaic.production.current",
+            "timestamp": "2023-05-26T19:19:13.292Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "discharge"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/ess.operationState",
+            "gatewayId": "################",
+            "feature": "ess.operationState",
+            "timestamp": "2023-05-26T18:33:10.937Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        }
+    ]
+}

--- a/tests/test_VitochargeVX3.py
+++ b/tests/test_VitochargeVX3.py
@@ -1,0 +1,109 @@
+import unittest
+
+from PyViCare.PyViCareElectricalEnergySystem import ElectricalEnergySystem
+from tests.ViCareServiceMock import ViCareServiceMock
+
+
+class VitochargeVX3(unittest.TestCase):
+    def setUp(self):
+        self.service = ViCareServiceMock('response/VitochargeVX3.json')
+        self.device = ElectricalEnergySystem(self.service)
+
+    def test_getPointOfCommonCouplingTransferPowerExchange(self):
+        self.assertEqual(self.device.getPointOfCommonCouplingTransferPowerExchange(), 0)
+
+    
+    def test_getPhotovoltaicProductionCumulatedUnit(self):
+        self.assertEqual(self.device.getPhotovoltaicProductionCumulatedUnit(), "wattHour")
+    
+    def test_getPhotovoltaicProductionCumulatedCurrentDay(self):
+        self.assertEqual(self.device.getPhotovoltaicProductionCumulatedCurrentDay(), 47440)
+
+    
+    def test_getPhotovoltaicProductionCumulatedCurrentWeek(self):
+        self.assertEqual(self.device.getPhotovoltaicProductionCumulatedCurrentWeek(), 208436)
+
+    
+    def test_getPhotovoltaicProductionCumulatedCurrentMonth(self):
+        self.assertEqual(self.device.getPhotovoltaicProductionCumulatedCurrentMonth(), 487670)
+
+    
+    def test_getPhotovoltaicProductionCumulatedCurrentYear(self):
+        self.assertEqual(self.device.getPhotovoltaicProductionCumulatedCurrentYear(), 487670)
+
+    
+    def test_getPhotovoltaicProductionCumulatedLifeCycle(self):
+        self.assertEqual(self.device.getPhotovoltaicProductionCumulatedLifeCycle(), 487670)
+
+    
+    def test_getPhotovoltaicStatus(self):
+        self.assertEqual(self.device.getPhotovoltaicStatus(), "ready")
+
+    
+    def test_getPhotovoltaicProductionCurrent(self):
+        self.assertEqual(self.device.getPhotovoltaicProductionCurrent(), 0)
+    
+    
+    def test_getPhotovoltaicProductionCurrentUnit(self):
+        self.assertEqual(self.device.getPhotovoltaicProductionCurrentUnit(), "kilowatt")
+
+    
+    def test_getPointOfCommonCouplingTransferConsumptionTotal(self):
+        self.assertEqual(self.device.getPointOfCommonCouplingTransferConsumptionTotal(),7700)
+
+    
+    def test_getPointOfCommonCouplingTransferConsumptionTotalUnit(self):
+        self.assertEqual(self.device.getPointOfCommonCouplingTransferConsumptionTotalUnit(),"wattHour")
+
+    
+    def test_getPointOfCommonCouplingTransferFeedInTotal(self):
+        self.assertEqual(self.device.getPointOfCommonCouplingTransferFeedInTotal(),298900)
+
+    
+    def test_getPointOfCommonCouplingTransferFeedInTotalUnit(self):
+        self.assertEqual(self.device.getPointOfCommonCouplingTransferFeedInTotalUnit(),"wattHour")
+
+    
+    def test_getElectricalEnergySystemTransferDischargeCumulatedUnit(self):
+        self.assertEqual(self.device.getElectricalEnergySystemTransferDischargeCumulatedUnit(),"wattHour")
+
+    
+    def test_getElectricalEnergySystemTransferDischargeCumulatedCurrentDay(self):
+        self.assertEqual(self.device.getElectricalEnergySystemTransferDischargeCumulatedCurrentDay(),4751)
+
+    
+    def test_getElectricalEnergySystemTransferDischargeCumulatedCurrentWeek(self):
+        self.assertEqual(self.device.getElectricalEnergySystemTransferDischargeCumulatedCurrentWeek(),29820)
+    
+    def test_getElectricalEnergySystemTransferDischargeCumulatedCurrentMonth(self):
+        self.assertEqual(self.device.getElectricalEnergySystemTransferDischargeCumulatedCurrentMonth(),66926)
+
+    
+    def test_getElectricalEnergySystemTransferDischargeCumulatedCurrentYear(self):
+        self.assertEqual(self.device.getElectricalEnergySystemTransferDischargeCumulatedCurrentYear(),66926)
+
+    
+    def test_getElectricalEnergySystemTransferDischargeCumulatedLifeCycle(self):
+        self.assertEqual(self.device.getElectricalEnergySystemTransferDischargeCumulatedLifeCycle(),66926)
+
+    
+    def test_getElectricalEnergySystemSOC(self):
+        self.assertEqual(self.device.getElectricalEnergySystemSOC(),91)
+
+    
+    def test_getElectricalEnergySystemSOCUnit(self):
+       self.assertEqual(self.device.getElectricalEnergySystemSOCUnit(),"percent")
+
+    
+    def test_getElectricalEnergySystemPower(self):
+        self.assertEqual(self.device.getElectricalEnergySystemPower(),700)
+
+    
+    def test_getElectricalEnergySystemPowerUnit(self):
+        self.assertEqual(self.device.getElectricalEnergySystemPowerUnit(),"watt")
+    
+    def test_getElectricalEnergySystemOperationState(self):
+       self.assertEqual(self.device.getElectricalEnergySystemOperationState(),"discharge")
+
+    
+


### PR DESCRIPTION
I would like to add Data Point Support for:
- HEMS (Energy Management)
- Vitocharge VX3 (Inverter and Battery Storage)

Data points that would be supported: ess.* photovoltaic.* pcc.*

Sadly, to use these Data Points, you need the Advanced or Electric Subscription.