### PR TITLE
Remove HEMS an EEBus devices and change TCU handling to gateway

### DIFF
--- a/PyViCare/PyViCare.py
+++ b/PyViCare/PyViCare.py
@@ -53,7 +53,7 @@ class PyViCare:
             for gateway in installation.gateways:
                 for device in gateway.devices:
                     if device.deviceType not in ["heating", "zigbee", "vitoconnect", "electricityStorage", "tcu", "ventilation"]:
-                        continue  # we are only interested in heating, photovoltaic, electricityStorage, hems and ventilation devices
+                        continue  # we are only interested in heating, photovoltaic, electricityStorage, and ventilation devices
 
                     accessor = ViCareDeviceAccessor(
                         installation.id, gateway.serial, device.id)

--- a/PyViCare/PyViCare.py
+++ b/PyViCare/PyViCare.py
@@ -55,9 +55,6 @@ class PyViCare:
                     if device.deviceType not in ["heating", "zigbee", "vitoconnect", "electricityStorage", "tcu", "ventilation"]:
                         continue  # we are only interested in heating, photovoltaic, electricityStorage, hems and ventilation devices
 
-                    if device.id == "gateway" and device.deviceType == "vitoconnect":
-                        device.id = "0"  # vitoconnect has no device id, so we use 0
-
                     accessor = ViCareDeviceAccessor(
                         installation.id, gateway.serial, device.id)
                     service = self.__buildService(accessor, device.roles)

--- a/PyViCare/PyViCare.py
+++ b/PyViCare/PyViCare.py
@@ -52,20 +52,11 @@ class PyViCare:
         for installation in self.installations:
             for gateway in installation.gateways:
                 for device in gateway.devices:
-                    if device.deviceType not in ["heating", "zigbee", "vitoconnect", "electricityStorage", "EEBus", "hems", "tcu", "ventilation"]:
+                    if device.deviceType not in ["heating", "zigbee", "vitoconnect", "electricityStorage", "tcu", "ventilation"]:
                         continue  # we are only interested in heating, photovoltaic, electricityStorage, hems and ventilation devices
 
                     if device.id == "gateway" and device.deviceType == "vitoconnect":
                         device.id = "0"  # vitoconnect has no device id, so we use 0
-
-                    if device.id == "gateway" and device.deviceType == "tcu":
-                        device.id = "0"  # tcu has no device id, so we use 0
-
-                    if device.id == "HEMS" and device.deviceType == "hems":
-                        device.id = "0"  # hems has no device id, so we use 0
-
-                    if device.id == "EEBUS" and device.deviceType == "EEBus":
-                        device.id = "0" # EEBus has no device id,
 
                     accessor = ViCareDeviceAccessor(
                         installation.id, gateway.serial, device.id)

--- a/PyViCare/PyViCareDeviceConfig.py
+++ b/PyViCare/PyViCareDeviceConfig.py
@@ -85,7 +85,7 @@ class PyViCareDeviceConfig:
             (self.asRadiatorActuator, r"E3_RadiatorActuator", ["type:radiator"]),
             (self.asRoomSensor, r"E3_RoomSensor", ["type:climateSensor"]),
             (self.asElectricalEnergySystem, r"E3_HEMS", ["type:hems"]),
-            (self.asElectricalEnergySystem, r"E3_TCU10_x07", ["type:tcu"]),
+            (self.asGateway, r"E3_TCU10_x07", ["type:tcu"]),
             (self.asElectricalEnergySystem, r"E3_EEBus", ["type:eebus"]),
             (self.asElectricalEnergySystem, r"E3_VitoCharge_03", ["type:energy_storage"]),
             (self.asVentilation, r"E3_ViAir", ["type:ventilation"]),

--- a/PyViCare/PyViCareDeviceConfig.py
+++ b/PyViCare/PyViCareDeviceConfig.py
@@ -84,10 +84,8 @@ class PyViCareDeviceConfig:
             (self.asPelletsBoiler, r"Vitoligno|Ecotronic|VBC550P", []),
             (self.asRadiatorActuator, r"E3_RadiatorActuator", ["type:radiator"]),
             (self.asRoomSensor, r"E3_RoomSensor", ["type:climateSensor"]),
