### PR TITLE
feat: switch Viessmann API to v2

### DIFF
--- a/PyViCare/PyViCareAbstractOAuthManager.py
+++ b/PyViCare/PyViCareAbstractOAuthManager.py
@@ -13,7 +13,7 @@ from PyViCare.PyViCareUtils import (PyViCareCommandError,
 logger = logging.getLogger('ViCare')
 logger.addHandler(logging.NullHandler())
 
-API_BASE_URL = 'https://api.viessmann.com/iot/v1'
+API_BASE_URL = 'https://api.viessmann.com/iot/v2'
 
 
 class AbstractViCareOAuthManager:


### PR DESCRIPTION
Switch to v2 of IoT Features API, as v1 will be deprecated End of month. Change is described in the API Documentation: https://documentation.viessmann.com/static/changelog