### PR TITLE
Added a reboot_gateway method to ViCareService object.

### DIFF
--- a/PyViCare/PyViCare.py
+++ b/PyViCare/PyViCare.py
@@ -39,7 +39,7 @@ class PyViCare:
 
     def __loadInstallations(self):
         installations = self.oauth_manager.get(
-            "/equipment/installations?includeGateways=true")
+            "/v1/equipment/installations?includeGateways=true")
         if "data" not in installations:
             logger.error("Missing 'data' property when fetching installations")
             raise PyViCareInvalidDataError(installations)

--- a/PyViCare/PyViCareAbstractOAuthManager.py
+++ b/PyViCare/PyViCareAbstractOAuthManager.py
@@ -13,7 +13,7 @@ from PyViCare.PyViCareUtils import (PyViCareCommandError,
 logger = logging.getLogger('ViCare')
 logger.addHandler(logging.NullHandler())
 
-API_BASE_URL = 'https://api.viessmann.com/iot/v1'
+API_BASE_URL = 'https://api.viessmann.com/iot'
 
 
 class AbstractViCareOAuthManager:

--- a/PyViCare/PyViCareService.py
+++ b/PyViCare/PyViCareService.py
@@ -21,7 +21,7 @@ def hasRoles(requested_roles: List[str], existing_roles: List[str]) -> bool:
     return len(requested_roles) > 0 and set(requested_roles).issubset(set(existing_roles))
 
 def buildSetPropertyUrl(accessor, property_name, action):
-    return f'/features/installations/{accessor.id}/gateways/{accessor.serial}/devices/{accessor.device_id}/features/{property_name}/commands/{action}'
+    return f'/v1/features/installations/{accessor.id}/gateways/{accessor.serial}/devices/{accessor.device_id}/features/{property_name}/commands/{action}'
 
 class ViCareDeviceAccessor:
     def __init__(self, _id: int, serial: str, device_id: str) -> None:
@@ -41,8 +41,8 @@ class ViCareService:
 
     def buildGetPropertyUrl(self, property_name):
         if self._isGateway():
-            return f'/features/installations/{self.accessor.id}/gateways/{self.accessor.serial}/features/{property_name}'
-        return f'/features/installations/{self.accessor.id}/gateways/{self.accessor.serial}/devices/{self.accessor.device_id}/features/{property_name}'
+            return f'/v1/features/installations/{self.accessor.id}/gateways/{self.accessor.serial}/features/{property_name}'
+        return f'/v1/features/installations/{self.accessor.id}/gateways/{self.accessor.serial}/devices/{self.accessor.device_id}/features/{property_name}'
 
     def hasRoles(self, requested_roles) -> bool:
         return hasRoles(requested_roles, self.roles)
@@ -58,7 +58,12 @@ class ViCareService:
         return self.oauth_manager.post(url, post_data)
 
     def fetch_all_features(self) -> Any:
-        url = f'/features/installations/{self.accessor.id}/gateways/{self.accessor.serial}/devices/{self.accessor.device_id}/features/'
+        url = f'/v1/features/installations/{self.accessor.id}/gateways/{self.accessor.serial}/devices/{self.accessor.device_id}/features/'
         if self._isGateway():
-            url = f'/features/installations/{self.accessor.id}/gateways/{self.accessor.serial}/features/'
+            url = f'/v1/features/installations/{self.accessor.id}/gateways/{self.accessor.serial}/features/'
         return self.oauth_manager.get(url)
+
+    def reboot_gateway(self) -> Any:
+        url = f'/v2/equipment/installations/{self.accessor.id}/gateways/{self.accessor.serial}/reboot'
+        data = "{}"
+        return self.oauth_manager.post(url, data)

--- a/tests/test_PyViCareCachedService.py
+++ b/tests/test_PyViCareCachedService.py
@@ -21,7 +21,7 @@ class PyViCareCachedServiceTest(unittest.TestCase):
     def test_getProperty_existing(self):
         self.service.getProperty("someprop")
         self.oauth_mock.get.assert_called_once_with(
-            '/features/installations/[id]/gateways/[serial]/devices/[device]/features/')
+            '/v1/features/installations/[id]/gateways/[serial]/devices/[device]/features/')
 
     def test_getProperty_nonexisting_raises_exception(self):
 
