### PR TITLE
added version for updated 050W

### DIFF
--- a/tests/response/Vitodens050W_2.json
+++ b/tests/response/Vitodens050W_2.json
@@ -1,0 +1,1112 @@
+{
+    "data": [
+        {
+            "apiVersion": 1,
+            "commands": {
+                "setMode": {
+                    "isExecutable": true,
+                    "name": "setMode",
+                    "params": {
+                        "mode": {
+                            "constraints": {
+                                "enum": [
+                                    "comfort",
+                                    "eco",
+                                    "off"
+                                ]
+                            },
+                            "required": true,
+                            "type": "string"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active/commands/setMode"
+                }
+            },
+            "deviceId": "0",
+            "feature": "heating.dhw.operating.modes.active",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "comfort"
+                }
+            },
+            "timestamp": "2025-01-17T14:42:40.580Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.dhw.operating.modes.balanced",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2025-01-17T14:42:40.580Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.balanced"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.dhw.operating.modes.comfort",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "timestamp": "2025-01-17T14:42:40.580Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.comfort"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.dhw.operating.modes.eco",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "timestamp": "2025-01-17T14:42:40.580Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.eco"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.dhw.operating.modes.off",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "timestamp": "2025-01-17T14:42:40.580Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.off"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "setLevels": {
+                    "isExecutable": false,
+                    "name": "setLevels",
+                    "params": {
+                        "maxTemperature": {
+                            "constraints": {
+                                "max": 70,
+                                "min": 10,
+                                "stepping": 1
+                            },
+                            "required": true,
+                            "type": "number"
+                        },
+                        "minTemperature": {
+                            "constraints": {
+                                "max": 30,
+                                "min": 1,
+                                "stepping": 1
+                            },
+                            "required": true,
+                            "type": "number"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setLevels"
+                },
+                "setMax": {
+                    "isExecutable": false,
+                    "name": "setMax",
+                    "params": {
+                        "temperature": {
+                            "constraints": {
+                                "max": 70,
+                                "min": 10,
+                                "stepping": 1
+                            },
+                            "required": true,
+                            "type": "number"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setMax"
+                },
+                "setMin": {
+                    "isExecutable": false,
+                    "name": "setMin",
+                    "params": {
+                        "temperature": {
+                            "constraints": {
+                                "max": 30,
+                                "min": 1,
+                                "stepping": 1
+                            },
+                            "required": true,
+                            "type": "number"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setMin"
+                }
+            },
+            "deviceId": "0",
+            "feature": "heating.circuits.0.temperature.levels",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "max": {
+                    "type": "number",
+                    "unit": "celsius",
+                    "value": 82
+                },
+                "min": {
+                    "type": "number",
+                    "unit": "celsius",
+                    "value": 20
+                }
+            },
+            "timestamp": "2025-01-17T14:42:40.580Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "enabled": {
+                    "type": "array",
+                    "value": [
+                        "0"
+                    ]
+                }
+            },
+            "timestamp": "2025-01-17T14:42:40.580Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "device.messages.errors.raw",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "entries": {
+                    "type": "array",
+                    "value": []
+                }
+            },
+            "timestamp": "2025-01-17T14:42:40.580Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.messages.errors.raw"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "device.serial",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "################"
+                }
+            },
+            "timestamp": "2025-01-17T14:42:40.580Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.serial"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.boiler.sensors.temperature.commonSupply",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                },
+                "value": {
+                    "type": "number",
+                    "unit": "celsius",
+                    "value": 63.4
+                }
+            },
+            "timestamp": "2025-01-18T09:56:18.569Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.boiler.serial",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "################"
+                }
+            },
+            "timestamp": "2025-01-17T14:42:40.580Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.boiler.temperature",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "unit": "celsius",
+                    "value": 20
+                }
+            },
+            "timestamp": "2025-01-17T14:42:40.580Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.temperature"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.burners",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "enabled": {
+                    "type": "array",
+                    "value": [
+                        "0"
+                    ]
+                }
+            },
+            "timestamp": "2025-01-17T14:42:40.580Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.burners.0.modulation",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "unit": "percent",
+                    "value": 0
+                }
+            },
+            "timestamp": "2025-01-18T09:32:31.435Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0.modulation"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.burners.0.statistics",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "hours": {
+                    "type": "number",
+                    "unit": "hour",
+                    "value": 6
+                },
+                "starts": {
+                    "type": "number",
+                    "unit": "",
+                    "value": 133
+                }
+            },
+            "timestamp": "2025-01-18T09:32:11.976Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0.statistics"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.burners.0",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "timestamp": "2025-01-18T09:32:48.963Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.0.frostprotection",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "off"
+                }
+            },
+            "timestamp": "2025-01-17T14:42:40.580Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "setMode": {
+                    "isExecutable": true,
+                    "name": "setMode",
+                    "params": {
+                        "mode": {
+                            "constraints": {
+                                "enum": [
+                                    "heating",
+                                    "standby"
+                                ]
+                            },
+                            "required": true,
+                            "type": "string"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
+                }
+            },
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.modes.active",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "standby"
+                }
+            },
+            "timestamp": "2025-01-18T09:10:33.195Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.modes.heating",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "timestamp": "2025-01-18T09:10:33.195Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.modes.standby",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "timestamp": "2025-01-18T09:10:33.195Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.0.sensors.temperature.supply",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                },
+                "value": {
+                    "type": "number",
+                    "unit": "celsius",
+                    "value": 63.4
+                }
+            },
+            "timestamp": "2025-01-18T09:56:15.153Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.0.temperature",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "unit": "celsius",
+                    "value": 0
+                }
+            },
+            "timestamp": "2025-01-18T09:10:34.183Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "setName": {
+                    "isExecutable": true,
+                    "name": "setName",
+                    "params": {
+                        "name": {
+                            "constraints": {
+                                "maxLength": 20,
+                                "minLength": 1
+                            },
+                            "required": true,
+                            "type": "string"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0/commands/setName"
+                }
+            },
+            "deviceId": "0",
+            "feature": "heating.circuits.0",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                },
+                "name": {
+                    "type": "string",
+                    "value": ""
+                },
+                "type": {
+                    "type": "string",
+                    "value": "heatingCircuit"
+                }
+            },
+            "timestamp": "2025-01-17T14:42:40.580Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.dhw",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                },
+                "status": {
+                    "type": "string",
+                    "value": "on"
+                }
+            },
+            "timestamp": "2025-01-17T14:42:40.580Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "activate": {
+                    "isDeprecated": true,
+                    "isExecutable": true,
+                    "name": "activate",
+                    "params": {},
+                    "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.comfort/commands/activate"
+                },
+                "deactivate": {
+                    "isDeprecated": true,
+                    "isExecutable": true,
+                    "name": "deactivate",
+                    "params": {},
+                    "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.comfort/commands/deactivate"
+                }
+            },
+            "deprecated": {
+                "info": "replaced by heating.dhw.operating.modes.active / heating.dhw.operating.modes.eco / heating.dhw.operating.modes.comfort",
+                "removalDate": "2024-09-15"
+            },
+            "deviceId": "0",
+            "feature": "heating.dhw.comfort",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "timestamp": "2025-01-17T14:42:40.580Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.comfort"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.dhw.pumps.primary",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2025-01-17T14:42:40.580Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.primary"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.dhw.pumps.secondary",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2025-01-17T14:42:40.580Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.secondary"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.dhw.sensors.temperature.dhwCylinder",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                },
+                "value": {
+                    "type": "number",
+                    "unit": "celsius",
+                    "value": 55.9
+                }
+            },
+            "timestamp": "2025-01-18T09:55:09.319Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deprecated": {
+                "info": "replaced by heating.dhw.sensors.temperature.dhwCylinder",
+                "removalDate": "2024-09-15"
+            },
+            "deviceId": "0",
+            "feature": "heating.dhw.sensors.temperature.hotWaterStorage",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                },
+                "value": {
+                    "type": "number",
+                    "unit": "celsius",
+                    "value": 55.9
+                }
+            },
+            "timestamp": "2025-01-18T09:55:09.319Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.dhw.sensors.temperature.outlet",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                },
+                "value": {
+                    "type": "number",
+                    "unit": "celsius",
+                    "value": 55
+                }
+            },
+            "timestamp": "2025-01-18T09:57:22.114Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.outlet"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.solar",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2025-01-17T14:42:40.580Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.programs.active",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "standby"
+                }
+            },
+            "timestamp": "2025-01-18T09:10:49.159Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.programs.comfortEnergySaving",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                },
+                "demand": {
+                    "type": "string",
+                    "value": "heating"
+                },
+                "reason": {
+                    "type": "string",
+                    "value": "noDemand"
+                }
+            },
+            "timestamp": "2025-01-18T09:10:49.159Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortEnergySaving"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deprecated": {
+                "info": "replaced by heating.circuits.N.operating.programs.reducedEnergySaving",
+                "removalDate": "2024-09-15"
+            },
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.programs.noDemand",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "timestamp": "2025-01-18T09:10:49.159Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.noDemand"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "setTemperature": {
+                    "isExecutable": false,
+                    "name": "setTemperature",
+                    "params": {
+                        "targetTemperature": {
+                            "constraints": {
+                                "max": 82,
+                                "min": 20,
+                                "stepping": 1
+                            },
+                            "required": true,
+                            "type": "number"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature"
+                }
+            },
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.programs.normal",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                },
+                "demand": {
+                    "type": "string",
+                    "value": "unknown"
+                },
+                "temperature": {
+                    "type": "number",
+                    "unit": "celsius",
+                    "value": 20
+                }
+            },
+            "timestamp": "2025-01-18T09:10:49.159Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.programs.normalEnergySaving",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                },
+                "demand": {
+                    "type": "string",
+                    "value": "heating"
+                },
+                "reason": {
+                    "type": "string",
+                    "value": "noDemand"
+                }
+            },
+            "timestamp": "2025-01-18T09:10:49.159Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalEnergySaving"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.circuits.0.operating.programs.reducedEnergySaving",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                },
+                "demand": {
+                    "type": "string",
+                    "value": "heating"
+                },
+                "reason": {
+                    "type": "string",
+                    "value": "noDemand"
+                }
+            },
+            "timestamp": "2025-01-18T09:10:49.159Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedEnergySaving"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.dhw.pumps.circulation",
+            "gatewayId": "################",
+            "isEnabled": false,
+            "isReady": true,
+            "properties": {},
+            "timestamp": "2025-01-17T14:42:40.580Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "setTargetTemperature": {
+                    "isExecutable": true,
+                    "name": "setTargetTemperature",
+                    "params": {
+                        "temperature": {
+                            "constraints": {
+                                "efficientLowerBorder": 30,
+                                "efficientUpperBorder": 60,
+                                "max": 60,
+                                "min": 30,
+                                "stepping": 1
+                            },
+                            "required": true,
+                            "type": "number"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
+                }
+            },
+            "deviceId": "0",
+            "feature": "heating.dhw.temperature.main",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "unit": "celsius",
+                    "value": 55
+                }
+            },
+            "timestamp": "2025-01-17T14:42:40.580Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.gas.consumption.summary.dhw",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "currentDay": {
+                    "type": "number",
+                    "unit": "cubicMeter",
+                    "value": 0.4
+                },
+                "currentMonth": {
+                    "type": "number",
+                    "unit": "cubicMeter",
+                    "value": 3.7
+                },
+                "currentYear": {
+                    "type": "number",
+                    "unit": "cubicMeter",
+                    "value": 3.7
+                },
+                "lastMonth": {
+                    "type": "number",
+                    "unit": "cubicMeter",
+                    "value": 0
+                },
+                "lastSevenDays": {
+                    "type": "number",
+                    "unit": "cubicMeter",
+                    "value": 3.7
+                },
+                "lastYear": {
+                    "type": "number",
+                    "unit": "cubicMeter",
+                    "value": 0
+                }
+            },
+            "timestamp": "2025-01-18T08:57:31.203Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.summary.dhw"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.gas.consumption.summary.heating",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "currentDay": {
+                    "type": "number",
+                    "unit": "cubicMeter",
+                    "value": 0.9
+                },
+                "currentMonth": {
+                    "type": "number",
+                    "unit": "cubicMeter",
+                    "value": 5.3
+                },
+                "currentYear": {
+                    "type": "number",
+                    "unit": "cubicMeter",
+                    "value": 5.3
+                },
+                "lastMonth": {
+                    "type": "number",
+                    "unit": "cubicMeter",
+                    "value": 0
+                },
+                "lastSevenDays": {
+                    "type": "number",
+                    "unit": "cubicMeter",
+                    "value": 5.3
+                },
+                "lastYear": {
+                    "type": "number",
+                    "unit": "cubicMeter",
+                    "value": 0
+                }
+            },
+            "timestamp": "2025-01-18T08:13:28.058Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.summary.heating"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.power.consumption.summary.dhw",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "currentDay": {
+                    "type": "number",
+                    "unit": "kilowattHour",
+                    "value": 0.1
+                },
+                "currentMonth": {
+                    "type": "number",
+                    "unit": "kilowattHour",
+                    "value": 0.4
+                },
+                "currentYear": {
+                    "type": "number",
+                    "unit": "kilowattHour",
+                    "value": 0.4
+                },
+                "lastMonth": {
+                    "type": "number",
+                    "unit": "kilowattHour",
+                    "value": 0
+                },
+                "lastSevenDays": {
+                    "type": "number",
+                    "unit": "kilowattHour",
+                    "value": 0.4
+                },
+                "lastYear": {
+                    "type": "number",
+                    "unit": "kilowattHour",
+                    "value": 0
+                }
+            },
+            "timestamp": "2025-01-17T22:47:56.081Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.dhw"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {},
+            "deviceId": "0",
+            "feature": "heating.power.consumption.summary.heating",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "currentDay": {
+                    "type": "number",
+                    "unit": "kilowattHour",
+                    "value": 0.2
+                },
+                "currentMonth": {
+                    "type": "number",
+                    "unit": "kilowattHour",
+                    "value": 0.7
+                },
+                "currentYear": {
+                    "type": "number",
+                    "unit": "kilowattHour",
+                    "value": 0.7
+                },
+                "lastMonth": {
+                    "type": "number",
+                    "unit": "kilowattHour",
+                    "value": 0
+                },
+                "lastSevenDays": {
+                    "type": "number",
+                    "unit": "kilowattHour",
+                    "value": 0.7
+                },
+                "lastYear": {
+                    "type": "number",
+                    "unit": "kilowattHour",
+                    "value": 0
+                }
+            },
+            "timestamp": "2025-01-18T08:33:07.017Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.heating"
+        },
+        {
+            "apiVersion": 1,
+            "commands": {
+                "setName": {
+                    "isExecutable": true,
+                    "name": "setName",
+                    "params": {
+                        "name": {
+                            "constraints": {
+                                "maxLength": 20,
+                                "minLength": 1
+                            },
+                            "required": true,
+                            "type": "string"
+                        }
+                    },
+                    "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name/commands/setName"
+                }
+            },
+            "components": [],
+            "deviceId": "0",
+            "feature": "heating.circuits.0.name",
+            "gatewayId": "################",
+            "isEnabled": true,
+            "isReady": true,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "value": ""
+                }
+            },
+            "timestamp": "2025-01-17T14:42:40.580Z",
+            "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name"
+        }
+    ]
+}


### PR DESCRIPTION
I noticed when using the [Home Assistant integration](https://www.home-assistant.io/integrations/vicare/) that relies on this library that some features were not showing up as entities. I think this is due to some deprecated APIs which are present in the current 050W configuration.

For me, I want to use the `"feature": "heating.dhw.operating.modes.active"` to set between comfort/eco/off

Please let me know if you would prefer me to update the Vitodens050W.json instead of creating a _2, however I didn't want to introduce any breaking changes. 

I haven't yet had the time to study the library in full. Are there any other changes I should implement to update the library to add this feature? 