### PR TITLE
feat: Expose ventilation state

### DIFF
--- a/PyViCare/PyViCareVentilationDevice.py
+++ b/PyViCare/PyViCareVentilationDevice.py
@@ -91,3 +91,15 @@ class VentilationDevice(Device):
             "sat": properties["entries"]["value"]["sat"],
             "sun": properties["entries"]["value"]["sun"]
         }
+
+    @handleNotSupported
+    def getVentilationDemand(self) -> str:
+        return str(self.service.getProperty("ventilation.operating.state")["properties"]["demand"]["value"])
+
+    @handleNotSupported
+    def getVentilationLevel(self) -> str:
+        return str(self.service.getProperty("ventilation.operating.state")["properties"]["level"]["value"])
+
+    @handleNotSupported
+    def getVentilationReason(self) -> str:
+        return str(self.service.getProperty("ventilation.operating.state")["properties"]["reason"]["value"])

--- a/tests/test_VitoairFs300E.py
+++ b/tests/test_VitoairFs300E.py
@@ -41,5 +41,5 @@ class VitoairFs300(unittest.TestCase):
 
     def test_ventilationState(self):
         self.assertEqual(self.device.getVentilationDemand(), "unknown")
-        self.assertEqual(self.device.getVentilationLevel(), "unknown")
+        self.assertEqual(self.device.getVentilationLevel(), "levelFour")
         self.assertEqual(self.device.getVentilationReason(), "unknown")

--- a/tests/test_VitoairFs300E.py
+++ b/tests/test_VitoairFs300E.py
@@ -42,4 +42,4 @@ class VitoairFs300(unittest.TestCase):
     def test_ventilationState(self):
         self.assertEqual(self.device.getVentilationDemand(), "unknown")
         self.assertEqual(self.device.getVentilationLevel(), "levelFour")
-        self.assertEqual(self.device.getVentilationReason(), "unknown")
+        self.assertEqual(self.device.getVentilationReason(), "sensorOverride")

--- a/tests/test_VitoairFs300E.py
+++ b/tests/test_VitoairFs300E.py
@@ -38,3 +38,8 @@ class VitoairFs300(unittest.TestCase):
 
     def test_getSerial(self):
         self.assertEqual(self.device.getSerial(), "################")
+
+    def test_ventilationState(self):
+        self.assertEqual(self.device.getVentilationDemand(), "ventilation")
+        self.assertEqual(self.device.getVentilationLevel(), "unknown")
+        self.assertEqual(self.device.getVentilationReason(), "unknown")

--- a/tests/test_VitoairFs300E.py
+++ b/tests/test_VitoairFs300E.py
@@ -40,6 +40,6 @@ class VitoairFs300(unittest.TestCase):
         self.assertEqual(self.device.getSerial(), "################")
 
     def test_ventilationState(self):
-        self.assertEqual(self.device.getVentilationDemand(), "ventilation")
+        self.assertEqual(self.device.getVentilationDemand(), "unknown")
         self.assertEqual(self.device.getVentilationLevel(), "unknown")
         self.assertEqual(self.device.getVentilationReason(), "unknown")

--- a/tests/test_Vitopure350.py
+++ b/tests/test_Vitopure350.py
@@ -35,4 +35,4 @@ class Vitopure350(unittest.TestCase):
     def test_ventilationState(self):
         self.assertEqual(self.device.getVentilationDemand(), "unknown")
         self.assertEqual(self.device.getVentilationLevel(), "unknown")
-        self.assertEqual(self.device.getVentilationReason(), "unknown")
+        self.assertEqual(self.device.getVentilationReason(), "sensorDriven")

--- a/tests/test_Vitopure350.py
+++ b/tests/test_Vitopure350.py
@@ -31,3 +31,8 @@ class Vitopure350(unittest.TestCase):
     def test_getSerial(self):
         with self.assertRaises(PyViCareNotSupportedFeatureError):
             self.device.getSerial()
+
+    def test_ventilationState(self):
+        self.assertEqual(self.device.getVentilationDemand(), "ventilation")
+        self.assertEqual(self.device.getVentilationLevel(), "unknown")
+        self.assertEqual(self.device.getVentilationReason(), "unknown")

--- a/tests/test_Vitopure350.py
+++ b/tests/test_Vitopure350.py
@@ -33,6 +33,6 @@ class Vitopure350(unittest.TestCase):
             self.device.getSerial()
 
     def test_ventilationState(self):
-        self.assertEqual(self.device.getVentilationDemand(), "ventilation")
+        self.assertEqual(self.device.getVentilationDemand(), "unknown")
         self.assertEqual(self.device.getVentilationLevel(), "unknown")
         self.assertEqual(self.device.getVentilationReason(), "unknown")


### PR DESCRIPTION
Expose `ventilation.operating.state` datapoint