### PR TITLE
fix(trv): use device.name to determine device serial

### DIFF
--- a/PyViCare/PyViCareRadiatorActuator.py
+++ b/PyViCare/PyViCareRadiatorActuator.py
@@ -5,6 +5,10 @@ from PyViCare.PyViCareUtils import handleAPICommandErrors, handleNotSupported
 class RadiatorActuator(Device):
 
     @handleNotSupported
+    def getSerial(self):
+        return self.service.getProperty("device.name")["deviceId"]
+
+    @handleNotSupported
     def getTemperature(self):
         return self.service.getProperty("device.sensors.temperature")["properties"]["value"]["value"]
 

--- a/tests/test_zigbee_zk03839.py
+++ b/tests/test_zigbee_zk03839.py
@@ -9,6 +9,9 @@ class ZK03839(unittest.TestCase):
         self.service = ViCareServiceMock('response/zigbee_zk03839.json')
         self.device = RoomSensor(self.service)
 
+    def test_getSerial(self):
+        self.assertEqual(self.device.getSerial(), "zigbee-2c1165fffe977770")
+
     def test_isDomesticHotWaterDevice(self):
         self.assertEqual(self.device.isDomesticHotWaterDevice(), False)
 

--- a/tests/test_zigbee_zk03840.py
+++ b/tests/test_zigbee_zk03840.py
@@ -9,6 +9,9 @@ class ZK03840(unittest.TestCase):
         self.service = ViCareServiceMock('response/zigbee_zk03840_trv.json')
         self.device = RadiatorActuator(self.service)
 
+    def test_getSerial(self):
+        self.assertEqual(self.device.getSerial(), "zigbee-048727fffe196e03")
+
     def test_isDomesticHotWaterDevice(self):
         self.assertEqual(self.device.isDomesticHotWaterDevice(), False)
 


### PR DESCRIPTION
as no `device.serial` data point is exposed.