### PR TITLE
chore(ci): remove python v3.6 (eol)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6", "3.8", "3.9"]
+        python-version: ["3.8", "3.9"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
See https://devguide.python.org/versions/