@@ -32,7 +32,7 @@ class PyViCareCachedServiceTest(unittest.TestCase):
     def test_setProperty_works(self):
         self.service.setProperty("someotherprop", "doaction", {'name': 'abc'})
         self.oauth_mock.post.assert_called_once_with(
-            '/features/installations/[id]/gateways/[serial]/devices/[device]/features/someotherprop/commands/doaction', '{"name": "abc"}')
+            '/v1/features/installations/[id]/gateways/[serial]/devices/[device]/features/someotherprop/commands/doaction', '{"name": "abc"}')
 
     def test_getProperty_existing_cached(self):
         # time+0 seconds
@@ -46,7 +46,7 @@ class PyViCareCachedServiceTest(unittest.TestCase):
 
         self.assertEqual(self.oauth_mock.get.call_count, 1)
         self.oauth_mock.get.assert_called_once_with(
-            '/features/installations/[id]/gateways/[serial]/devices/[device]/features/')
+            '/v1/features/installations/[id]/gateways/[serial]/devices/[device]/features/')
 
         # time+70 seconds (must be more than CACHE_DURATION)
         with now_is('2000-01-01 00:01:10'):

--- a/tests/test_PyViCareService.py
+++ b/tests/test_PyViCareService.py
@@ -14,26 +14,26 @@ class PyViCareServiceTest(unittest.TestCase):
     def test_getProperty(self):
         self.service.getProperty("someprop")
         self.oauth_mock.get.assert_called_once_with(
-            '/features/installations/[id]/gateways/[serial]/devices/[device]/features/someprop')
+            '/v1/features/installations/[id]/gateways/[serial]/devices/[device]/features/someprop')
 
     def test_setProperty_object(self):
         self.service.setProperty("someprop", "doaction", {'name': 'abc'})
         self.oauth_mock.post.assert_called_once_with(
-            '/features/installations/[id]/gateways/[serial]/devices/[device]/features/someprop/commands/doaction', '{"name": "abc"}')
+            '/v1/features/installations/[id]/gateways/[serial]/devices/[device]/features/someprop/commands/doaction', '{"name": "abc"}')
 
     def test_setProperty_string(self):
         self.service.setProperty("someprop", "doaction", '{}')
         self.oauth_mock.post.assert_called_once_with(
-            '/features/installations/[id]/gateways/[serial]/devices/[device]/features/someprop/commands/doaction', '{}')
+            '/v1/features/installations/[id]/gateways/[serial]/devices/[device]/features/someprop/commands/doaction', '{}')
 
     def test_getProperty_gateway(self):
         self.service = ViCareService(self.oauth_mock, self.accessor, ["type:gateway;VitoconnectOpto1"])
         self.service.getProperty("someprop")
         self.oauth_mock.get.assert_called_once_with(
-            '/features/installations/[id]/gateways/[serial]/features/someprop')
+            '/v1/features/installations/[id]/gateways/[serial]/features/someprop')
 
     def test_fetch_all_features_gateway(self):
         self.service = ViCareService(self.oauth_mock, self.accessor, ["type:gateway;VitoconnectOpto1"])
         self.service.fetch_all_features()
         self.oauth_mock.get.assert_called_once_with(
-            '/features/installations/[id]/gateways/[serial]/features/')
+            '/v1/features/installations/[id]/gateways/[serial]/features/')


### PR DESCRIPTION
Rebooting the gateway will restore the energy consumption data points, and can so work around issue [#130273](https://github.com/home-assistant/core/issues/130273).

Note: Since the reboot API is using Viessmann API v2, the Viessmann API version is no longer hard coded to "/v1". You must now prefix all urls with the required API version.