### PR TITLE
feat: create reboot gateway function

### DIFF
--- a/PyViCare/PyViCareService.py
+++ b/PyViCare/PyViCareService.py
@@ -62,7 +62,6 @@ class ViCareService:
         if self._isGateway():
             url = f'/features/installations/{self.accessor.id}/gateways/{self.accessor.serial}/features/'
         return self.oauth_manager.get(url)
-        
     def reboot_gateway(self) -> Any:
         url = f'/equipment/installations/{self.accessor.id}/gateways/{self.accessor.serial}/reboot'
         data = "{}"

--- a/PyViCare/PyViCareService.py
+++ b/PyViCare/PyViCareService.py
@@ -62,6 +62,7 @@ class ViCareService:
         if self._isGateway():
             url = f'/features/installations/{self.accessor.id}/gateways/{self.accessor.serial}/features/'
         return self.oauth_manager.get(url)
+
     def reboot_gateway(self) -> Any:
         url = f'/equipment/installations/{self.accessor.id}/gateways/{self.accessor.serial}/reboot'
         data = "{}"

--- a/PyViCare/PyViCareService.py
+++ b/PyViCare/PyViCareService.py
@@ -62,3 +62,8 @@ class ViCareService:
         if self._isGateway():
             url = f'/features/installations/{self.accessor.id}/gateways/{self.accessor.serial}/features/'
         return self.oauth_manager.get(url)
+        
+    def reboot_gateway(self) -> Any:
+        url = f'/equipment/installations/{self.accessor.id}/gateways/{self.accessor.serial}/reboot'
+        data = "{}"
+        return self.oauth_manager.post(url, data)


### PR DESCRIPTION
Add reboot gateway function. Based on patch #524 from @tomgat6, but simplified following the recent update (#540) to the v2 API schema.
The reboot function enables a workaround for the following API bug which is temporarily cured by a daily scheduled gateway reboot: https://github.com/home-assistant/core/issues/130273.

closes #524 