### PR TITLE
feat: Expose ventilation levels

### DIFF
--- a/PyViCare/PyViCareVentilationDevice.py
+++ b/PyViCare/PyViCareVentilationDevice.py
@@ -73,6 +73,10 @@ class VentilationDevice(Device):
             json representation of the answer
         """
         return self.service.setProperty(f"ventilation.operating.programs.{program}", "deactivate", {})
+    
+    @handleNotSupported
+    def getPermanentLevels(self) -> list[str]:
+        return list[str](self.service.getProperty("ventilation.operating.modes.permanent")["commands"]["setLevel"]["params"]["level"]["constraints"]["enum"])
 
     @handleAPICommandErrors
     def setPermanentLevel(self, level: str):

--- a/PyViCare/PyViCareVentilationDevice.py
+++ b/PyViCare/PyViCareVentilationDevice.py
@@ -73,7 +73,7 @@ class VentilationDevice(Device):
             json representation of the answer
         """
         return self.service.setProperty(f"ventilation.operating.programs.{program}", "deactivate", {})
-    
+
     @handleNotSupported
     def getPermanentLevels(self) -> list[str]:
         return list[str](self.service.getProperty("ventilation.operating.modes.permanent")["commands"]["setLevel"]["params"]["level"]["constraints"]["enum"])

--- a/tests/test_VitoairFs300E.py
+++ b/tests/test_VitoairFs300E.py
@@ -32,6 +32,10 @@ class VitoairFs300(unittest.TestCase):
         expected_programs = ['standby']
         self.assertListEqual(self.device.getAvailablePrograms(), expected_programs)
 
+    def test_getPermanentLevels(self):
+        expected_levels = ['levelOne', 'levelTwo', 'levelThree', 'levelFour']
+        self.assertListEqual(expected_levels, self.device.getPermanentLevels())
+
     def test_getSchedule(self):
         keys = ['active', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']
         self.assertListEqual(list(self.device.getSchedule().keys()), keys)

--- a/tests/test_Vitopure350.py
+++ b/tests/test_Vitopure350.py
@@ -24,6 +24,10 @@ class Vitopure350(unittest.TestCase):
         expected_programs = ['standby']
         self.assertListEqual(expected_programs, self.device.getAvailablePrograms())
 
+    def test_getPermanentLevels(self):
+        expected_levels = ['levelOne', 'levelTwo', 'levelThree', 'levelFour']
+        self.assertListEqual(expected_levels, self.device.getPermanentLevels())
+
     def test_getSchedule(self):
         keys = ['active', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']
         self.assertListEqual(keys, list(self.device.getSchedule().keys()))


### PR DESCRIPTION
Expose `ventilation.operating.modes.permanent` datapoint command restriction `level`