### PR TITLE
fix: make types-requests only a dev dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -756,4 +756,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "3dd73244b8cbe1330e2eb20eff6eb225d65ddcd4957ac888ae9dc17d00a2a70d"
+content-hash = "c1bef2f9a9c09fca35cb788edf30627e189a6c2fc545ea30487654f479740a88"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ Changelog = "https://github.com/openviess/PyViCare/releases"
 authlib = ">1.2.0"
 python = "^3.8"
 requests = ">=2.31.0"
-types-requests = ">=2.31"
 
 [tool.poetry.group.dev.dependencies]
 codespell = "^2.3.0"
@@ -49,6 +48,7 @@ pylint = "^3.2.6"
 pytest = "^8.3.2"
 pytest-cov = "^5.0.0"
 ruff = "^0.6.7"
+types-requests = ">=2.31"
 
 [tool.mypy]
 # Specify the target platform details in config, so your developers are


### PR DESCRIPTION
`types-requests` isn't needed at runtime. Make it a dev dependency instead.