### PR TITLE
feat: Add getSerial for room sensors

### DIFF
--- a/PyViCare/PyViCareRoomSensor.py
+++ b/PyViCare/PyViCareRoomSensor.py
@@ -3,7 +3,7 @@ from PyViCare.PyViCareUtils import handleNotSupported
 
 
 class RoomSensor(Device):
-    
+
     @handleNotSupported
     def getSerial(self):
         return self.service.getProperty("device.name")["deviceId"]

--- a/PyViCare/PyViCareRoomSensor.py
+++ b/PyViCare/PyViCareRoomSensor.py
@@ -3,6 +3,10 @@ from PyViCare.PyViCareUtils import handleNotSupported
 
 
 class RoomSensor(Device):
+    
+    @handleNotSupported
+    def getSerial(self):
+        return self.service.getProperty("device.name")["deviceId"]
 
     @handleNotSupported
     def getTemperature(self):

--- a/PyViCare/PyViCareRoomSensor.py
+++ b/PyViCare/PyViCareRoomSensor.py
@@ -6,7 +6,7 @@ class RoomSensor(Device):
 
     @handleNotSupported
     def getSerial(self):
-        return self.service.getProperty("device.name")["deviceId"]
+        return self.service.getProperty("device.sensors.temperature")["deviceId"]
 
     @handleNotSupported
     def getTemperature(self):


### PR DESCRIPTION
This exposes the `deviceID` of room temp sensors and TRVs to be used in HA to identify the device.

https://github.com/somm15/PyViCare/blob/f8d1b446d3b74fb73d55552461c6e26b450923af/tests/response/zigbee_zk03839.json#L28