### PR TITLE
add more programs to getPrograms

### DIFF
--- a/PyViCare/PyViCareHeatingDevice.py
+++ b/PyViCare/PyViCareHeatingDevice.py
@@ -564,8 +564,8 @@ class HeatingCircuit(HeatingDeviceWithComponent):
     def getPrograms(self):
         available_programs = []
         for program in ['comfort', 'comfortCooling', 'comfortCoolingEnergySaving', 'comfortEnergySaving', 
-                        'comfortHeating', 'dhwPrecedence', 'forcedLastFromSchedule', 'frostprotection', 'eco', 
-                        'external', 'fixed', 'holiday', 'holidayAtHome', 'manual', 'normal', 'normalCooling', 
+                        'comfortHeating', 'dhwPrecedence', 'eco', 'external', 'fixed', 'forcedLastFromSchedule', 
+                        'frostprotection', 'holiday', 'holidayAtHome', 'manual', 'normal', 'normalCooling', 
                         'normalCoolingEnergySaving', 'normalEnergySaving', 'normalHeating', 'reduced', 'reducedCooling',
                         'reducedCoolingEnergySaving', 'reducedEnergySaving', 'reducedHeating', 'standby', 'summerEco']:
             with suppress(PyViCareNotSupportedFeatureError):

--- a/PyViCare/PyViCareHeatingDevice.py
+++ b/PyViCare/PyViCareHeatingDevice.py
@@ -563,7 +563,7 @@ class HeatingCircuit(HeatingDeviceWithComponent):
     @handleNotSupported
     def getPrograms(self):
         available_programs = []
-        for program in ['active', 'comfort', 'comfortCooling', 'comfortCoolingEnergySaving', 'comfortEnergySaving', 
+        for program in ['comfort', 'comfortCooling', 'comfortCoolingEnergySaving', 'comfortEnergySaving', 
                         'comfortHeating', 'dhwPrecedence', 'forcedLastFromSchedule', 'frostprotection', 'eco', 
                         'external', 'fixed', 'holiday', 'holidayAtHome', 'manual', 'normal', 'normalCooling', 
                         'normalCoolingEnergySaving', 'normalEnergySaving', 'normalHeating', 'reduced', 'reducedCooling',

--- a/PyViCare/PyViCareHeatingDevice.py
+++ b/PyViCare/PyViCareHeatingDevice.py
@@ -563,8 +563,11 @@ class HeatingCircuit(HeatingDeviceWithComponent):
     @handleNotSupported
     def getPrograms(self):
         available_programs = []
-        for program in ['active', 'comfort', 'forcedLastFromSchedule', 'eco', 'external', 'fixed', 'holiday',
-                        'normal', 'reduced', 'standby']:
+        for program in ['active', 'comfort', 'comfortCooling', 'comfortCoolingEnergySaving', 'comfortEnergySaving', 
+                        'comfortHeating', 'dhwPrecedence', 'forcedLastFromSchedule', 'frostprotection', 'eco', 
+                        'external', 'fixed', 'holiday', 'holidayAtHome', 'manual', 'normal', 'normalCooling', 
+                        'normalCoolingEnergySaving', 'normalEnergySaving', 'normalHeating', 'reduced', 'reducedCooling',
+                        'reducedCoolingEnergySaving', 'reducedEnergySaving', 'reducedHeating', 'standby', 'summerEco']:
             with suppress(PyViCareNotSupportedFeatureError):
                 if self.service.getProperty(
                         f"heating.circuits.{self.circuit}.operating.programs.{program}") is not None:

--- a/tests/test_Vitocal200.py
+++ b/tests/test_Vitocal200.py
@@ -69,8 +69,7 @@ class Vitocal200(unittest.TestCase):
             self.device.getSupplyTemperaturePrimaryCircuit(), 11.6)
 
     def test_getPrograms(self):
-        expected_programs = ['active', 'comfort', 'eco',
-                             'fixed', 'normal', 'reduced', 'standby']
+        expected_programs = ['comfort', 'eco', 'fixed', 'normal', 'reduced', 'standby']
         self.assertListEqual(
             self.device.getCircuit(0).getPrograms(), expected_programs)
 

--- a/tests/test_Vitocal250A.py
+++ b/tests/test_Vitocal250A.py
@@ -36,7 +36,7 @@ class Vitocal250A(unittest.TestCase):
             self.device.getSupplyTemperaturePrimaryCircuit(), 5.9)
 
     def test_getPrograms(self):
-        expected_programs = ['active', 'forcedLastFromSchedule', 'fixed', 'standby']
+        expected_programs = ['comfortCooling', 'comfortCoolingEnergySaving', 'comfortEnergySaving', 'comfortHeating', 'fixed', 'forcedLastFromSchedule', 'frostprotection', 'normalCooling', 'normalCoolingEnergySaving', 'normalEnergySaving', 'normalHeating', 'reducedCooling', 'reducedCoolingEnergySaving', 'reducedEnergySaving', 'reducedHeating', 'standby', 'summerEco']
         self.assertListEqual(
             self.device.circuits[0].getPrograms(), expected_programs)
 