-            (self.asElectricalEnergySystem, r"E3_HEMS", ["type:hems"]),
-            (self.asGateway, r"E3_TCU10_x07", ["type:tcu"]),
-            (self.asElectricalEnergySystem, r"E3_EEBus", ["type:eebus"]),
-            (self.asElectricalEnergySystem, r"E3_VitoCharge_03", ["type:energy_storage"]),
+            (self.asGateway, r"E3_TCU10_x07", ["type:gateway;TCU300"]),
+            (self.asElectricalEnergySystem, r"E3_VitoCharge_03", ["type:ees"]),
             (self.asVentilation, r"E3_ViAir", ["type:ventilation"]),
             (self.asGateway, r"Heatbox1", ["type:gateway;VitoconnectOpto1"])
         ]

--- a/PyViCare/PyViCareService.py
+++ b/PyViCare/PyViCareService.py
@@ -54,7 +54,9 @@ class ViCareService:
         return hasRoles(requested_roles, self.roles)
 
     def _isGateway(self) -> bool:
-        return self.hasRoles(["type:gateway;VitoconnectOpto1"])
+        return self.hasRoles(["type:gateway;VitoconnectOpto1"]) or self.hasRoles(["type:gateway;TCU300"])
+
+
 
     def setProperty(self, property_name: str, action: str, data: Any) -> Any:
         url = buildSetPropertyUrl(

--- a/PyViCare/PyViCareService.py
+++ b/PyViCare/PyViCareService.py
@@ -56,8 +56,6 @@ class ViCareService:
     def _isGateway(self) -> bool:
         return self.hasRoles(["type:gateway;VitoconnectOpto1"]) or self.hasRoles(["type:gateway;TCU300"])
 
-
-
     def setProperty(self, property_name: str, action: str, data: Any) -> Any:
         url = buildSetPropertyUrl(
             self.accessor, property_name, action)

--- a/tests/response/TCU300_ethernet.json
+++ b/tests/response/TCU300_ethernet.json
@@ -1,0 +1,107 @@
+{
+    "data": [
+        {
+            "feature": "gateway.devices",
+            "gatewayId": "################",
+            "timestamp": "2024-03-17T18:55:46.182Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/252756/gateways/################/features/gateway.devices",
+            "properties": {
+                "devices": {
+                    "type": "DeviceList",
+                    "value": [
+                        {
+                            "id": "gateway",
+                            "fingerprint": "####",
+                            "modelId": "E3_TCU10_x07",
+                            "modelVersion": "####",
+                            "name": "TCU",
+                            "type": "tcu",
+                            "roles": [
+                                "capability:hems",
+                                "capability:zigbeeCoordinator",
+                                "type:E3",
+                                "type:gateway;TCU300"
+                            ],
+                            "status": "online"
+                        },
+                        {
+                            "id": "HEMS",
+                            "fingerprint": "###",
+                            "modelId": "E3_HEMS",
+                            "modelVersion": "###",
+                            "name": "Home Energy Management System",
+                            "type": "hems",
+                            "roles": [
+                                "type:E3",
+                                "type:virtual;hems"
+                            ],
+                            "status": "online"
+                        },
+                        {
+                            "id": "RoomControl-1",
+                            "fingerprint": "###",
+                            "modelId": "E3_RoomControl_One_525",
+                            "modelVersion": "####",
+                            "name": "E3_RoomControl_One_525",
+                            "type": "roomControl",
+                            "roles": [
+                                "capability:monetization;FTDC",
+                                "capability:monetization;OWD",
+                                "capability:zigbeeCoordinator",
+                                "type:E3",
+                                "type:virtual;smartRoomControl"
+                            ],
+                            "status": "online"
+                        },
+                        {
+                            "id": "EEBUS",
+                            "fingerprint": "#####",
+                            "modelId": "E3_EEBus",
+                            "modelVersion": "#####",
+                            "name": "accessories",
+                            "type": "EEBus",
+                            "roles": [
+                                "type:E3",
+                                "type:accessory;eeBus"
+                            ],
+                            "status": "online"
+                        },
+                        {
+                            "id": "0",
+                            "fingerprint": "ecu;#####",
+                            "modelId": "E3_VitoCharge_03",
+                            "modelVersion": "####",
+                            "name": "E3 device",
+                            "type": "electricityStorage",
+                            "roles": [
+                                "capability:hems",
+                                "type:E3",
+                                "type:ess",
+                                "type:photovoltaic;Internal",
+                                "type:product;Vitocharge"
+                            ],
+                            "status": "online"
+                        },
+                        {
+                            "id": "eebus-1",
+                            "fingerprint": "eebus:wallbox;########",
+                            "modelId": "E3_HEMS_VCS",
+                            "modelVersion": "####",
+                            "name": "Home Energy Management System",
+                            "type": "vehicleChargingStation",
+                            "roles": [
+                                "type:E3",
+                                "type:accessory;vehicleChargingStation"
+                            ],
+                            "status": "online"
+                        }
+                    ]
+                }
+            },
+            "commands": {}
+        }
+    ]
+}

--- a/tests/test_E3_TCU300_ethernet.py
+++ b/tests/test_E3_TCU300_ethernet.py
@@ -1,0 +1,19 @@
+import unittest
+
+from PyViCare.PyViCareGateway import Gateway
+from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
+from tests.ViCareServiceMock import ViCareServiceMock
+
+
+class TCU300_ethernet(unittest.TestCase):
+    def setUp(self):
+        self.service = ViCareServiceMock('response/TCU300_ethernet.json')
+        self.device = Gateway(self.service)
+
+    def test_getSerial(self):
+        self.assertEqual(
+            self.device.getSerial(), "################")
+
+    def test_getWifiSignalStrength(self):
+        with self.assertRaises(PyViCareNotSupportedFeatureError):
+            self.device.getWifiSignalStrength()

--- a/tests/test_PyViCareDeviceConfig.py
+++ b/tests/test_PyViCareDeviceConfig.py
@@ -72,8 +72,20 @@ class PyViCareDeviceConfigTest(unittest.TestCase):
         device_type = c.asAutoDetectDevice()
         self.assertEqual("Gateway", type(device_type).__name__)
 
+    def test_autoDetect_TCU300_asGateway(self):
+        c = PyViCareDeviceConfig(self.service, "0", "E3_TCU10_x07", "Online")
+        device_type = c.asAutoDetectDevice()
+        self.assertEqual("Gateway", type(device_type).__name__)
+
     def test_autoDetect_RoleGateway_asGateway(self):
         self.service.hasRoles = has_roles(["type:gateway;VitoconnectOpto1"])
         c = PyViCareDeviceConfig(self.service, "0", "Unknown", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("Gateway", type(device_type).__name__)
+    
+    def test_autoDetect_RoleGateway_asGateway_TCU300(self):
+        self.service.hasRoles = has_roles(["type:gateway;TCU300"])
+        c = PyViCareDeviceConfig(self.service, "0", "Unknown", "Online")
+        device_type = c.asAutoDetectDevice()
+        self.assertEqual("Gateway", type(device_type).__name__)
+    

--- a/tests/test_PyViCareDeviceConfig.py
+++ b/tests/test_PyViCareDeviceConfig.py
@@ -82,7 +82,7 @@ class PyViCareDeviceConfigTest(unittest.TestCase):
         c = PyViCareDeviceConfig(self.service, "0", "Unknown", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("Gateway", type(device_type).__name__)
-    
+
     def test_autoDetect_RoleGateway_asGateway_TCU300(self):
         self.service.hasRoles = has_roles(["type:gateway;TCU300"])
         c = PyViCareDeviceConfig(self.service, "0", "Unknown", "Online")

--- a/tests/test_PyViCareDeviceConfig.py
+++ b/tests/test_PyViCareDeviceConfig.py
@@ -88,4 +88,3 @@ class PyViCareDeviceConfigTest(unittest.TestCase):
         c = PyViCareDeviceConfig(self.service, "0", "Unknown", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("Gateway", type(device_type).__name__)
-    


### PR DESCRIPTION
This PR will remove the handling of HEMS and EEBUS devices because the API does not provide any features or data points.
The Functionality of managing the Vitocharge VX3 is not affected, the HEMS and EEBus devices are separate devices, which I accidentally messed up in my last PR
The handling of the E3_TCU unit will be changed to a gateway, like mentioned by @CFenner in PR #318
Maybe in the future there will be more possibilities to manage, for example Vehicle Charging Stations (VCS).
The devices are already listed, but we cannot access features or data points.

Sadly, I cannot test the TCU data point for Wi-Fi strength because my TCU is connected via Ethernet. There is a documented data point for Ethernet `gateway.ethernet.config`, but this also somehow doesn't show up on my TCU, so I can't implement this currently.