--- a/tests/test_Vitocal300G.py
+++ b/tests/test_Vitocal300G.py
@@ -59,8 +59,7 @@ class Vitocal300G(unittest.TestCase):
             self.device.getSupplyTemperaturePrimaryCircuit(), 18.2)
 
     def test_getPrograms(self):
-        expected_programs = ['active', 'comfort', 'eco',
-                             'fixed', 'holiday', 'normal', 'reduced', 'standby']
+        expected_programs = ['comfort', 'eco', 'fixed', 'holiday', 'normal', 'reduced', 'standby']
         self.assertListEqual(
             self.device.circuits[0].getPrograms(), expected_programs)
 

--- a/tests/test_Vitocaldens222F.py
+++ b/tests/test_Vitocaldens222F.py
@@ -42,8 +42,7 @@ class Vitocaldens222F(unittest.TestCase):
         self.assertEqual(self.device.getCompressor(0).getHours(), 1.4)
 
     def test_getPrograms(self):
-        expected_programs = ['active', 'comfort', 'eco', 'fixed',
-                             'normal', 'reduced', 'standby']
+        expected_programs = ['comfort', 'eco', 'fixed', 'normal', 'reduced', 'standby']
         self.assertListEqual(
             self.device.getCircuit(1).getPrograms(), expected_programs)
 

--- a/tests/test_Vitodens200W.py
+++ b/tests/test_Vitodens200W.py
@@ -32,8 +32,7 @@ class Vitodens200W(unittest.TestCase):
         self.assertEqual(self.device.burners[0].getModulation(), 0)
 
     def test_getPrograms(self):
-        expected_programs = [
-            'active', 'comfort', 'forcedLastFromSchedule', 'normal', 'reduced', 'standby']
+        expected_programs = ['comfort', 'forcedLastFromSchedule', 'normal', 'reduced', 'standby']
         self.assertListEqual(
             self.device.circuits[0].getPrograms(), expected_programs)
 

--- a/tests/test_Vitodens200W_2.py
+++ b/tests/test_Vitodens200W_2.py
@@ -29,8 +29,7 @@ class Vitodens200W_2(unittest.TestCase):
         self.assertEqual(self.device.burners[0].getModulation(), 0)
 
     def test_getPrograms(self):
-        expected_programs = [
-            'active', 'comfort', 'eco', 'external', 'holiday', 'normal', 'reduced', 'standby']
+        expected_programs = ['comfort', 'eco', 'external', 'holiday', 'normal', 'reduced', 'standby']
         self.assertListEqual(
             self.device.circuits[0].getPrograms(), expected_programs)
 

--- a/tests/test_Vitodens222W.py
+++ b/tests/test_Vitodens222W.py
@@ -23,7 +23,7 @@ class Vitodens222W(unittest.TestCase):
         self.assertEqual(self.device.burners[0].getModulation(), 15.8)
 
     def test_getPrograms(self):
-        expected_programs = ['active', 'comfort', 'forcedLastFromSchedule', 'normal', 'reduced', 'standby']
+        expected_programs = ['comfort', 'forcedLastFromSchedule', 'normal', 'reduced', 'standby']
         self.assertListEqual(
             self.device.circuits[0].getPrograms(), expected_programs)
 

--- a/tests/test_Vitodens300W.py
+++ b/tests/test_Vitodens300W.py
@@ -26,8 +26,7 @@ class Vitodens300W(unittest.TestCase):
         self.assertEqual(self.device.burners[0].getModulation(), 0)
 
     def test_getPrograms(self):
-        expected_programs = ['active', 'comfort', 'eco',
-                             'external', 'holiday', 'normal', 'reduced', 'standby']
+        expected_programs = ['comfort', 'eco', 'external', 'holiday', 'normal', 'reduced', 'standby']
         self.assertListEqual(
             self.device.circuits[0].getPrograms(), expected_programs)
 

--- a/tests/test_Vitodens333F.py
+++ b/tests/test_Vitodens333F.py
@@ -24,8 +24,7 @@ class Vitodens333F(unittest.TestCase):
         self.assertEqual(self.device.burners[0].getModulation(), 0)
 
     def test_getPrograms(self):
-        expected_programs = ['active', 'comfort', 'eco',
-                             'external', 'holiday', 'normal', 'reduced', 'standby']
+        expected_programs = ['comfort', 'eco', 'external', 'holiday', 'normal', 'reduced', 'standby']
         self.assertListEqual(
             self.device.circuits[0].getPrograms(), expected_programs)
 


### PR DESCRIPTION
add all available programs from vicare api: heating.circuits.N.operating.programs.XXX
Note: 'active' is not a program but it shows the current active operating program on the device therefore I have it removed.