### PR TITLE
Change URLs to new domain viessmann-climatesolutions.com

### DIFF
--- a/PyViCare/PyViCareAbstractOAuthManager.py
+++ b/PyViCare/PyViCareAbstractOAuthManager.py
@@ -13,7 +13,7 @@ from PyViCare.PyViCareUtils import (PyViCareCommandError,
 logger = logging.getLogger('ViCare')
 logger.addHandler(logging.NullHandler())
 
-API_BASE_URL = 'https://api.viessmann.com/iot/v2'
+API_BASE_URL = 'https://api.viessmann-climatesolutions.com/iot/v2'
 
 
 class AbstractViCareOAuthManager:

--- a/PyViCare/PyViCareBrowserOAuthManager.py
+++ b/PyViCare/PyViCareBrowserOAuthManager.py
@@ -14,8 +14,8 @@ from PyViCare.PyViCareUtils import (PyViCareBrowserOAuthTimeoutReachedError,
 logger = logging.getLogger('ViCare')
 logger.addHandler(logging.NullHandler())
 
-AUTHORIZE_URL = 'https://iam.viessmann.com/idp/v3/authorize'
-TOKEN_URL = 'https://iam.viessmann.com/idp/v3/token'
+AUTHORIZE_URL = 'https://iam.viessmann-climatesolutions.com/idp/v3/authorize'
+TOKEN_URL = 'https://iam.viessmann-climatesolutions.com/idp/v3/token'
 REDIRECT_PORT = 51125
 VIESSMANN_SCOPE = ["IoT User", "offline_access"]
 AUTH_TIMEOUT = 60 * 3

--- a/PyViCare/PyViCareOAuthManager.py
+++ b/PyViCare/PyViCareOAuthManager.py
@@ -15,8 +15,8 @@ from PyViCare.PyViCareUtils import (PyViCareInvalidConfigurationError,
 logger = logging.getLogger('ViCare')
 logger.addHandler(logging.NullHandler())
 
-AUTHORIZE_URL = 'https://iam.viessmann.com/idp/v3/authorize'
-TOKEN_URL = 'https://iam.viessmann.com/idp/v3/token'
+AUTHORIZE_URL = 'https://iam.viessmann-climatesolutions.com/idp/v3/authorize'
+TOKEN_URL = 'https://iam.viessmann-climatesolutions.com/idp/v3/token'
 REDIRECT_URI = "vicare://oauth-callback/everest"
 VIESSMANN_SCOPE = ["IoT User"]
 

--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ Follow these steps to access the API in Postman:
    - Grant Type: `Authorization Code (With PKCE)`
    - Callback URL: `vicare://oauth-callback/everest`
    - Authorize using browser: Disabled
-   - Auth URL: `https://iam.viessmann.com/idp/v3/authorize`
-   - Access Token URL: `https://iam.viessmann.com/idp/v3/token`
+   - Auth URL: `https://iam.viessmann-climatesolutions.com/idp/v3/authorize`
+   - Access Token URL: `https://iam.viessmann-climatesolutions.com/idp/v3/token`
    - Client ID: Your personal Client ID created in the developer portal.
    - Client Secret: Blank
    - Code Challenge Method: `SHA-256`
@@ -133,7 +133,7 @@ Follow these steps to access the API in Postman:
 
 2. Use this URL to access your `installationId`, `gatewaySerial` and `deviceId`:
 
-   `https://api.viessmann.com/iot/v1/equipment/installations?includeGateways=true`
+   `https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations?includeGateways=true`
 
    - `installationId` is `data[0].id`
    - `gatewaySerial` is `data[0].gateways[0].serial`
@@ -141,7 +141,7 @@ Follow these steps to access the API in Postman:
 
 3. Use above data to replace `{installationId}`, `{gatewaySerial}` and `{deviceId}` in this URL to investigate the Viessmann API:
 
-   `https://api.viessmann.com/iot/v1/features/installations/{installationId}/gateways/{gatewaySerial}/devices/{deviceId}/features`
+   `https://api.viessmann-climatesolutions.com/iot/v1/features/installations/{installationId}/gateways/{gatewaySerial}/devices/{deviceId}/features`
 
 ## Rate Limits
 

--- a/tests/response/Ecotronic.json
+++ b/tests/response/Ecotronic.json
@@ -15,7 +15,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.messages.errors.raw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.messages.errors.raw"
     },
     {
       "apiVersion": 1,
@@ -33,7 +33,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.airflaps.0.position.current"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.airflaps.0.position.current"
     },
     {
       "apiVersion": 1,
@@ -51,7 +51,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:38.877Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.airflaps.1.position.current"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.airflaps.1.position.current"
     },
     {
       "apiVersion": 1,
@@ -69,7 +69,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.ash.level.current"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.ash.level.current"
     },
     {
       "apiVersion": 1,
@@ -86,7 +86,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.operating.phase"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.operating.phase"
     },
     {
       "apiVersion": 1,
@@ -103,7 +103,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.pumps.circuit"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.pumps.circuit"
     },
     {
       "apiVersion": 1,
@@ -125,7 +125,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -143,7 +143,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.temperature"
     },
     {
       "apiVersion": 1,
@@ -169,7 +169,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:32.623Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.buffer.sensors.temperature.top"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.buffer.sensors.temperature.top"
     },
     {
       "apiVersion": 1,
@@ -191,7 +191,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.bufferCylinder.sensors.temperature.bottom"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.bufferCylinder.sensors.temperature.bottom"
     },
     {
       "apiVersion": 1,
@@ -213,7 +213,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.bufferCylinder.sensors.temperature.midBottom"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.bufferCylinder.sensors.temperature.midBottom"
     },
     {
       "apiVersion": 1,
@@ -235,7 +235,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:32.623Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.bufferCylinder.sensors.temperature.midTop"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.bufferCylinder.sensors.temperature.midTop"
     },
     {
       "apiVersion": 1,
@@ -247,7 +247,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:32.623Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.bufferCylinder.sensors.temperature.middle"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.bufferCylinder.sensors.temperature.middle"
     },
     {
       "apiVersion": 1,
@@ -269,7 +269,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:32.623Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.bufferCylinder.sensors.temperature.top"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.bufferCylinder.sensors.temperature.top"
     },
     {
       "apiVersion": 1,
@@ -288,7 +288,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners"
     },
     {
       "apiVersion": 1,
@@ -305,7 +305,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0"
     },
     {
       "apiVersion": 1,
@@ -328,7 +328,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:38.877Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0.statistics"
     },
     {
       "apiVersion": 1,
@@ -347,7 +347,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits"
     },
     {
       "apiVersion": 1,
@@ -365,7 +365,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0/commands/setName"
         }
       },
       "deviceId": "0",
@@ -388,7 +388,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0"
     },
     {
       "apiVersion": 1,
@@ -405,7 +405,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -422,7 +422,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -450,7 +450,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve"
         }
       },
       "deviceId": "0",
@@ -471,7 +471,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -480,7 +480,7 @@
           "isExecutable": false,
           "name": "resetSchedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule/commands/resetSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule/commands/resetSchedule"
         },
         "setSchedule": {
           "isExecutable": true,
@@ -500,7 +500,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -576,7 +576,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -594,7 +594,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name/commands/setName"
         }
       },
       "components": [],
@@ -610,7 +610,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name"
     },
     {
       "apiVersion": 1,
@@ -630,7 +630,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
         }
       },
       "deviceId": "0",
@@ -645,7 +645,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -662,7 +662,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -679,7 +679,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -696,7 +696,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -715,13 +715,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/activate"
         },
         "deactivate": {
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/deactivate"
         },
         "setTemperature": {
           "isExecutable": true,
@@ -737,7 +737,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -761,7 +761,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -778,7 +778,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.dhwPrecedence"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.dhwPrecedence"
     },
     {
       "apiVersion": 1,
@@ -787,13 +787,13 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco/commands/activate"
         },
         "deactivate": {
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -813,7 +813,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -830,7 +830,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -849,7 +849,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -873,7 +873,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -892,7 +892,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -916,7 +916,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -933,7 +933,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -945,7 +945,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -967,7 +967,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -979,7 +979,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1"
     },
     {
       "apiVersion": 1,
@@ -991,7 +991,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -1003,7 +1003,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1015,7 +1015,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -1027,7 +1027,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -1039,7 +1039,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -1051,7 +1051,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -1063,7 +1063,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -1075,7 +1075,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1087,7 +1087,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -1099,7 +1099,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.dhwPrecedence"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.dhwPrecedence"
     },
     {
       "apiVersion": 1,
@@ -1111,7 +1111,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -1123,7 +1123,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1135,7 +1135,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -1147,7 +1147,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -1159,7 +1159,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1171,7 +1171,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1183,7 +1183,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1195,7 +1195,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2"
     },
     {
       "apiVersion": 1,
@@ -1207,7 +1207,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -1219,7 +1219,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1231,7 +1231,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -1243,7 +1243,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -1255,7 +1255,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -1267,7 +1267,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -1279,7 +1279,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -1291,7 +1291,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1303,7 +1303,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -1315,7 +1315,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.dhwPrecedence"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.dhwPrecedence"
     },
     {
       "apiVersion": 1,
@@ -1327,7 +1327,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -1339,7 +1339,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1351,7 +1351,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -1363,7 +1363,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -1375,7 +1375,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1387,7 +1387,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1399,7 +1399,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1411,7 +1411,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3"
     },
     {
       "apiVersion": 1,
@@ -1423,7 +1423,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -1435,7 +1435,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1447,7 +1447,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -1459,7 +1459,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -1471,7 +1471,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -1483,7 +1483,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -1495,7 +1495,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -1507,7 +1507,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1519,7 +1519,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -1531,7 +1531,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.dhwPrecedence"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.dhwPrecedence"
     },
     {
       "apiVersion": 1,
@@ -1543,7 +1543,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -1555,7 +1555,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1567,7 +1567,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -1579,7 +1579,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -1591,7 +1591,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1603,7 +1603,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1615,7 +1615,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1633,7 +1633,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.configuration.fuel.need"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.configuration.fuel.need"
     },
     {
       "apiVersion": 1,
@@ -1650,7 +1650,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.device.software"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.device.software"
     },
     {
       "apiVersion": 1,
@@ -1671,7 +1671,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.device.variant"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.device.variant"
     },
     {
       "apiVersion": 1,
@@ -1683,7 +1683,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw"
     },
     {
       "apiVersion": 1,
@@ -1695,7 +1695,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.charging"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.charging"
     },
     {
       "apiVersion": 1,
@@ -1707,7 +1707,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -1719,7 +1719,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.balanced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.balanced"
     },
     {
       "apiVersion": 1,
@@ -1731,7 +1731,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.off"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.off"
     },
     {
       "apiVersion": 1,
@@ -1743,7 +1743,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
     },
     {
       "apiVersion": 1,
@@ -1755,7 +1755,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
     },
     {
       "apiVersion": 1,
@@ -1767,7 +1767,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.primary"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.primary"
     },
     {
       "apiVersion": 1,
@@ -1779,7 +1779,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule"
     },
     {
       "apiVersion": 1,
@@ -1791,7 +1791,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder"
     },
     {
       "apiVersion": 1,
@@ -1807,7 +1807,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
     },
     {
       "apiVersion": 1,
@@ -1819,7 +1819,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -1841,7 +1841,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:38.877Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.flue.sensors.o2.lambda"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.flue.sensors.o2.lambda"
     },
     {
       "apiVersion": 1,
@@ -1863,7 +1863,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:38.877Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.flue.sensors.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.flue.sensors.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -1881,7 +1881,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
         },
         "schedule": {
           "isExecutable": true,
@@ -1903,13 +1903,13 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/schedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/schedule"
         },
         "unschedule": {
           "isExecutable": true,
           "name": "unschedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
         }
       },
       "deviceId": "0",
@@ -1932,7 +1932,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday"
     },
     {
       "apiVersion": 1,
@@ -1954,7 +1954,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.outside"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.outside"
     },
     {
       "apiVersion": 1,
@@ -1976,7 +1976,7 @@
         }
       },
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.return"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.return"
     },
     {
       "apiVersion": 1,
@@ -1988,7 +1988,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar"
     },
     {
       "apiVersion": 1,
@@ -2000,7 +2000,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.power.production"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.power.production"
     },
     {
       "apiVersion": 1,
@@ -2012,7 +2012,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.pumps.circuit"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.pumps.circuit"
     },
     {
       "apiVersion": 1,
@@ -2024,7 +2024,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.rechargeSuppression"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.rechargeSuppression"
     },
     {
       "apiVersion": 1,
@@ -2036,7 +2036,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.collector"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.collector"
     },
     {
       "apiVersion": 1,
@@ -2048,7 +2048,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.dhw"
     },
     {
       "apiVersion": 1,
@@ -2060,7 +2060,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-02-13T17:52:28.209Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.statistics"
     }
   ]
 }

--- a/tests/response/TCU300_ethernet.json
+++ b/tests/response/TCU300_ethernet.json
@@ -101,7 +101,7 @@
         }
       },
       "timestamp": "2024-03-17T18:55:46.182Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/252756/gateways/################/features/gateway.devices"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/252756/gateways/################/features/gateway.devices"
     }
   ]
 }

--- a/tests/response/VitoairFs300E.json
+++ b/tests/response/VitoairFs300E.json
@@ -15,7 +15,7 @@
         }
       },
       "timestamp": "2024-11-07T02:31:11.736Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/device.messages.errors.raw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/device.messages.errors.raw"
     },
     {
       "apiVersion": 1,
@@ -37,7 +37,7 @@
         }
       },
       "timestamp": "2024-11-07T02:31:11.736Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/device.productIdentification"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/device.productIdentification"
     },
     {
       "apiVersion": 1,
@@ -54,7 +54,7 @@
         }
       },
       "timestamp": "2024-11-07T02:31:11.736Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/device.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/device.serial"
     },
     {
       "apiVersion": 1,
@@ -71,7 +71,7 @@
         }
       },
       "timestamp": "2024-11-07T02:31:11.736Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/heating.boiler.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/heating.boiler.serial"
     },
     {
       "apiVersion": 1,
@@ -88,7 +88,7 @@
         }
       },
       "timestamp": "2024-11-07T02:31:11.736Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation"
     },
     {
       "apiVersion": 1,
@@ -106,7 +106,7 @@
         }
       },
       "timestamp": "2024-11-07T02:31:11.736Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.levels.levelFour"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.levels.levelFour"
     },
     {
       "apiVersion": 1,
@@ -124,7 +124,7 @@
         }
       },
       "timestamp": "2024-11-07T02:31:11.736Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.levels.levelOne"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.levels.levelOne"
     },
     {
       "apiVersion": 1,
@@ -142,7 +142,7 @@
         }
       },
       "timestamp": "2024-11-07T02:31:11.736Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.levels.levelThree"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.levels.levelThree"
     },
     {
       "apiVersion": 1,
@@ -160,7 +160,7 @@
         }
       },
       "timestamp": "2024-11-07T02:31:11.736Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.levels.levelTwo"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.levels.levelTwo"
     },
     {
       "apiVersion": 1,
@@ -182,13 +182,13 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.modes.active/commands/setMode"
         },
         "setModeContinuousSensorOverride": {
           "isExecutable": true,
           "name": "setModeContinuousSensorOverride",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.modes.active/commands/setModeContinuousSensorOverride"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.modes.active/commands/setModeContinuousSensorOverride"
         }
       },
       "deviceId": "################",
@@ -203,7 +203,7 @@
         }
       },
       "timestamp": "2024-11-07T02:31:12.967Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -220,7 +220,7 @@
         }
       },
       "timestamp": "2024-11-07T02:31:11.736Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.modes.filterChange"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.modes.filterChange"
     },
     {
       "apiVersion": 1,
@@ -242,7 +242,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.modes.permanent/commands/setLevel"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.modes.permanent/commands/setLevel"
         }
       },
       "deviceId": "################",
@@ -257,7 +257,7 @@
         }
       },
       "timestamp": "2024-11-07T07:20:15.814Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.modes.permanent"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.modes.permanent"
     },
     {
       "apiVersion": 1,
@@ -274,7 +274,7 @@
         }
       },
       "timestamp": "2024-11-07T02:31:11.736Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.modes.sensorDriven"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.modes.sensorDriven"
     },
     {
       "apiVersion": 1,
@@ -291,7 +291,7 @@
         }
       },
       "timestamp": "2024-11-07T02:31:11.736Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.modes.sensorOverride"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.modes.sensorOverride"
     },
     {
       "apiVersion": 1,
@@ -308,7 +308,7 @@
         }
       },
       "timestamp": "2024-11-07T02:31:11.736Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.modes.ventilation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.modes.ventilation"
     },
     {
       "apiVersion": 1,
@@ -325,7 +325,7 @@
         }
       },
       "timestamp": "2024-11-07T07:20:15.814Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -345,14 +345,14 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.forcedLevelFour/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.forcedLevelFour/commands/activate"
         },
         "deactivate": {
           "isDeprecated": true,
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.forcedLevelFour/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.forcedLevelFour/commands/deactivate"
         },
         "setDefaultRuntime": {
           "isDeprecated": true,
@@ -369,7 +369,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.forcedLevelFour/commands/setDefaultRuntime"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.forcedLevelFour/commands/setDefaultRuntime"
         },
         "setTimeout": {
           "isDeprecated": true,
@@ -386,7 +386,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.forcedLevelFour/commands/setTimeout"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.forcedLevelFour/commands/setTimeout"
         }
       },
       "deprecated": {
@@ -414,7 +414,7 @@
         }
       },
       "timestamp": "2024-11-07T02:31:12.967Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.forcedLevelFour"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.forcedLevelFour"
     },
     {
       "apiVersion": 1,
@@ -440,7 +440,7 @@
         }
       },
       "timestamp": "2024-11-07T07:20:15.814Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.levelFour"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.levelFour"
     },
     {
       "apiVersion": 1,
@@ -466,7 +466,7 @@
         }
       },
       "timestamp": "2024-11-07T07:20:15.814Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.levelOne"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.levelOne"
     },
     {
       "apiVersion": 1,
@@ -492,7 +492,7 @@
         }
       },
       "timestamp": "2024-11-07T02:31:11.736Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.levelThree"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.levelThree"
     },
     {
       "apiVersion": 1,
@@ -518,7 +518,7 @@
         }
       },
       "timestamp": "2024-11-07T02:31:11.736Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.levelTwo"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.levelTwo"
     },
     {
       "apiVersion": 1,
@@ -538,14 +538,14 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.silent/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.silent/commands/activate"
         },
         "deactivate": {
           "isDeprecated": true,
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.silent/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.silent/commands/deactivate"
         },
         "setDefaultRuntime": {
           "isDeprecated": true,
@@ -562,7 +562,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.silent/commands/setDefaultRuntime"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.silent/commands/setDefaultRuntime"
         },
         "setTimeout": {
           "isDeprecated": true,
@@ -579,7 +579,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.silent/commands/setTimeout"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.silent/commands/setTimeout"
         }
       },
       "deprecated": {
@@ -607,7 +607,7 @@
         }
       },
       "timestamp": "2024-11-07T02:31:12.967Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.silent"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.silent"
     },
     {
       "apiVersion": 1,
@@ -629,7 +629,7 @@
         }
       },
       "timestamp": "2024-11-07T02:31:11.736Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -654,7 +654,7 @@
         }
       },
       "timestamp": "2024-11-07T07:20:15.814Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.state"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.operating.state"
     },
     {
       "apiVersion": 1,
@@ -673,13 +673,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.quickmodes.forcedLevelFour/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.quickmodes.forcedLevelFour/commands/activate"
         },
         "deactivate": {
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.quickmodes.forcedLevelFour/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.quickmodes.forcedLevelFour/commands/deactivate"
         },
         "setDefaultRuntime": {
           "isExecutable": true,
@@ -695,7 +695,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.quickmodes.forcedLevelFour/commands/setDefaultRuntime"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.quickmodes.forcedLevelFour/commands/setDefaultRuntime"
         },
         "setTimeout": {
           "isExecutable": true,
@@ -711,7 +711,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.quickmodes.forcedLevelFour/commands/setTimeout"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.quickmodes.forcedLevelFour/commands/setTimeout"
         }
       },
       "deviceId": "################",
@@ -735,7 +735,7 @@
         }
       },
       "timestamp": "2024-11-07T02:31:12.967Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.quickmodes.forcedLevelFour"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.quickmodes.forcedLevelFour"
     },
     {
       "apiVersion": 1,
@@ -754,13 +754,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.quickmodes.silent/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.quickmodes.silent/commands/activate"
         },
         "deactivate": {
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.quickmodes.silent/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.quickmodes.silent/commands/deactivate"
         },
         "setDefaultRuntime": {
           "isExecutable": true,
@@ -776,7 +776,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.quickmodes.silent/commands/setDefaultRuntime"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.quickmodes.silent/commands/setDefaultRuntime"
         },
         "setTimeout": {
           "isExecutable": true,
@@ -792,7 +792,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.quickmodes.silent/commands/setTimeout"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.quickmodes.silent/commands/setTimeout"
         }
       },
       "deviceId": "################",
@@ -816,7 +816,7 @@
         }
       },
       "timestamp": "2024-11-07T02:31:12.967Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.quickmodes.silent"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.quickmodes.silent"
     },
     {
       "apiVersion": 1,
@@ -825,7 +825,7 @@
           "isExecutable": false,
           "name": "resetSchedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.schedule/commands/resetSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.schedule/commands/resetSchedule"
         },
         "setSchedule": {
           "isExecutable": true,
@@ -847,7 +847,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.schedule/commands/setSchedule"
         }
       },
       "deviceId": "################",
@@ -1049,7 +1049,7 @@
         }
       },
       "timestamp": "2024-11-07T02:31:11.736Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ventilation.schedule"
     }
   ]
 }

--- a/tests/response/Vitocal-200S-with-Vitovent-300W.json
+++ b/tests/response/Vitocal-200S-with-Vitovent-300W.json
@@ -15,7 +15,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.messages.errors.raw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.messages.errors.raw"
     },
     {
       "apiVersion": 1,
@@ -32,7 +32,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.serial"
     },
     {
       "apiVersion": 1,
@@ -49,7 +49,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
     },
     {
       "apiVersion": 1,
@@ -66,7 +66,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
     },
     {
       "apiVersion": 1,
@@ -92,7 +92,7 @@
         }
       },
       "timestamp": "2024-10-01T10:48:22.973Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.buffer.sensors.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.buffer.sensors.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -118,7 +118,7 @@
         }
       },
       "timestamp": "2024-10-01T10:48:22.973Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.buffer.sensors.temperature.top"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.buffer.sensors.temperature.top"
     },
     {
       "apiVersion": 1,
@@ -140,7 +140,7 @@
         }
       },
       "timestamp": "2024-10-01T10:48:22.973Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.bufferCylinder.sensors.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.bufferCylinder.sensors.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -162,7 +162,7 @@
         }
       },
       "timestamp": "2024-10-01T10:48:22.973Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.bufferCylinder.sensors.temperature.top"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.bufferCylinder.sensors.temperature.top"
     },
     {
       "apiVersion": 1,
@@ -179,7 +179,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners"
     },
     {
       "apiVersion": 1,
@@ -191,7 +191,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0"
     },
     {
       "apiVersion": 1,
@@ -203,7 +203,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0.modulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0.modulation"
     },
     {
       "apiVersion": 1,
@@ -215,7 +215,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0.statistics"
     },
     {
       "apiVersion": 1,
@@ -234,7 +234,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits"
     },
     {
       "apiVersion": 1,
@@ -246,7 +246,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0"
     },
     {
       "apiVersion": 1,
@@ -258,7 +258,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -270,7 +270,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -282,7 +282,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -294,7 +294,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -306,7 +306,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -318,7 +318,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.cooling"
     },
     {
       "apiVersion": 1,
@@ -330,7 +330,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -342,7 +342,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -354,7 +354,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeatingCooling"
     },
     {
       "apiVersion": 1,
@@ -366,7 +366,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.forcedNormal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.forcedNormal"
     },
     {
       "apiVersion": 1,
@@ -378,7 +378,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.forcedReduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.forcedReduced"
     },
     {
       "apiVersion": 1,
@@ -390,7 +390,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -402,7 +402,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heatingCooling"
     },
     {
       "apiVersion": 1,
@@ -414,7 +414,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.normalStandby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.normalStandby"
     },
     {
       "apiVersion": 1,
@@ -426,7 +426,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -438,7 +438,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -450,7 +450,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -462,7 +462,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -474,7 +474,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.fixed"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.fixed"
     },
     {
       "apiVersion": 1,
@@ -486,7 +486,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -498,7 +498,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -510,7 +510,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -522,7 +522,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -534,7 +534,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -546,7 +546,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature"
     },
     {
       "apiVersion": 1,
@@ -558,7 +558,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels"
     },
     {
       "apiVersion": 1,
@@ -576,7 +576,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1/commands/setName"
         }
       },
       "deviceId": "0",
@@ -599,7 +599,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1"
     },
     {
       "apiVersion": 1,
@@ -616,7 +616,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -633,7 +633,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -661,7 +661,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve/commands/setCurve"
         }
       },
       "deviceId": "0",
@@ -682,7 +682,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -691,7 +691,7 @@
           "isExecutable": true,
           "name": "resetSchedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule/commands/resetSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule/commands/resetSchedule"
         },
         "setSchedule": {
           "isExecutable": true,
@@ -713,7 +713,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -873,7 +873,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -891,7 +891,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.name/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.name/commands/setName"
         }
       },
       "components": [],
@@ -907,7 +907,7 @@
         }
       },
       "timestamp": "2024-09-30T06:29:44.472Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.name"
     },
     {
       "apiVersion": 1,
@@ -928,7 +928,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active/commands/setMode"
         }
       },
       "deviceId": "0",
@@ -943,7 +943,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -955,7 +955,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.cooling"
     },
     {
       "apiVersion": 1,
@@ -972,7 +972,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -989,7 +989,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -1001,7 +1001,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeatingCooling"
     },
     {
       "apiVersion": 1,
@@ -1018,7 +1018,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.forcedNormal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.forcedNormal"
     },
     {
       "apiVersion": 1,
@@ -1035,7 +1035,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.forcedReduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.forcedReduced"
     },
     {
       "apiVersion": 1,
@@ -1047,7 +1047,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -1059,7 +1059,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heatingCooling"
     },
     {
       "apiVersion": 1,
@@ -1076,7 +1076,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.normalStandby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.normalStandby"
     },
     {
       "apiVersion": 1,
@@ -1093,7 +1093,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -1110,7 +1110,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1129,13 +1129,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort/commands/activate"
         },
         "deactivate": {
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort/commands/deactivate"
         },
         "setTemperature": {
           "isExecutable": true,
@@ -1151,7 +1151,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -1175,7 +1175,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -1184,13 +1184,13 @@
           "isExecutable": false,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.eco/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.eco/commands/activate"
         },
         "deactivate": {
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.eco/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.eco/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -1210,7 +1210,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -1227,7 +1227,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.fixed"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.fixed"
     },
     {
       "apiVersion": 1,
@@ -1246,7 +1246,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -1270,7 +1270,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -1289,7 +1289,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -1313,7 +1313,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -1330,7 +1330,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1342,7 +1342,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1364,7 +1364,7 @@
         }
       },
       "timestamp": "2024-10-01T10:17:21.636Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1382,7 +1382,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature"
     },
     {
       "apiVersion": 1,
@@ -1410,7 +1410,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature.levels/commands/setLevels"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature.levels/commands/setLevels"
         },
         "setMax": {
           "isExecutable": true,
@@ -1426,7 +1426,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature.levels/commands/setMax"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature.levels/commands/setMax"
         },
         "setMin": {
           "isExecutable": true,
@@ -1442,7 +1442,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature.levels/commands/setMin"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature.levels/commands/setMin"
         }
       },
       "deviceId": "0",
@@ -1463,7 +1463,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature.levels"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature.levels"
     },
     {
       "apiVersion": 1,
@@ -1475,7 +1475,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2"
     },
     {
       "apiVersion": 1,
@@ -1487,7 +1487,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -1499,7 +1499,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1511,7 +1511,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -1523,7 +1523,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -1535,7 +1535,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -1547,7 +1547,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.cooling"
     },
     {
       "apiVersion": 1,
@@ -1559,7 +1559,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -1571,7 +1571,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -1583,7 +1583,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeatingCooling"
     },
     {
       "apiVersion": 1,
@@ -1595,7 +1595,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.forcedNormal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.forcedNormal"
     },
     {
       "apiVersion": 1,
@@ -1607,7 +1607,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.forcedReduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.forcedReduced"
     },
     {
       "apiVersion": 1,
@@ -1619,7 +1619,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -1631,7 +1631,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heatingCooling"
     },
     {
       "apiVersion": 1,
@@ -1643,7 +1643,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.normalStandby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.normalStandby"
     },
     {
       "apiVersion": 1,
@@ -1655,7 +1655,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -1667,7 +1667,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1679,7 +1679,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -1691,7 +1691,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -1703,7 +1703,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.fixed"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.fixed"
     },
     {
       "apiVersion": 1,
@@ -1715,7 +1715,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -1727,7 +1727,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -1739,7 +1739,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1751,7 +1751,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1763,7 +1763,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1775,7 +1775,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.temperature"
     },
     {
       "apiVersion": 1,
@@ -1787,7 +1787,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.temperature.levels"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.temperature.levels"
     },
     {
       "apiVersion": 1,
@@ -1806,7 +1806,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors"
     },
     {
       "apiVersion": 1,
@@ -1827,7 +1827,7 @@
         }
       },
       "timestamp": "2024-10-01T10:42:27.339Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0"
     },
     {
       "apiVersion": 1,
@@ -1850,7 +1850,7 @@
         }
       },
       "timestamp": "2024-10-01T10:56:51.362Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0.statistics"
     },
     {
       "apiVersion": 1,
@@ -1862,7 +1862,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.1"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.1"
     },
     {
       "apiVersion": 1,
@@ -1874,7 +1874,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.1.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.1.statistics"
     },
     {
       "apiVersion": 1,
@@ -1894,7 +1894,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.configuration.dhw.temperature.dhwCylinder.max/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.configuration.dhw.temperature.dhwCylinder.max/commands/setTemperature"
         }
       },
       "deprecated": {
@@ -1914,7 +1914,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.configuration.dhw.temperature.dhwCylinder.max"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.configuration.dhw.temperature.dhwCylinder.max"
     },
     {
       "apiVersion": 1,
@@ -1931,7 +1931,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.controller.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.controller.serial"
     },
     {
       "apiVersion": 1,
@@ -1952,7 +1952,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw"
     },
     {
       "apiVersion": 1,
@@ -1969,7 +1969,7 @@
         }
       },
       "timestamp": "2024-10-01T10:40:23.496Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.charging"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.charging"
     },
     {
       "apiVersion": 1,
@@ -1978,13 +1978,13 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/activate"
         },
         "deactivate": {
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -1999,7 +1999,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge"
     },
     {
       "apiVersion": 1,
@@ -2016,7 +2016,7 @@
         }
       },
       "timestamp": "2024-10-01T09:35:14.996Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
     },
     {
       "apiVersion": 1,
@@ -2025,7 +2025,7 @@
           "isExecutable": true,
           "name": "resetSchedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/resetSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/resetSchedule"
         },
         "setSchedule": {
           "isExecutable": true,
@@ -2047,7 +2047,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -2207,7 +2207,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
     },
     {
       "apiVersion": 1,
@@ -2224,7 +2224,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.primary"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.primary"
     },
     {
       "apiVersion": 1,
@@ -2233,7 +2233,7 @@
           "isExecutable": true,
           "name": "resetSchedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule/commands/resetSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule/commands/resetSchedule"
         },
         "setSchedule": {
           "isExecutable": true,
@@ -2255,7 +2255,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -2331,7 +2331,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule"
     },
     {
       "apiVersion": 1,
@@ -2353,7 +2353,7 @@
         }
       },
       "timestamp": "2024-10-01T10:56:57.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder"
     },
     {
       "apiVersion": 1,
@@ -2370,7 +2370,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder.bottom"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder.bottom"
     },
     {
       "apiVersion": 1,
@@ -2392,7 +2392,7 @@
         }
       },
       "timestamp": "2024-10-01T10:56:57.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder.top"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder.top"
     },
     {
       "apiVersion": 1,
@@ -2418,7 +2418,7 @@
         }
       },
       "timestamp": "2024-10-01T10:56:57.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
     },
     {
       "apiVersion": 1,
@@ -2439,7 +2439,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.bottom"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.bottom"
     },
     {
       "apiVersion": 1,
@@ -2465,7 +2465,7 @@
         }
       },
       "timestamp": "2024-10-01T10:56:57.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.top"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.top"
     },
     {
       "apiVersion": 1,
@@ -2482,7 +2482,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.outlet"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.outlet"
     },
     {
       "apiVersion": 1,
@@ -2501,7 +2501,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresis"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresis"
         },
         "setHysteresisSwitchOffValue": {
           "isExecutable": false,
@@ -2517,7 +2517,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOffValue"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOffValue"
         },
         "setHysteresisSwitchOnValue": {
           "isExecutable": true,
@@ -2533,7 +2533,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOnValue"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOnValue"
         }
       },
       "deviceId": "0",
@@ -2559,7 +2559,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis"
     },
     {
       "apiVersion": 1,
@@ -2580,7 +2580,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
         }
       },
       "deviceId": "0",
@@ -2596,7 +2596,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -2615,7 +2615,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.temp2/commands/setTargetTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.temp2/commands/setTargetTemperature"
         }
       },
       "deviceId": "0",
@@ -2631,7 +2631,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.temp2"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.temp2"
     },
     {
       "apiVersion": 1,
@@ -2649,7 +2649,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
         },
         "schedule": {
           "isExecutable": true,
@@ -2671,13 +2671,13 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/schedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/schedule"
         },
         "unschedule": {
           "isExecutable": true,
           "name": "unschedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
         }
       },
       "deviceId": "0",
@@ -2700,7 +2700,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday"
     },
     {
       "apiVersion": 1,
@@ -2717,7 +2717,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.primaryCircuit.sensors.temperature.return"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.primaryCircuit.sensors.temperature.return"
     },
     {
       "apiVersion": 1,
@@ -2739,7 +2739,7 @@
         }
       },
       "timestamp": "2024-10-01T10:56:41.784Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.primaryCircuit.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.primaryCircuit.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -2761,7 +2761,7 @@
         }
       },
       "timestamp": "2024-10-01T10:56:41.784Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.secondaryCircuit.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.secondaryCircuit.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -2783,7 +2783,7 @@
         }
       },
       "timestamp": "2024-10-01T10:53:57.789Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.outside"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.outside"
     },
     {
       "apiVersion": 1,
@@ -2805,7 +2805,7 @@
         }
       },
       "timestamp": "2024-10-01T10:56:35.542Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.return"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.return"
     },
     {
       "apiVersion": 1,
@@ -2817,7 +2817,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar"
     },
     {
       "apiVersion": 1,
@@ -2829,7 +2829,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.power.cumulativeProduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.power.cumulativeProduced"
     },
     {
       "apiVersion": 1,
@@ -2841,7 +2841,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.power.production"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.power.production"
     },
     {
       "apiVersion": 1,
@@ -2853,7 +2853,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.pumps.circuit"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.pumps.circuit"
     },
     {
       "apiVersion": 1,
@@ -2865,7 +2865,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.collector"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.collector"
     },
     {
       "apiVersion": 1,
@@ -2877,7 +2877,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.dhw"
     },
     {
       "apiVersion": 1,
@@ -2894,7 +2894,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation"
     },
     {
       "apiVersion": 1,
@@ -2906,7 +2906,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.levels.levelFour"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.levels.levelFour"
     },
     {
       "apiVersion": 1,
@@ -2918,7 +2918,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.levels.levelOne"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.levels.levelOne"
     },
     {
       "apiVersion": 1,
@@ -2930,7 +2930,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.levels.levelThree"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.levels.levelThree"
     },
     {
       "apiVersion": 1,
@@ -2942,7 +2942,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.levels.levelTwo"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.levels.levelTwo"
     },
     {
       "apiVersion": 1,
@@ -2963,13 +2963,13 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.active/commands/setMode"
         },
         "setModeContinuousSensorOverride": {
           "isExecutable": false,
           "name": "setModeContinuousSensorOverride",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.active/commands/setModeContinuousSensorOverride"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.active/commands/setModeContinuousSensorOverride"
         }
       },
       "deviceId": "0",
@@ -2984,7 +2984,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -3001,7 +3001,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.standard"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.standard"
     },
     {
       "apiVersion": 1,
@@ -3018,7 +3018,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -3035,7 +3035,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.ventilation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.ventilation"
     },
     {
       "apiVersion": 1,
@@ -3052,7 +3052,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -3062,14 +3062,14 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.comfort/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.comfort/commands/activate"
         },
         "deactivate": {
           "isDeprecated": true,
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.comfort/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.comfort/commands/deactivate"
         }
       },
       "deprecated": {
@@ -3088,7 +3088,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -3098,14 +3098,14 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.eco/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.eco/commands/activate"
         },
         "deactivate": {
           "isDeprecated": true,
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.eco/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.eco/commands/deactivate"
         }
       },
       "deprecated": {
@@ -3124,7 +3124,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -3142,7 +3142,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.holiday/commands/changeEndDate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.holiday/commands/changeEndDate"
         },
         "schedule": {
           "isExecutable": true,
@@ -3164,13 +3164,13 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.holiday/commands/schedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.holiday/commands/schedule"
         },
         "unschedule": {
           "isExecutable": true,
           "name": "unschedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.holiday/commands/unschedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.holiday/commands/unschedule"
         }
       },
       "deprecated": {
@@ -3197,7 +3197,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.holiday"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.holiday"
     },
     {
       "apiVersion": 1,
@@ -3218,7 +3218,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelFour"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelFour"
     },
     {
       "apiVersion": 1,
@@ -3239,7 +3239,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelOne"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelOne"
     },
     {
       "apiVersion": 1,
@@ -3260,7 +3260,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelThree"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelThree"
     },
     {
       "apiVersion": 1,
@@ -3281,7 +3281,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelTwo"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelTwo"
     },
     {
       "apiVersion": 1,
@@ -3303,7 +3303,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -3328,7 +3328,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.state"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.state"
     },
     {
       "apiVersion": 1,
@@ -3337,13 +3337,13 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.comfort/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.comfort/commands/activate"
         },
         "deactivate": {
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.comfort/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.comfort/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -3358,7 +3358,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.comfort"
     },
     {
       "apiVersion": 1,
@@ -3367,13 +3367,13 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.eco/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.eco/commands/activate"
         },
         "deactivate": {
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.eco/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.eco/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -3388,7 +3388,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.eco"
     },
     {
       "apiVersion": 1,
@@ -3406,7 +3406,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.holiday/commands/changeEndDate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.holiday/commands/changeEndDate"
         },
         "schedule": {
           "isExecutable": true,
@@ -3428,13 +3428,13 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.holiday/commands/schedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.holiday/commands/schedule"
         },
         "unschedule": {
           "isExecutable": true,
           "name": "unschedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.holiday/commands/unschedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.holiday/commands/unschedule"
         }
       },
       "deviceId": "0",
@@ -3457,7 +3457,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.holiday"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.holiday"
     },
     {
       "apiVersion": 1,
@@ -3466,7 +3466,7 @@
           "isExecutable": true,
           "name": "resetSchedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.schedule/commands/resetSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.schedule/commands/resetSchedule"
         },
         "setSchedule": {
           "isExecutable": true,
@@ -3488,7 +3488,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -3564,7 +3564,7 @@
         }
       },
       "timestamp": "2024-10-01T01:07:09.296Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.schedule"
     }
   ]
 }

--- a/tests/response/Vitocal111S.json
+++ b/tests/response/Vitocal111S.json
@@ -15,7 +15,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.messages.errors.raw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.messages.errors.raw"
     },
     {
       "apiVersion": 1,
@@ -32,7 +32,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.serial"
     },
     {
       "apiVersion": 1,
@@ -49,7 +49,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:05.734Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
     },
     {
       "apiVersion": 1,
@@ -66,7 +66,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
     },
     {
       "apiVersion": 1,
@@ -87,7 +87,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:14.344Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.buffer.sensors.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.buffer.sensors.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -108,7 +108,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:14.344Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.buffer.sensors.temperature.top"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.buffer.sensors.temperature.top"
     },
     {
       "apiVersion": 1,
@@ -125,7 +125,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:14.344Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.bufferCylinder.sensors.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.bufferCylinder.sensors.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -142,7 +142,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:14.344Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.bufferCylinder.sensors.temperature.top"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.bufferCylinder.sensors.temperature.top"
     },
     {
       "apiVersion": 1,
@@ -159,7 +159,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners"
     },
     {
       "apiVersion": 1,
@@ -171,7 +171,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0"
     },
     {
       "apiVersion": 1,
@@ -183,7 +183,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0.modulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0.modulation"
     },
     {
       "apiVersion": 1,
@@ -195,7 +195,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0.statistics"
     },
     {
       "apiVersion": 1,
@@ -214,7 +214,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits"
     },
     {
       "apiVersion": 1,
@@ -232,7 +232,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0/commands/setName"
         }
       },
       "deviceId": "0",
@@ -255,7 +255,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0"
     },
     {
       "apiVersion": 1,
@@ -272,7 +272,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -289,7 +289,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -317,7 +317,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve"
         }
       },
       "deviceId": "0",
@@ -338,7 +338,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -363,7 +363,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -439,7 +439,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -457,7 +457,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name/commands/setName"
         }
       },
       "components": [],
@@ -473,7 +473,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name"
     },
     {
       "apiVersion": 1,
@@ -494,7 +494,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
         }
       },
       "deviceId": "0",
@@ -509,7 +509,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -526,7 +526,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.cooling"
     },
     {
       "apiVersion": 1,
@@ -543,7 +543,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -555,7 +555,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -572,7 +572,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeatingCooling"
     },
     {
       "apiVersion": 1,
@@ -589,7 +589,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.forcedNormal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.forcedNormal"
     },
     {
       "apiVersion": 1,
@@ -606,7 +606,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.forcedReduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.forcedReduced"
     },
     {
       "apiVersion": 1,
@@ -618,7 +618,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -630,7 +630,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heatingCooling"
     },
     {
       "apiVersion": 1,
@@ -647,7 +647,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.normalStandby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.normalStandby"
     },
     {
       "apiVersion": 1,
@@ -664,7 +664,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -681,7 +681,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -700,13 +700,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/activate"
         },
         "deactivate": {
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/deactivate"
         },
         "setTemperature": {
           "isExecutable": true,
@@ -722,7 +722,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -746,7 +746,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -755,13 +755,13 @@
           "isExecutable": false,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco/commands/activate"
         },
         "deactivate": {
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -781,7 +781,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -798,7 +798,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.fixed"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.fixed"
     },
     {
       "apiVersion": 1,
@@ -817,7 +817,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -841,7 +841,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -860,7 +860,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -884,7 +884,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -901,7 +901,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -923,7 +923,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:37.908Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -945,7 +945,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:05.734Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -963,7 +963,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature"
     },
     {
       "apiVersion": 1,
@@ -991,7 +991,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setLevels"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setLevels"
         },
         "setMax": {
           "isExecutable": true,
@@ -1007,7 +1007,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setMax"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setMax"
         },
         "setMin": {
           "isExecutable": true,
@@ -1023,7 +1023,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setMin"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setMin"
         }
       },
       "deviceId": "0",
@@ -1044,7 +1044,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels"
     },
     {
       "apiVersion": 1,
@@ -1056,7 +1056,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1"
     },
     {
       "apiVersion": 1,
@@ -1068,7 +1068,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -1080,7 +1080,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1092,7 +1092,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -1104,7 +1104,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -1116,7 +1116,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -1128,7 +1128,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.cooling"
     },
     {
       "apiVersion": 1,
@@ -1140,7 +1140,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -1152,7 +1152,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -1164,7 +1164,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeatingCooling"
     },
     {
       "apiVersion": 1,
@@ -1176,7 +1176,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.forcedNormal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.forcedNormal"
     },
     {
       "apiVersion": 1,
@@ -1188,7 +1188,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.forcedReduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.forcedReduced"
     },
     {
       "apiVersion": 1,
@@ -1200,7 +1200,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -1212,7 +1212,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heatingCooling"
     },
     {
       "apiVersion": 1,
@@ -1224,7 +1224,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.normalStandby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.normalStandby"
     },
     {
       "apiVersion": 1,
@@ -1236,7 +1236,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -1248,7 +1248,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1260,7 +1260,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -1272,7 +1272,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -1284,7 +1284,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.fixed"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.fixed"
     },
     {
       "apiVersion": 1,
@@ -1296,7 +1296,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -1308,7 +1308,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -1320,7 +1320,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1332,7 +1332,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:37.908Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1344,7 +1344,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:05.734Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1356,7 +1356,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature"
     },
     {
       "apiVersion": 1,
@@ -1368,7 +1368,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature.levels"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature.levels"
     },
     {
       "apiVersion": 1,
@@ -1380,7 +1380,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2"
     },
     {
       "apiVersion": 1,
@@ -1392,7 +1392,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -1404,7 +1404,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1416,7 +1416,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -1428,7 +1428,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -1440,7 +1440,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -1452,7 +1452,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.cooling"
     },
     {
       "apiVersion": 1,
@@ -1464,7 +1464,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -1476,7 +1476,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -1488,7 +1488,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeatingCooling"
     },
     {
       "apiVersion": 1,
@@ -1500,7 +1500,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.forcedNormal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.forcedNormal"
     },
     {
       "apiVersion": 1,
@@ -1512,7 +1512,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.forcedReduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.forcedReduced"
     },
     {
       "apiVersion": 1,
@@ -1524,7 +1524,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -1536,7 +1536,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heatingCooling"
     },
     {
       "apiVersion": 1,
@@ -1548,7 +1548,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.normalStandby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.normalStandby"
     },
     {
       "apiVersion": 1,
@@ -1560,7 +1560,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -1572,7 +1572,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1584,7 +1584,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -1596,7 +1596,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -1608,7 +1608,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.fixed"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.fixed"
     },
     {
       "apiVersion": 1,
@@ -1620,7 +1620,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -1632,7 +1632,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -1644,7 +1644,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1656,7 +1656,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:37.908Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1668,7 +1668,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:05.734Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1680,7 +1680,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.temperature"
     },
     {
       "apiVersion": 1,
@@ -1692,7 +1692,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.temperature.levels"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.temperature.levels"
     },
     {
       "apiVersion": 1,
@@ -1711,7 +1711,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors"
     },
     {
       "apiVersion": 1,
@@ -1732,7 +1732,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0"
     },
     {
       "apiVersion": 1,
@@ -1755,7 +1755,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0.statistics"
     },
     {
       "apiVersion": 1,
@@ -1767,7 +1767,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.1"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.1"
     },
     {
       "apiVersion": 1,
@@ -1779,7 +1779,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.1.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.1.statistics"
     },
     {
       "apiVersion": 1,
@@ -1799,7 +1799,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.configuration.dhw.temperature.dhwCylinder.max/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.configuration.dhw.temperature.dhwCylinder.max/commands/setTemperature"
         }
       },
       "deprecated": {
@@ -1819,7 +1819,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.configuration.dhw.temperature.dhwCylinder.max"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.configuration.dhw.temperature.dhwCylinder.max"
     },
     {
       "apiVersion": 1,
@@ -1836,7 +1836,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.controller.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.controller.serial"
     },
     {
       "apiVersion": 1,
@@ -1857,7 +1857,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw"
     },
     {
       "apiVersion": 1,
@@ -1874,7 +1874,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.charging"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.charging"
     },
     {
       "apiVersion": 1,
@@ -1883,13 +1883,13 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/activate"
         },
         "deactivate": {
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -1904,7 +1904,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge"
     },
     {
       "apiVersion": 1,
@@ -1921,7 +1921,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
     },
     {
       "apiVersion": 1,
@@ -1946,7 +1946,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -1973,7 +1973,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
     },
     {
       "apiVersion": 1,
@@ -1990,7 +1990,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.primary"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.primary"
     },
     {
       "apiVersion": 1,
@@ -2015,7 +2015,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -2115,7 +2115,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule"
     },
     {
       "apiVersion": 1,
@@ -2137,7 +2137,7 @@
         }
       },
       "timestamp": "2024-05-26T17:03:59.884Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder"
     },
     {
       "apiVersion": 1,
@@ -2154,7 +2154,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:14.344Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder.bottom"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder.bottom"
     },
     {
       "apiVersion": 1,
@@ -2176,7 +2176,7 @@
         }
       },
       "timestamp": "2024-05-26T17:03:59.884Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder.top"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder.top"
     },
     {
       "apiVersion": 1,
@@ -2202,7 +2202,7 @@
         }
       },
       "timestamp": "2024-05-26T17:03:59.884Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
     },
     {
       "apiVersion": 1,
@@ -2223,7 +2223,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:14.344Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.bottom"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.bottom"
     },
     {
       "apiVersion": 1,
@@ -2249,7 +2249,7 @@
         }
       },
       "timestamp": "2024-05-26T17:03:59.884Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.top"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.top"
     },
     {
       "apiVersion": 1,
@@ -2266,7 +2266,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:05.734Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.outlet"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.outlet"
     },
     {
       "apiVersion": 1,
@@ -2285,7 +2285,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresis"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresis"
         },
         "setHysteresisSwitchOffValue": {
           "isExecutable": true,
@@ -2301,7 +2301,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOffValue"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOffValue"
         },
         "setHysteresisSwitchOnValue": {
           "isExecutable": true,
@@ -2317,7 +2317,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOnValue"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOnValue"
         }
       },
       "deviceId": "0",
@@ -2343,7 +2343,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:14.344Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis"
     },
     {
       "apiVersion": 1,
@@ -2364,7 +2364,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
         }
       },
       "deviceId": "0",
@@ -2380,7 +2380,7 @@
         }
       },
       "timestamp": "2024-05-26T17:19:15.317Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -2399,7 +2399,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.temp2/commands/setTargetTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.temp2/commands/setTargetTemperature"
         }
       },
       "deviceId": "0",
@@ -2415,7 +2415,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.temp2"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.temp2"
     },
     {
       "apiVersion": 1,
@@ -2433,7 +2433,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
         },
         "schedule": {
           "isExecutable": true,
@@ -2455,13 +2455,13 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/schedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/schedule"
         },
         "unschedule": {
           "isExecutable": true,
           "name": "unschedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
         }
       },
       "deviceId": "0",
@@ -2484,7 +2484,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday"
     },
     {
       "apiVersion": 1,
@@ -2501,7 +2501,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:37.908Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.primaryCircuit.sensors.temperature.return"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.primaryCircuit.sensors.temperature.return"
     },
     {
       "apiVersion": 1,
@@ -2523,7 +2523,7 @@
         }
       },
       "timestamp": "2024-05-26T17:04:07.853Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.primaryCircuit.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.primaryCircuit.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -2545,7 +2545,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:14.344Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.secondaryCircuit.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.secondaryCircuit.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -2567,7 +2567,7 @@
         }
       },
       "timestamp": "2024-05-26T17:19:24.536Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.outside"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.outside"
     },
     {
       "apiVersion": 1,
@@ -2589,7 +2589,7 @@
         }
       },
       "timestamp": "2024-05-26T17:19:33.599Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.return"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.return"
     },
     {
       "apiVersion": 1,
@@ -2601,7 +2601,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar"
     },
     {
       "apiVersion": 1,
@@ -2613,7 +2613,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:14.344Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.power.cumulativeProduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.power.cumulativeProduced"
     },
     {
       "apiVersion": 1,
@@ -2625,7 +2625,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:50:07.957Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.power.production"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.power.production"
     },
     {
       "apiVersion": 1,
@@ -2637,7 +2637,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.pumps.circuit"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.pumps.circuit"
     },
     {
       "apiVersion": 1,
@@ -2649,7 +2649,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:14.344Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.collector"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.collector"
     },
     {
       "apiVersion": 1,
@@ -2661,7 +2661,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:14.344Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.dhw"
     },
     {
       "apiVersion": 1,
@@ -2673,7 +2673,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation"
     },
     {
       "apiVersion": 1,
@@ -2685,7 +2685,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.levels.levelFour"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.levels.levelFour"
     },
     {
       "apiVersion": 1,
@@ -2697,7 +2697,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.levels.levelOne"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.levels.levelOne"
     },
     {
       "apiVersion": 1,
@@ -2709,7 +2709,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.levels.levelThree"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.levels.levelThree"
     },
     {
       "apiVersion": 1,
@@ -2721,7 +2721,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.levels.levelTwo"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.levels.levelTwo"
     },
     {
       "apiVersion": 1,
@@ -2733,7 +2733,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -2745,7 +2745,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.standard"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.standard"
     },
     {
       "apiVersion": 1,
@@ -2757,7 +2757,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -2769,7 +2769,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.ventilation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.ventilation"
     },
     {
       "apiVersion": 1,
@@ -2781,7 +2781,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:14.344Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -2797,7 +2797,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -2813,7 +2813,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -2829,7 +2829,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.holiday"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.holiday"
     },
     {
       "apiVersion": 1,
@@ -2845,7 +2845,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:14.344Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelFour"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelFour"
     },
     {
       "apiVersion": 1,
@@ -2861,7 +2861,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:14.344Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelOne"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelOne"
     },
     {
       "apiVersion": 1,
@@ -2877,7 +2877,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:14.344Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelThree"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelThree"
     },
     {
       "apiVersion": 1,
@@ -2893,7 +2893,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:14.344Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelTwo"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelTwo"
     },
     {
       "apiVersion": 1,
@@ -2905,7 +2905,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -2930,7 +2930,7 @@
         }
       },
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.state"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.state"
     },
     {
       "apiVersion": 1,
@@ -2942,7 +2942,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.comfort"
     },
     {
       "apiVersion": 1,
@@ -2954,7 +2954,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.eco"
     },
     {
       "apiVersion": 1,
@@ -2966,7 +2966,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.holiday"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.holiday"
     },
     {
       "apiVersion": 1,
@@ -2978,7 +2978,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-05-26T16:49:01.343Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.schedule"
     }
   ]
 }

--- a/tests/response/Vitocal151A.json
+++ b/tests/response/Vitocal151A.json
@@ -15,7 +15,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.129Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/device.messages.errors.raw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/device.messages.errors.raw"
     },
     {
       "apiVersion": 1,
@@ -37,7 +37,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/device.productIdentification"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/device.productIdentification"
     },
     {
       "apiVersion": 1,
@@ -61,7 +61,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/device.productMatrix"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/device.productMatrix"
     },
     {
       "apiVersion": 1,
@@ -78,7 +78,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.129Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/device.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/device.serial"
     },
     {
       "apiVersion": 1,
@@ -100,7 +100,7 @@
         }
       },
       "timestamp": "2023-08-25T19:59:54.277Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
     },
     {
       "apiVersion": 1,
@@ -117,7 +117,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.133Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
     },
     {
       "apiVersion": 1,
@@ -129,7 +129,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.129Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.buffer.sensors.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.buffer.sensors.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -148,7 +148,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits"
     },
     {
       "apiVersion": 1,
@@ -166,7 +166,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0/commands/setName"
         }
       },
       "deviceId": "0",
@@ -189,7 +189,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0"
     },
     {
       "apiVersion": 1,
@@ -206,7 +206,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -223,7 +223,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -251,7 +251,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve"
         }
       },
       "deviceId": "0",
@@ -272,7 +272,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -296,7 +296,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -372,7 +372,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -390,7 +390,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name/commands/setName"
         }
       },
       "components": [],
@@ -406,7 +406,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name"
     },
     {
       "apiVersion": 1,
@@ -428,7 +428,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
         }
       },
       "deviceId": "0",
@@ -443,7 +443,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -460,7 +460,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.cooling"
     },
     {
       "apiVersion": 1,
@@ -477,7 +477,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -494,7 +494,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heatingCooling"
     },
     {
       "apiVersion": 1,
@@ -511,7 +511,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -528,7 +528,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -547,13 +547,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortCooling/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortCooling/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortCooling/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortCooling/commands/deactivate"
         },
         "setTemperature": {
           "isExecutable": true,
@@ -569,7 +569,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortCooling/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortCooling/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -593,7 +593,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortCooling"
     },
     {
       "apiVersion": 1,
@@ -618,7 +618,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -643,7 +643,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -662,13 +662,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortHeating/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortHeating/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortHeating/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortHeating/commands/deactivate"
         },
         "setTemperature": {
           "isExecutable": true,
@@ -684,7 +684,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortHeating/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortHeating/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -708,7 +708,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortHeating"
     },
     {
       "apiVersion": 1,
@@ -725,7 +725,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.fixed"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.fixed"
     },
     {
       "apiVersion": 1,
@@ -734,13 +734,13 @@
           "isExecutable": false,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule/commands/activate"
         },
         "deactivate": {
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -755,7 +755,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule"
     },
     {
       "apiVersion": 1,
@@ -772,7 +772,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -791,13 +791,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalCooling/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalCooling/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalCooling/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalCooling/commands/deactivate"
         },
         "setTemperature": {
           "isExecutable": true,
@@ -813,7 +813,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalCooling/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalCooling/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -837,7 +837,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalCooling"
     },
     {
       "apiVersion": 1,
@@ -862,7 +862,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -887,7 +887,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -906,13 +906,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalHeating/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalHeating/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalHeating/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalHeating/commands/deactivate"
         },
         "setTemperature": {
           "isExecutable": true,
@@ -928,7 +928,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalHeating/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalHeating/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -952,7 +952,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalHeating"
     },
     {
       "apiVersion": 1,
@@ -971,13 +971,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedCooling/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedCooling/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedCooling/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedCooling/commands/deactivate"
         },
         "setTemperature": {
           "isExecutable": true,
@@ -993,7 +993,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedCooling/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedCooling/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -1017,7 +1017,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedCooling"
     },
     {
       "apiVersion": 1,
@@ -1042,7 +1042,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1067,7 +1067,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1086,13 +1086,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedHeating/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedHeating/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedHeating/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedHeating/commands/deactivate"
         },
         "setTemperature": {
           "isExecutable": true,
@@ -1108,7 +1108,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedHeating/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedHeating/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -1132,7 +1132,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedHeating"
     },
     {
       "apiVersion": 1,
@@ -1149,7 +1149,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1166,7 +1166,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.summerEco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.summerEco"
     },
     {
       "apiVersion": 1,
@@ -1178,7 +1178,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1200,7 +1200,7 @@
         }
       },
       "timestamp": "2023-08-25T19:19:50.453Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1212,7 +1212,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature"
     },
     {
       "apiVersion": 1,
@@ -1229,7 +1229,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.zone.mode"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.zone.mode"
     },
     {
       "apiVersion": 1,
@@ -1241,7 +1241,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1"
     },
     {
       "apiVersion": 1,
@@ -1253,7 +1253,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -1265,7 +1265,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1277,7 +1277,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -1289,7 +1289,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -1302,7 +1302,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-14T19:35:16.096Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.name"
     },
     {
       "apiVersion": 1,
@@ -1314,7 +1314,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -1326,7 +1326,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.cooling"
     },
     {
       "apiVersion": 1,
@@ -1338,7 +1338,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -1350,7 +1350,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heatingCooling"
     },
     {
       "apiVersion": 1,
@@ -1362,7 +1362,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -1374,7 +1374,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1386,7 +1386,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortCooling"
     },
     {
       "apiVersion": 1,
@@ -1398,7 +1398,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1410,7 +1410,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1422,7 +1422,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortHeating"
     },
     {
       "apiVersion": 1,
@@ -1434,7 +1434,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.fixed"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.fixed"
     },
     {
       "apiVersion": 1,
@@ -1446,7 +1446,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule"
     },
     {
       "apiVersion": 1,
@@ -1458,7 +1458,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1470,7 +1470,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalCooling"
     },
     {
       "apiVersion": 1,
@@ -1482,7 +1482,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1494,7 +1494,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1506,7 +1506,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalHeating"
     },
     {
       "apiVersion": 1,
@@ -1518,7 +1518,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedCooling"
     },
     {
       "apiVersion": 1,
@@ -1530,7 +1530,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1555,7 +1555,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1567,7 +1567,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedHeating"
     },
     {
       "apiVersion": 1,
@@ -1579,7 +1579,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1596,7 +1596,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.summerEco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.summerEco"
     },
     {
       "apiVersion": 1,
@@ -1608,7 +1608,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1620,7 +1620,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1632,7 +1632,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature"
     },
     {
       "apiVersion": 1,
@@ -1649,7 +1649,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.zone.mode"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.zone.mode"
     },
     {
       "apiVersion": 1,
@@ -1661,7 +1661,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2"
     },
     {
       "apiVersion": 1,
@@ -1673,7 +1673,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -1685,7 +1685,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1697,7 +1697,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -1709,7 +1709,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -1722,7 +1722,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-14T19:35:16.097Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.name"
     },
     {
       "apiVersion": 1,
@@ -1734,7 +1734,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -1746,7 +1746,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.cooling"
     },
     {
       "apiVersion": 1,
@@ -1758,7 +1758,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -1770,7 +1770,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heatingCooling"
     },
     {
       "apiVersion": 1,
@@ -1782,7 +1782,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -1794,7 +1794,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1806,7 +1806,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortCooling"
     },
     {
       "apiVersion": 1,
@@ -1818,7 +1818,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1830,7 +1830,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1842,7 +1842,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortHeating"
     },
     {
       "apiVersion": 1,
@@ -1854,7 +1854,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.fixed"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.fixed"
     },
     {
       "apiVersion": 1,
@@ -1866,7 +1866,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.forcedLastFromSchedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.forcedLastFromSchedule"
     },
     {
       "apiVersion": 1,
@@ -1878,7 +1878,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1890,7 +1890,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalCooling"
     },
     {
       "apiVersion": 1,
@@ -1902,7 +1902,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1914,7 +1914,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1926,7 +1926,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalHeating"
     },
     {
       "apiVersion": 1,
@@ -1938,7 +1938,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedCooling"
     },
     {
       "apiVersion": 1,
@@ -1950,7 +1950,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1975,7 +1975,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1987,7 +1987,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedHeating"
     },
     {
       "apiVersion": 1,
@@ -1999,7 +1999,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -2016,7 +2016,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.summerEco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.summerEco"
     },
     {
       "apiVersion": 1,
@@ -2028,7 +2028,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -2040,7 +2040,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -2052,7 +2052,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.temperature"
     },
     {
       "apiVersion": 1,
@@ -2069,7 +2069,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.zone.mode"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.zone.mode"
     },
     {
       "apiVersion": 1,
@@ -2081,7 +2081,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3"
     },
     {
       "apiVersion": 1,
@@ -2093,7 +2093,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -2105,7 +2105,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -2117,7 +2117,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -2129,7 +2129,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -2142,7 +2142,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-14T19:35:16.097Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.name"
     },
     {
       "apiVersion": 1,
@@ -2154,7 +2154,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -2166,7 +2166,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.cooling"
     },
     {
       "apiVersion": 1,
@@ -2178,7 +2178,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -2190,7 +2190,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.heatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.heatingCooling"
     },
     {
       "apiVersion": 1,
@@ -2202,7 +2202,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -2214,7 +2214,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -2226,7 +2226,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortCooling"
     },
     {
       "apiVersion": 1,
@@ -2238,7 +2238,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -2250,7 +2250,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -2262,7 +2262,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortHeating"
     },
     {
       "apiVersion": 1,
@@ -2274,7 +2274,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.fixed"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.fixed"
     },
     {
       "apiVersion": 1,
@@ -2286,7 +2286,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.forcedLastFromSchedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.forcedLastFromSchedule"
     },
     {
       "apiVersion": 1,
@@ -2298,7 +2298,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -2310,7 +2310,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalCooling"
     },
     {
       "apiVersion": 1,
@@ -2322,7 +2322,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -2334,7 +2334,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -2346,7 +2346,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalHeating"
     },
     {
       "apiVersion": 1,
@@ -2358,7 +2358,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedCooling"
     },
     {
       "apiVersion": 1,
@@ -2370,7 +2370,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -2395,7 +2395,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -2407,7 +2407,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedHeating"
     },
     {
       "apiVersion": 1,
@@ -2419,7 +2419,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -2436,7 +2436,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.summerEco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.summerEco"
     },
     {
       "apiVersion": 1,
@@ -2448,7 +2448,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -2460,7 +2460,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -2472,7 +2472,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.temperature"
     },
     {
       "apiVersion": 1,
@@ -2489,7 +2489,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.zone.mode"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.zone.mode"
     },
     {
       "apiVersion": 1,
@@ -2508,7 +2508,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.132Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.compressors"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.compressors"
     },
     {
       "apiVersion": 1,
@@ -2529,7 +2529,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.compressors.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.compressors.0"
     },
     {
       "apiVersion": 1,
@@ -2552,7 +2552,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.132Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.compressors.0.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.compressors.0.statistics"
     },
     {
       "apiVersion": 1,
@@ -2573,7 +2573,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw"
     },
     {
       "apiVersion": 1,
@@ -2582,19 +2582,19 @@
           "isExecutable": false,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/activate"
         },
         "disable": {
           "isExecutable": false,
           "name": "disable",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/disable"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/disable"
         },
         "enable": {
           "isExecutable": true,
           "name": "enable",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/enable"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/enable"
         }
       },
       "deviceId": "0",
@@ -2609,7 +2609,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene"
     },
     {
       "apiVersion": 1,
@@ -2621,7 +2621,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene.trigger"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene.trigger"
     },
     {
       "apiVersion": 1,
@@ -2630,13 +2630,13 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/activate"
         },
         "deactivate": {
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -2651,7 +2651,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge"
     },
     {
       "apiVersion": 1,
@@ -2672,7 +2672,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active/commands/setMode"
         }
       },
       "deviceId": "0",
@@ -2687,7 +2687,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.132Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -2699,7 +2699,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.132Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.balanced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.balanced"
     },
     {
       "apiVersion": 1,
@@ -2716,7 +2716,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.132Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.comfort"
     },
     {
       "apiVersion": 1,
@@ -2733,7 +2733,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.132Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.eco"
     },
     {
       "apiVersion": 1,
@@ -2750,7 +2750,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.132Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.off"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.off"
     },
     {
       "apiVersion": 1,
@@ -2762,7 +2762,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
     },
     {
       "apiVersion": 1,
@@ -2774,7 +2774,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
     },
     {
       "apiVersion": 1,
@@ -2786,7 +2786,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.secondary"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.secondary"
     },
     {
       "apiVersion": 1,
@@ -2809,7 +2809,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -2885,7 +2885,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule"
     },
     {
       "apiVersion": 1,
@@ -2907,7 +2907,7 @@
         }
       },
       "timestamp": "2023-08-25T20:12:54.721Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
     },
     {
       "apiVersion": 1,
@@ -2919,7 +2919,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.132Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.middle"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.middle"
     },
     {
       "apiVersion": 1,
@@ -2931,7 +2931,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T20:12:54.721Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.top"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.top"
     },
     {
       "apiVersion": 1,
@@ -2943,7 +2943,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hygiene"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hygiene"
     },
     {
       "apiVersion": 1,
@@ -2962,7 +2962,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresis"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresis"
         },
         "setHysteresisSwitchOffValue": {
           "isExecutable": true,
@@ -2978,7 +2978,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOffValue"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOffValue"
         },
         "setHysteresisSwitchOnValue": {
           "isExecutable": true,
@@ -2994,7 +2994,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOnValue"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOnValue"
         }
       },
       "deviceId": "0",
@@ -3020,7 +3020,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis"
     },
     {
       "apiVersion": 1,
@@ -3048,7 +3048,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.levels"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.levels"
     },
     {
       "apiVersion": 1,
@@ -3069,7 +3069,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
         }
       },
       "deviceId": "0",
@@ -3085,7 +3085,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -3103,7 +3103,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
         },
         "schedule": {
           "isExecutable": true,
@@ -3125,13 +3125,13 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/schedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/schedule"
         },
         "unschedule": {
           "isExecutable": true,
           "name": "unschedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
         }
       },
       "deviceId": "0",
@@ -3154,7 +3154,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday"
     },
     {
       "apiVersion": 1,
@@ -3172,7 +3172,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/changeEndDate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/changeEndDate"
         },
         "schedule": {
           "isExecutable": true,
@@ -3194,13 +3194,13 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/schedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/schedule"
         },
         "unschedule": {
           "isExecutable": true,
           "name": "unschedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/unschedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/unschedule"
         }
       },
       "deviceId": "0",
@@ -3223,7 +3223,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:27.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome"
     },
     {
       "apiVersion": 1,
@@ -3307,7 +3307,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.133Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.cooling"
     },
     {
       "apiVersion": 1,
@@ -3391,7 +3391,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.133Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.dhw"
     },
     {
       "apiVersion": 1,
@@ -3475,7 +3475,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.133Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.heating"
     },
     {
       "apiVersion": 1,
@@ -3518,7 +3518,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.dhw"
     },
     {
       "apiVersion": 1,
@@ -3561,7 +3561,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.heating"
     },
     {
       "apiVersion": 1,
@@ -3645,7 +3645,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.133Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.total"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.total"
     },
     {
       "apiVersion": 1,
@@ -3667,7 +3667,7 @@
         }
       },
       "timestamp": "2023-08-25T20:07:25.911Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.primaryCircuit.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.primaryCircuit.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -3689,7 +3689,7 @@
         }
       },
       "timestamp": "2023-08-25T20:12:59.986Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.secondaryCircuit.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.secondaryCircuit.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -3701,7 +3701,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.hydraulicSeparator"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.hydraulicSeparator"
     },
     {
       "apiVersion": 1,
@@ -3723,7 +3723,7 @@
         }
       },
       "timestamp": "2023-08-25T19:22:01.474Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.outside"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.outside"
     },
     {
       "apiVersion": 1,
@@ -3745,7 +3745,7 @@
         }
       },
       "timestamp": "2023-08-25T20:11:42.336Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.return"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.return"
     },
     {
       "apiVersion": 1,
@@ -3767,7 +3767,7 @@
         }
       },
       "timestamp": "2023-08-25T19:12:31.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.volumetricFlow.allengra"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.volumetricFlow.allengra"
     }
   ]
 }

--- a/tests/response/Vitocal200.json
+++ b/tests/response/Vitocal200.json
@@ -15,7 +15,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.389Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/device.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/device.serial"
     },
     {
       "apiVersion": 1,
@@ -32,7 +32,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.389Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
     },
     {
       "apiVersion": 1,
@@ -49,7 +49,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.389Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.boiler.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.boiler.serial"
     },
     {
       "apiVersion": 1,
@@ -66,7 +66,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.389Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.buffer.sensors.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.buffer.sensors.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -83,7 +83,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.389Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.buffer.sensors.temperature.top"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.buffer.sensors.temperature.top"
     },
     {
       "apiVersion": 1,
@@ -100,7 +100,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.389Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.burners"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.burners"
     },
     {
       "apiVersion": 1,
@@ -112,7 +112,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.burners.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.burners.0"
     },
     {
       "apiVersion": 1,
@@ -124,7 +124,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.burners.0.modulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.burners.0.modulation"
     },
     {
       "apiVersion": 1,
@@ -136,7 +136,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.burners.0.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.burners.0.statistics"
     },
     {
       "apiVersion": 1,
@@ -155,7 +155,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits"
     },
     {
       "apiVersion": 1,
@@ -173,7 +173,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0/commands/setName"
         }
       },
       "deviceId": "0",
@@ -196,7 +196,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.222Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0"
     },
     {
       "apiVersion": 1,
@@ -213,7 +213,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -230,7 +230,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -258,7 +258,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve"
         }
       },
       "deviceId": "0",
@@ -279,7 +279,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.222Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -304,7 +304,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -380,7 +380,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -398,7 +398,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.name/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.name/commands/setName"
         }
       },
       "components": [],
@@ -414,7 +414,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.222Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.name"
     },
     {
       "apiVersion": 1,
@@ -435,7 +435,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
         }
       },
       "deviceId": "0",
@@ -450,7 +450,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.222Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -467,7 +467,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.modes.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.modes.cooling"
     },
     {
       "apiVersion": 1,
@@ -484,7 +484,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -496,7 +496,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -513,7 +513,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeatingCooling"
     },
     {
       "apiVersion": 1,
@@ -530,7 +530,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.modes.forcedNormal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.modes.forcedNormal"
     },
     {
       "apiVersion": 1,
@@ -547,7 +547,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.modes.forcedReduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.modes.forcedReduced"
     },
     {
       "apiVersion": 1,
@@ -559,7 +559,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -571,7 +571,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.391Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.modes.heatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.modes.heatingCooling"
     },
     {
       "apiVersion": 1,
@@ -588,7 +588,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.391Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.modes.normalStandby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.modes.normalStandby"
     },
     {
       "apiVersion": 1,
@@ -605,7 +605,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.391Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -622,7 +622,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.391Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -641,13 +641,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/deactivate"
         },
         "setTemperature": {
           "isExecutable": true,
@@ -663,7 +663,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -687,7 +687,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.222Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -696,13 +696,13 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.programs.eco/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.programs.eco/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.programs.eco/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.programs.eco/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -722,7 +722,7 @@
         }
       },
       "timestamp": "2023-05-12T05:10:37.384Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -739,7 +739,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.391Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.programs.fixed"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.programs.fixed"
     },
     {
       "apiVersion": 1,
@@ -758,7 +758,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -782,7 +782,7 @@
         }
       },
       "timestamp": "2023-05-12T05:10:37.384Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -801,7 +801,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.programs.reduced/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.programs.reduced/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -825,7 +825,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.222Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -842,7 +842,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -864,7 +864,7 @@
         }
       },
       "timestamp": "2023-05-12T18:43:41.663Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -886,7 +886,7 @@
         }
       },
       "timestamp": "2023-05-12T12:39:02.148Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -904,7 +904,7 @@
         }
       },
       "timestamp": "2023-05-12T18:40:52.060Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.temperature"
     },
     {
       "apiVersion": 1,
@@ -932,7 +932,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.temperature.levels/commands/setLevels"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.temperature.levels/commands/setLevels"
         },
         "setMax": {
           "isExecutable": true,
@@ -948,7 +948,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.temperature.levels/commands/setMax"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.temperature.levels/commands/setMax"
         },
         "setMin": {
           "isExecutable": true,
@@ -964,7 +964,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.temperature.levels/commands/setMin"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.temperature.levels/commands/setMin"
         }
       },
       "deviceId": "0",
@@ -993,7 +993,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.222Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.temperature.levels"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.0.temperature.levels"
     },
     {
       "apiVersion": 1,
@@ -1005,7 +1005,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1"
     },
     {
       "apiVersion": 1,
@@ -1017,7 +1017,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -1029,7 +1029,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1057,7 +1057,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.heating.curve/commands/setCurve"
         }
       },
       "deviceId": "0",
@@ -1078,7 +1078,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.222Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -1090,7 +1090,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -1103,7 +1103,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-04T14:50:27.994Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.name"
     },
     {
       "apiVersion": 1,
@@ -1115,7 +1115,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -1127,7 +1127,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.modes.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.modes.cooling"
     },
     {
       "apiVersion": 1,
@@ -1139,7 +1139,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -1151,7 +1151,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -1163,7 +1163,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeatingCooling"
     },
     {
       "apiVersion": 1,
@@ -1175,7 +1175,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.modes.forcedNormal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.modes.forcedNormal"
     },
     {
       "apiVersion": 1,
@@ -1187,7 +1187,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.modes.forcedReduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.modes.forcedReduced"
     },
     {
       "apiVersion": 1,
@@ -1199,7 +1199,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -1211,7 +1211,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.391Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.modes.heatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.modes.heatingCooling"
     },
     {
       "apiVersion": 1,
@@ -1223,7 +1223,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.391Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.modes.normalStandby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.modes.normalStandby"
     },
     {
       "apiVersion": 1,
@@ -1235,7 +1235,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.391Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -1247,7 +1247,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.391Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1259,7 +1259,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.222Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -1271,7 +1271,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -1283,7 +1283,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.391Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.programs.fixed"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.programs.fixed"
     },
     {
       "apiVersion": 1,
@@ -1295,7 +1295,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -1307,7 +1307,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -1319,7 +1319,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1331,7 +1331,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.391Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1343,7 +1343,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.391Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1361,7 +1361,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.391Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.temperature"
     },
     {
       "apiVersion": 1,
@@ -1373,7 +1373,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.temperature.levels"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.1.temperature.levels"
     },
     {
       "apiVersion": 1,
@@ -1385,7 +1385,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2"
     },
     {
       "apiVersion": 1,
@@ -1397,7 +1397,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -1409,7 +1409,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1437,7 +1437,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.heating.curve/commands/setCurve"
         }
       },
       "deviceId": "0",
@@ -1458,7 +1458,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.222Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -1470,7 +1470,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -1483,7 +1483,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-04T14:50:27.998Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.name"
     },
     {
       "apiVersion": 1,
@@ -1495,7 +1495,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -1507,7 +1507,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.modes.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.modes.cooling"
     },
     {
       "apiVersion": 1,
@@ -1519,7 +1519,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -1531,7 +1531,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -1543,7 +1543,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeatingCooling"
     },
     {
       "apiVersion": 1,
@@ -1555,7 +1555,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.modes.forcedNormal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.modes.forcedNormal"
     },
     {
       "apiVersion": 1,
@@ -1567,7 +1567,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.390Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.modes.forcedReduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.modes.forcedReduced"
     },
     {
       "apiVersion": 1,
@@ -1579,7 +1579,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.391Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -1591,7 +1591,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.391Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.modes.heatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.modes.heatingCooling"
     },
     {
       "apiVersion": 1,
@@ -1603,7 +1603,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.391Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.modes.normalStandby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.modes.normalStandby"
     },
     {
       "apiVersion": 1,
@@ -1615,7 +1615,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.391Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -1627,7 +1627,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.391Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1639,7 +1639,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -1651,7 +1651,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -1663,7 +1663,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.391Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.programs.fixed"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.programs.fixed"
     },
     {
       "apiVersion": 1,
@@ -1675,7 +1675,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -1687,7 +1687,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -1699,7 +1699,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1711,7 +1711,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.391Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1723,7 +1723,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.391Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1741,7 +1741,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.392Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.temperature"
     },
     {
       "apiVersion": 1,
@@ -1753,7 +1753,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.temperature.levels"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.circuits.2.temperature.levels"
     },
     {
       "apiVersion": 1,
@@ -1772,7 +1772,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.392Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.compressors"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.compressors"
     },
     {
       "apiVersion": 1,
@@ -1793,7 +1793,7 @@
         }
       },
       "timestamp": "2023-05-12T09:36:10.159Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.compressors.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.compressors.0"
     },
     {
       "apiVersion": 1,
@@ -1841,7 +1841,7 @@
         }
       },
       "timestamp": "2023-05-12T09:22:43.824Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.compressors.0.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.compressors.0.statistics"
     },
     {
       "apiVersion": 1,
@@ -1853,7 +1853,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.compressors.1"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.compressors.1"
     },
     {
       "apiVersion": 1,
@@ -1865,7 +1865,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.392Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.compressors.1.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.compressors.1.statistics"
     },
     {
       "apiVersion": 1,
@@ -1882,7 +1882,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.392Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.controller.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.controller.serial"
     },
     {
       "apiVersion": 1,
@@ -1903,7 +1903,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.393Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw"
     },
     {
       "apiVersion": 1,
@@ -1920,7 +1920,7 @@
         }
       },
       "timestamp": "2023-05-12T09:24:30.772Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.charging"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.charging"
     },
     {
       "apiVersion": 1,
@@ -1929,13 +1929,13 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.oneTimeCharge/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.oneTimeCharge/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -1950,7 +1950,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.oneTimeCharge"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.oneTimeCharge"
     },
     {
       "apiVersion": 1,
@@ -1967,7 +1967,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.393Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.pumps.circulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.pumps.circulation"
     },
     {
       "apiVersion": 1,
@@ -1992,7 +1992,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -2019,7 +2019,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.pumps.circulation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.pumps.circulation.schedule"
     },
     {
       "apiVersion": 1,
@@ -2036,7 +2036,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.393Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.pumps.primary"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.pumps.primary"
     },
     {
       "apiVersion": 1,
@@ -2061,7 +2061,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -2143,7 +2143,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.schedule"
     },
     {
       "apiVersion": 1,
@@ -2165,7 +2165,7 @@
         }
       },
       "timestamp": "2023-05-12T18:37:03.923Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
     },
     {
       "apiVersion": 1,
@@ -2182,7 +2182,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.393Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.bottom"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.bottom"
     },
     {
       "apiVersion": 1,
@@ -2204,7 +2204,7 @@
         }
       },
       "timestamp": "2023-05-12T18:37:03.923Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.top"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.top"
     },
     {
       "apiVersion": 1,
@@ -2221,7 +2221,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.393Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.sensors.temperature.outlet"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.sensors.temperature.outlet"
     },
     {
       "apiVersion": 1,
@@ -2240,7 +2240,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresis"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresis"
         },
         "setHysteresisSwitchOffValue": {
           "isExecutable": true,
@@ -2256,7 +2256,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOffValue"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOffValue"
         },
         "setHysteresisSwitchOnValue": {
           "isExecutable": true,
@@ -2272,7 +2272,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOnValue"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOnValue"
         }
       },
       "deviceId": "0",
@@ -2298,7 +2298,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.temperature.hysteresis"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.temperature.hysteresis"
     },
     {
       "apiVersion": 1,
@@ -2319,7 +2319,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
         }
       },
       "deviceId": "0",
@@ -2335,7 +2335,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.222Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -2354,7 +2354,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.temperature.temp2/commands/setTargetTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.temperature.temp2/commands/setTargetTemperature"
         }
       },
       "deviceId": "0",
@@ -2370,7 +2370,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.temperature.temp2"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.dhw.temperature.temp2"
     },
     {
       "apiVersion": 1,
@@ -2388,7 +2388,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
         },
         "schedule": {
           "isExecutable": true,
@@ -2410,13 +2410,13 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.operating.programs.holiday/commands/schedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.operating.programs.holiday/commands/schedule"
         },
         "unschedule": {
           "isExecutable": true,
           "name": "unschedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
         }
       },
       "deviceId": "0",
@@ -2439,7 +2439,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.operating.programs.holiday"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.operating.programs.holiday"
     },
     {
       "apiVersion": 1,
@@ -2456,7 +2456,7 @@
         }
       },
       "timestamp": "2023-05-11T14:01:17.393Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.primaryCircuit.sensors.temperature.return"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.primaryCircuit.sensors.temperature.return"
     },
     {
       "apiVersion": 1,
@@ -2478,7 +2478,7 @@
         }
       },
       "timestamp": "2023-05-12T18:39:11.581Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.primaryCircuit.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.primaryCircuit.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -2500,7 +2500,7 @@
         }
       },
       "timestamp": "2023-05-12T18:22:29.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.secondaryCircuit.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.secondaryCircuit.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -2522,7 +2522,7 @@
         }
       },
       "timestamp": "2023-05-12T18:25:31.991Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.sensors.temperature.outside"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.sensors.temperature.outside"
     },
     {
       "apiVersion": 1,
@@ -2544,7 +2544,7 @@
         }
       },
       "timestamp": "2023-05-12T18:31:30.745Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.sensors.temperature.return"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.sensors.temperature.return"
     },
     {
       "apiVersion": 1,
@@ -2556,7 +2556,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.394Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.solar"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.solar"
     },
     {
       "apiVersion": 1,
@@ -2568,7 +2568,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.394Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.solar.power.cumulativeProduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.solar.power.cumulativeProduced"
     },
     {
       "apiVersion": 1,
@@ -2580,7 +2580,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.394Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.solar.power.production"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.solar.power.production"
     },
     {
       "apiVersion": 1,
@@ -2592,7 +2592,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.394Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.solar.pumps.circuit"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.solar.pumps.circuit"
     },
     {
       "apiVersion": 1,
@@ -2604,7 +2604,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.394Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.solar.sensors.temperature.collector"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.solar.sensors.temperature.collector"
     },
     {
       "apiVersion": 1,
@@ -2616,7 +2616,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.394Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.solar.sensors.temperature.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/heating.solar.sensors.temperature.dhw"
     },
     {
       "apiVersion": 1,
@@ -2628,7 +2628,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.394Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/ventilation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/ventilation"
     },
     {
       "apiVersion": 1,
@@ -2640,7 +2640,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/ventilation.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/ventilation.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -2652,7 +2652,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.394Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/ventilation.operating.modes.standard"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/ventilation.operating.modes.standard"
     },
     {
       "apiVersion": 1,
@@ -2664,7 +2664,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.394Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/ventilation.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/ventilation.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -2676,7 +2676,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.394Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/ventilation.operating.modes.ventilation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/ventilation.operating.modes.ventilation"
     },
     {
       "apiVersion": 1,
@@ -2688,7 +2688,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.394Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/ventilation.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/ventilation.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -2700,7 +2700,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/ventilation.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/ventilation.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -2712,7 +2712,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/ventilation.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/ventilation.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -2724,7 +2724,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.221Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/ventilation.operating.programs.holiday"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/ventilation.operating.programs.holiday"
     },
     {
       "apiVersion": 1,
@@ -2736,7 +2736,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.394Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/ventilation.operating.programs.levelFour"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/ventilation.operating.programs.levelFour"
     },
     {
       "apiVersion": 1,
@@ -2748,7 +2748,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.394Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/ventilation.operating.programs.levelOne"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/ventilation.operating.programs.levelOne"
     },
     {
       "apiVersion": 1,
@@ -2760,7 +2760,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.394Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/ventilation.operating.programs.levelThree"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/ventilation.operating.programs.levelThree"
     },
     {
       "apiVersion": 1,
@@ -2772,7 +2772,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.394Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/ventilation.operating.programs.levelTwo"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/ventilation.operating.programs.levelTwo"
     },
     {
       "apiVersion": 1,
@@ -2784,7 +2784,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.394Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/ventilation.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/ventilation.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -2796,7 +2796,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-05-11T14:01:17.222Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/ventilation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/XXXXXX/gateways/XXXXXX/devices/0/features/ventilation.schedule"
     }
   ]
 }

--- a/tests/response/Vitocal200S_E8NEV.json
+++ b/tests/response/Vitocal200S_E8NEV.json
@@ -15,7 +15,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:33.442Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/device.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/device.serial"
     },
     {
       "apiVersion": 1,
@@ -37,7 +37,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:39.520Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
     },
     {
       "apiVersion": 1,
@@ -54,7 +54,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:33.445Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
     },
     {
       "apiVersion": 1,
@@ -66,7 +66,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:33.442Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.buffer.sensors.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.buffer.sensors.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -85,7 +85,7 @@
         }
       },
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits"
     },
     {
       "apiVersion": 1,
@@ -103,7 +103,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0/commands/setName"
         }
       },
       "deviceId": "0",
@@ -126,7 +126,7 @@
         }
       },
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0"
     },
     {
       "apiVersion": 1,
@@ -143,7 +143,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:33.442Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -160,7 +160,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:33.442Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -188,7 +188,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve"
         }
       },
       "deviceId": "0",
@@ -209,7 +209,7 @@
         }
       },
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -233,7 +233,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -309,7 +309,7 @@
         }
       },
       "timestamp": "2023-03-15T06:22:55.292Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -327,7 +327,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name/commands/setName"
         }
       },
       "components": [],
@@ -343,7 +343,7 @@
         }
       },
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name"
     },
     {
       "apiVersion": 1,
@@ -363,7 +363,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
         }
       },
       "deviceId": "0",
@@ -378,7 +378,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:34.508Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -390,7 +390,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.cooling"
     },
     {
       "apiVersion": 1,
@@ -407,7 +407,7 @@
         }
       },
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -419,7 +419,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heatingCooling"
     },
     {
       "apiVersion": 1,
@@ -436,7 +436,7 @@
         }
       },
       "timestamp": "2023-03-15T06:22:55.292Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -453,7 +453,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:33.443Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -465,7 +465,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortCooling"
     },
     {
       "apiVersion": 1,
@@ -490,7 +490,7 @@
         }
       },
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -515,7 +515,7 @@
         }
       },
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -534,13 +534,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortHeating/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortHeating/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortHeating/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortHeating/commands/deactivate"
         },
         "setTemperature": {
           "isExecutable": true,
@@ -556,7 +556,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortHeating/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortHeating/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -580,7 +580,7 @@
         }
       },
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortHeating"
     },
     {
       "apiVersion": 1,
@@ -597,7 +597,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:33.443Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.fixed"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.fixed"
     },
     {
       "apiVersion": 1,
@@ -606,13 +606,13 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -627,7 +627,7 @@
         }
       },
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule"
     },
     {
       "apiVersion": 1,
@@ -644,7 +644,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:33.443Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -656,7 +656,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalCooling"
     },
     {
       "apiVersion": 1,
@@ -681,7 +681,7 @@
         }
       },
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -706,7 +706,7 @@
         }
       },
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -725,13 +725,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalHeating/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalHeating/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalHeating/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalHeating/commands/deactivate"
         },
         "setTemperature": {
           "isExecutable": true,
@@ -747,7 +747,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalHeating/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalHeating/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -771,7 +771,7 @@
         }
       },
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalHeating"
     },
     {
       "apiVersion": 1,
@@ -783,7 +783,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedCooling"
     },
     {
       "apiVersion": 1,
@@ -808,7 +808,7 @@
         }
       },
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -833,7 +833,7 @@
         }
       },
       "timestamp": "2023-03-15T06:22:55.292Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -852,13 +852,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedHeating/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedHeating/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedHeating/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedHeating/commands/deactivate"
         },
         "setTemperature": {
           "isExecutable": true,
@@ -874,7 +874,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedHeating/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedHeating/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -898,7 +898,7 @@
         }
       },
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedHeating"
     },
     {
       "apiVersion": 1,
@@ -915,7 +915,7 @@
         }
       },
       "timestamp": "2023-03-15T06:22:55.292Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -932,7 +932,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:33.442Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.summerEco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.summerEco"
     },
     {
       "apiVersion": 1,
@@ -944,7 +944,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:33.442Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -966,7 +966,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:39.520Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -978,7 +978,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:33.442Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature"
     },
     {
       "apiVersion": 1,
@@ -995,7 +995,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:33.442Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.zone.mode"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.zone.mode"
     },
     {
       "apiVersion": 1,
@@ -1007,7 +1007,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1"
     },
     {
       "apiVersion": 1,
@@ -1019,7 +1019,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:33.442Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -1031,7 +1031,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:33.442Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1043,7 +1043,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.292Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -1055,7 +1055,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -1068,7 +1068,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-10-01T01:26:13.488Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.name"
     },
     {
       "apiVersion": 1,
@@ -1080,7 +1080,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:34.523Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -1092,7 +1092,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.cooling"
     },
     {
       "apiVersion": 1,
@@ -1104,7 +1104,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -1116,7 +1116,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heatingCooling"
     },
     {
       "apiVersion": 1,
@@ -1128,7 +1128,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -1140,7 +1140,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:33.443Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1152,7 +1152,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortCooling"
     },
     {
       "apiVersion": 1,
@@ -1164,7 +1164,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1176,7 +1176,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.292Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1188,7 +1188,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortHeating"
     },
     {
       "apiVersion": 1,
@@ -1200,7 +1200,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:33.443Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.fixed"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.fixed"
     },
     {
       "apiVersion": 1,
@@ -1212,7 +1212,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.292Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule"
     },
     {
       "apiVersion": 1,
@@ -1224,7 +1224,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:33.443Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1236,7 +1236,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalCooling"
     },
     {
       "apiVersion": 1,
@@ -1248,7 +1248,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.292Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1260,7 +1260,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1272,7 +1272,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.292Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalHeating"
     },
     {
       "apiVersion": 1,
@@ -1284,7 +1284,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedCooling"
     },
     {
       "apiVersion": 1,
@@ -1296,7 +1296,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1321,7 +1321,7 @@
         }
       },
       "timestamp": "2023-03-15T06:22:55.292Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1333,7 +1333,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedHeating"
     },
     {
       "apiVersion": 1,
@@ -1345,7 +1345,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1362,7 +1362,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:33.442Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.summerEco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.summerEco"
     },
     {
       "apiVersion": 1,
@@ -1374,7 +1374,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:33.442Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1386,7 +1386,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:33.442Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1398,7 +1398,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:33.442Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature"
     },
     {
       "apiVersion": 1,
@@ -1415,7 +1415,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:33.442Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.zone.mode"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.zone.mode"
     },
     {
       "apiVersion": 1,
@@ -1427,7 +1427,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2"
     },
     {
       "apiVersion": 1,
@@ -1439,7 +1439,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:33.442Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -1451,7 +1451,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:33.442Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1463,7 +1463,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.292Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -1475,7 +1475,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -1488,7 +1488,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-10-01T01:26:13.494Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.name"
     },
     {
       "apiVersion": 1,
@@ -1500,7 +1500,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:34.535Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -1512,7 +1512,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.cooling"
     },
     {
       "apiVersion": 1,
@@ -1524,7 +1524,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.292Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -1536,7 +1536,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.292Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heatingCooling"
     },
     {
       "apiVersion": 1,
@@ -1548,7 +1548,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -1560,7 +1560,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:33.443Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1572,7 +1572,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortCooling"
     },
     {
       "apiVersion": 1,
@@ -1584,7 +1584,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1596,7 +1596,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.292Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1608,7 +1608,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.292Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortHeating"
     },
     {
       "apiVersion": 1,
@@ -1620,7 +1620,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:33.443Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.fixed"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.fixed"
     },
     {
       "apiVersion": 1,
@@ -1632,7 +1632,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.292Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.forcedLastFromSchedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.forcedLastFromSchedule"
     },
     {
       "apiVersion": 1,
@@ -1644,7 +1644,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:33.443Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1656,7 +1656,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalCooling"
     },
     {
       "apiVersion": 1,
@@ -1668,7 +1668,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1680,7 +1680,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1692,7 +1692,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalHeating"
     },
     {
       "apiVersion": 1,
@@ -1704,7 +1704,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.292Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedCooling"
     },
     {
       "apiVersion": 1,
@@ -1716,7 +1716,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1741,7 +1741,7 @@
         }
       },
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1753,7 +1753,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedHeating"
     },
     {
       "apiVersion": 1,
@@ -1765,7 +1765,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1782,7 +1782,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:33.442Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.summerEco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.summerEco"
     },
     {
       "apiVersion": 1,
@@ -1794,7 +1794,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:33.442Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1806,7 +1806,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:33.442Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1818,7 +1818,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:33.442Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.temperature"
     },
     {
       "apiVersion": 1,
@@ -1835,7 +1835,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:33.442Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.zone.mode"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.zone.mode"
     },
     {
       "apiVersion": 1,
@@ -1847,7 +1847,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.292Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3"
     },
     {
       "apiVersion": 1,
@@ -1859,7 +1859,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:33.442Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -1871,7 +1871,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:33.442Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1883,7 +1883,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.292Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -1895,7 +1895,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -1908,7 +1908,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-10-01T01:26:13.497Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.name"
     },
     {
       "apiVersion": 1,
@@ -1920,7 +1920,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:34.549Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -1932,7 +1932,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.cooling"
     },
     {
       "apiVersion": 1,
@@ -1944,7 +1944,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -1956,7 +1956,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.heatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.heatingCooling"
     },
     {
       "apiVersion": 1,
@@ -1968,7 +1968,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.292Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -1980,7 +1980,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:33.443Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1992,7 +1992,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.292Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortCooling"
     },
     {
       "apiVersion": 1,
@@ -2004,7 +2004,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -2016,7 +2016,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -2028,7 +2028,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.292Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortHeating"
     },
     {
       "apiVersion": 1,
@@ -2040,7 +2040,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:33.443Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.fixed"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.fixed"
     },
     {
       "apiVersion": 1,
@@ -2052,7 +2052,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.forcedLastFromSchedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.forcedLastFromSchedule"
     },
     {
       "apiVersion": 1,
@@ -2064,7 +2064,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:33.443Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -2076,7 +2076,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalCooling"
     },
     {
       "apiVersion": 1,
@@ -2088,7 +2088,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.292Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -2100,7 +2100,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -2112,7 +2112,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalHeating"
     },
     {
       "apiVersion": 1,
@@ -2124,7 +2124,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedCooling"
     },
     {
       "apiVersion": 1,
@@ -2136,7 +2136,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -2161,7 +2161,7 @@
         }
       },
       "timestamp": "2023-03-15T06:22:55.292Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -2173,7 +2173,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedHeating"
     },
     {
       "apiVersion": 1,
@@ -2185,7 +2185,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -2202,7 +2202,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:33.442Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.summerEco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.summerEco"
     },
     {
       "apiVersion": 1,
@@ -2214,7 +2214,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:33.442Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -2226,7 +2226,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:33.442Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -2238,7 +2238,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:33.442Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.temperature"
     },
     {
       "apiVersion": 1,
@@ -2255,7 +2255,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:33.442Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.zone.mode"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.zone.mode"
     },
     {
       "apiVersion": 1,
@@ -2274,7 +2274,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:33.443Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.compressors"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.compressors"
     },
     {
       "apiVersion": 1,
@@ -2295,7 +2295,7 @@
         }
       },
       "timestamp": "2023-03-16T13:12:53.008Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.compressors.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.compressors.0"
     },
     {
       "apiVersion": 1,
@@ -2318,7 +2318,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:33.444Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.compressors.0.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.compressors.0.statistics"
     },
     {
       "apiVersion": 1,
@@ -2339,7 +2339,7 @@
         }
       },
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw"
     },
     {
       "apiVersion": 1,
@@ -2348,19 +2348,19 @@
           "isExecutable": false,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/activate"
         },
         "disable": {
           "isExecutable": false,
           "name": "disable",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/disable"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/disable"
         },
         "enable": {
           "isExecutable": true,
           "name": "enable",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/enable"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/enable"
         }
       },
       "deviceId": "0",
@@ -2375,7 +2375,7 @@
         }
       },
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene"
     },
     {
       "apiVersion": 1,
@@ -2387,7 +2387,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene.trigger"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene.trigger"
     },
     {
       "apiVersion": 1,
@@ -2396,13 +2396,13 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -2417,7 +2417,7 @@
         }
       },
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge"
     },
     {
       "apiVersion": 1,
@@ -2438,7 +2438,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active/commands/setMode"
         }
       },
       "deviceId": "0",
@@ -2453,7 +2453,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:33.444Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -2465,7 +2465,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:33.444Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.balanced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.balanced"
     },
     {
       "apiVersion": 1,
@@ -2482,7 +2482,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:33.444Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.comfort"
     },
     {
       "apiVersion": 1,
@@ -2499,7 +2499,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:33.444Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.eco"
     },
     {
       "apiVersion": 1,
@@ -2516,7 +2516,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:33.444Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.off"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.off"
     },
     {
       "apiVersion": 1,
@@ -2528,7 +2528,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:33.443Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
     },
     {
       "apiVersion": 1,
@@ -2540,7 +2540,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
     },
     {
       "apiVersion": 1,
@@ -2563,7 +2563,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -2639,7 +2639,7 @@
         }
       },
       "timestamp": "2023-03-15T06:22:55.292Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule"
     },
     {
       "apiVersion": 1,
@@ -2661,7 +2661,7 @@
         }
       },
       "timestamp": "2023-03-16T15:43:55.466Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
     },
     {
       "apiVersion": 1,
@@ -2673,7 +2673,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hygiene"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hygiene"
     },
     {
       "apiVersion": 1,
@@ -2692,7 +2692,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresis"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresis"
         },
         "setHysteresisSwitchOffValue": {
           "isExecutable": true,
@@ -2708,7 +2708,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOffValue"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOffValue"
         },
         "setHysteresisSwitchOnValue": {
           "isExecutable": true,
@@ -2724,7 +2724,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOnValue"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOnValue"
         }
       },
       "deviceId": "0",
@@ -2750,7 +2750,7 @@
         }
       },
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis"
     },
     {
       "apiVersion": 1,
@@ -2778,7 +2778,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:33.443Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.levels"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.levels"
     },
     {
       "apiVersion": 1,
@@ -2799,7 +2799,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
         }
       },
       "deviceId": "0",
@@ -2815,7 +2815,7 @@
         }
       },
       "timestamp": "2023-03-15T11:12:10.865Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -2833,7 +2833,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
         },
         "schedule": {
           "isExecutable": true,
@@ -2855,13 +2855,13 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/schedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/schedule"
         },
         "unschedule": {
           "isExecutable": true,
           "name": "unschedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
         }
       },
       "deviceId": "0",
@@ -2884,7 +2884,7 @@
         }
       },
       "timestamp": "2023-03-15T06:22:55.291Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday"
     },
     {
       "apiVersion": 1,
@@ -2902,7 +2902,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/changeEndDate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/changeEndDate"
         },
         "schedule": {
           "isExecutable": true,
@@ -2924,13 +2924,13 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/schedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/schedule"
         },
         "unschedule": {
           "isExecutable": true,
           "name": "unschedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/unschedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/unschedule"
         }
       },
       "deviceId": "0",
@@ -2953,7 +2953,7 @@
         }
       },
       "timestamp": "2023-03-15T06:22:55.292Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome"
     },
     {
       "apiVersion": 1,
@@ -3035,7 +3035,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:39.521Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.dhw"
     },
     {
       "apiVersion": 1,
@@ -3117,7 +3117,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:39.521Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.heating"
     },
     {
       "apiVersion": 1,
@@ -3160,7 +3160,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:33.443Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.dhw"
     },
     {
       "apiVersion": 1,
@@ -3203,7 +3203,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:33.443Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.heating"
     },
     {
       "apiVersion": 1,
@@ -3285,7 +3285,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:39.521Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.total"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.total"
     },
     {
       "apiVersion": 1,
@@ -3307,7 +3307,7 @@
         }
       },
       "timestamp": "2023-03-16T15:43:49.806Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.primaryCircuit.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.primaryCircuit.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -3329,7 +3329,7 @@
         }
       },
       "timestamp": "2023-03-16T15:43:42.367Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.secondaryCircuit.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.secondaryCircuit.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -3341,7 +3341,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-03-16T15:29:33.443Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.hydraulicSeparator"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.hydraulicSeparator"
     },
     {
       "apiVersion": 1,
@@ -3363,7 +3363,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:39.521Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.outside"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.outside"
     },
     {
       "apiVersion": 1,
@@ -3385,7 +3385,7 @@
         }
       },
       "timestamp": "2023-03-16T15:43:39.039Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.return"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.return"
     },
     {
       "apiVersion": 1,
@@ -3407,7 +3407,7 @@
         }
       },
       "timestamp": "2023-03-16T15:29:39.521Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.volumetricFlow.allengra"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.volumetricFlow.allengra"
     }
   ]
 }

--- a/tests/response/Vitocal250A.json
+++ b/tests/response/Vitocal250A.json
@@ -15,7 +15,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.messages.errors.raw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.messages.errors.raw"
     },
     {
       "apiVersion": 1,
@@ -37,7 +37,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.productIdentification"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.productIdentification"
     },
     {
       "apiVersion": 1,
@@ -67,7 +67,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.productMatrix"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.productMatrix"
     },
     {
       "apiVersion": 1,
@@ -84,7 +84,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.serial"
     },
     {
       "apiVersion": 1,
@@ -106,7 +106,7 @@
         }
       },
       "timestamp": "2024-10-01T16:28:33.694Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
     },
     {
       "apiVersion": 1,
@@ -123,7 +123,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
     },
     {
       "apiVersion": 1,
@@ -149,7 +149,7 @@
         }
       },
       "timestamp": "2024-10-01T16:28:33.694Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.buffer.sensors.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.buffer.sensors.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -171,7 +171,7 @@
         }
       },
       "timestamp": "2024-10-01T16:28:33.694Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.bufferCylinder.sensors.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.bufferCylinder.sensors.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -190,7 +190,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits"
     },
     {
       "apiVersion": 1,
@@ -202,7 +202,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0"
     },
     {
       "apiVersion": 1,
@@ -214,7 +214,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T16:09:57.180Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -226,7 +226,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -238,7 +238,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -250,7 +250,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -262,7 +262,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -274,7 +274,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.cooling"
     },
     {
       "apiVersion": 1,
@@ -286,7 +286,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -298,7 +298,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heatingCooling"
     },
     {
       "apiVersion": 1,
@@ -310,7 +310,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -322,7 +322,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:26.264Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -334,7 +334,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortCooling"
     },
     {
       "apiVersion": 1,
@@ -346,7 +346,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -358,7 +358,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -370,7 +370,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortHeating"
     },
     {
       "apiVersion": 1,
@@ -382,7 +382,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -394,7 +394,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.fixed"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.fixed"
     },
     {
       "apiVersion": 1,
@@ -406,7 +406,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule"
     },
     {
       "apiVersion": 1,
@@ -418,7 +418,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -430,7 +430,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalCooling"
     },
     {
       "apiVersion": 1,
@@ -442,7 +442,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -454,7 +454,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -466,7 +466,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalHeating"
     },
     {
       "apiVersion": 1,
@@ -478,7 +478,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedCooling"
     },
     {
       "apiVersion": 1,
@@ -490,7 +490,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -502,7 +502,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -514,7 +514,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedHeating"
     },
     {
       "apiVersion": 1,
@@ -526,7 +526,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -542,7 +542,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.summerEco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.summerEco"
     },
     {
       "apiVersion": 1,
@@ -554,7 +554,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:26.264Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.remoteController"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.remoteController"
     },
     {
       "apiVersion": 1,
@@ -566,7 +566,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -578,7 +578,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -590,7 +590,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature"
     },
     {
       "apiVersion": 1,
@@ -602,7 +602,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:26.264Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels"
     },
     {
       "apiVersion": 1,
@@ -614,7 +614,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:26.264Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.zone.mode"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.zone.mode"
     },
     {
       "apiVersion": 1,
@@ -632,7 +632,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1/commands/setName"
         }
       },
       "deviceId": "0",
@@ -655,7 +655,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1"
     },
     {
       "apiVersion": 1,
@@ -672,7 +672,7 @@
         }
       },
       "timestamp": "2024-10-01T16:09:57.180Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -689,7 +689,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -717,7 +717,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve/commands/setCurve"
         }
       },
       "deviceId": "0",
@@ -738,7 +738,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -747,7 +747,7 @@
           "isExecutable": true,
           "name": "resetSchedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule/commands/resetSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule/commands/resetSchedule"
         },
         "setSchedule": {
           "isExecutable": true,
@@ -768,7 +768,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -844,7 +844,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -862,7 +862,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.name/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.name/commands/setName"
         }
       },
       "components": [],
@@ -878,7 +878,7 @@
         }
       },
       "timestamp": "2024-09-20T08:56:49.795Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.name"
     },
     {
       "apiVersion": 1,
@@ -898,7 +898,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active/commands/setMode"
         }
       },
       "deviceId": "0",
@@ -913,7 +913,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -925,7 +925,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.cooling"
     },
     {
       "apiVersion": 1,
@@ -942,7 +942,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -954,7 +954,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heatingCooling"
     },
     {
       "apiVersion": 1,
@@ -971,7 +971,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -988,7 +988,7 @@
         }
       },
       "timestamp": "2024-10-01T03:59:26.407Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1000,7 +1000,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortCooling"
     },
     {
       "apiVersion": 1,
@@ -1025,7 +1025,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1050,7 +1050,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1069,13 +1069,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortHeating/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortHeating/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortHeating/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortHeating/commands/deactivate"
         },
         "setTemperature": {
           "isExecutable": true,
@@ -1091,7 +1091,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortHeating/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortHeating/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -1115,7 +1115,7 @@
         }
       },
       "timestamp": "2024-10-01T03:59:26.407Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortHeating"
     },
     {
       "apiVersion": 1,
@@ -1132,7 +1132,7 @@
         }
       },
       "timestamp": "2024-10-01T03:59:26.407Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -1149,7 +1149,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.fixed"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.fixed"
     },
     {
       "apiVersion": 1,
@@ -1158,13 +1158,13 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule/commands/activate"
         },
         "deactivate": {
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -1179,7 +1179,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule"
     },
     {
       "apiVersion": 1,
@@ -1196,7 +1196,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1208,7 +1208,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalCooling"
     },
     {
       "apiVersion": 1,
@@ -1233,7 +1233,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1258,7 +1258,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1277,13 +1277,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalHeating/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalHeating/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalHeating/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalHeating/commands/deactivate"
         },
         "setTemperature": {
           "isExecutable": true,
@@ -1299,7 +1299,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalHeating/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalHeating/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -1323,7 +1323,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalHeating"
     },
     {
       "apiVersion": 1,
@@ -1335,7 +1335,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedCooling"
     },
     {
       "apiVersion": 1,
@@ -1360,7 +1360,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1385,7 +1385,7 @@
         }
       },
       "timestamp": "2024-10-01T03:59:26.407Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1404,13 +1404,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedHeating/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedHeating/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedHeating/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedHeating/commands/deactivate"
         },
         "setTemperature": {
           "isExecutable": true,
@@ -1426,7 +1426,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedHeating/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedHeating/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -1450,7 +1450,7 @@
         }
       },
       "timestamp": "2024-10-01T03:59:26.407Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedHeating"
     },
     {
       "apiVersion": 1,
@@ -1467,7 +1467,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1488,7 +1488,7 @@
         }
       },
       "timestamp": "2024-10-01T03:59:26.407Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.summerEco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.summerEco"
     },
     {
       "apiVersion": 1,
@@ -1497,7 +1497,7 @@
           "isExecutable": false,
           "name": "removeZigbeeController",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.remoteController/commands/removeZigbeeController"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.remoteController/commands/removeZigbeeController"
         },
         "setZigbeeController": {
           "isExecutable": true,
@@ -1511,7 +1511,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.remoteController/commands/setZigbeeController"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.remoteController/commands/setZigbeeController"
         }
       },
       "deviceId": "0",
@@ -1521,7 +1521,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:26.264Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.remoteController"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.remoteController"
     },
     {
       "apiVersion": 1,
@@ -1543,7 +1543,7 @@
         }
       },
       "timestamp": "2024-10-01T16:05:52.313Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1565,7 +1565,7 @@
         }
       },
       "timestamp": "2024-10-01T16:28:40.965Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1577,7 +1577,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T16:26:48.295Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature"
     },
     {
       "apiVersion": 1,
@@ -1605,7 +1605,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature.levels/commands/setLevels"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature.levels/commands/setLevels"
         },
         "setMax": {
           "isExecutable": true,
@@ -1621,7 +1621,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature.levels/commands/setMax"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature.levels/commands/setMax"
         },
         "setMin": {
           "isExecutable": true,
@@ -1637,7 +1637,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature.levels/commands/setMin"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature.levels/commands/setMin"
         }
       },
       "deviceId": "0",
@@ -1658,7 +1658,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:26.264Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature.levels"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature.levels"
     },
     {
       "apiVersion": 1,
@@ -1675,7 +1675,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:26.264Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.zone.mode"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.zone.mode"
     },
     {
       "apiVersion": 1,
@@ -1687,7 +1687,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2"
     },
     {
       "apiVersion": 1,
@@ -1699,7 +1699,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T16:09:57.180Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -1711,7 +1711,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1723,7 +1723,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -1735,7 +1735,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -1747,7 +1747,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -1759,7 +1759,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.cooling"
     },
     {
       "apiVersion": 1,
@@ -1771,7 +1771,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -1783,7 +1783,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heatingCooling"
     },
     {
       "apiVersion": 1,
@@ -1795,7 +1795,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -1807,7 +1807,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:26.264Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1819,7 +1819,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortCooling"
     },
     {
       "apiVersion": 1,
@@ -1831,7 +1831,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1843,7 +1843,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1855,7 +1855,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortHeating"
     },
     {
       "apiVersion": 1,
@@ -1867,7 +1867,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -1879,7 +1879,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.fixed"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.fixed"
     },
     {
       "apiVersion": 1,
@@ -1891,7 +1891,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.forcedLastFromSchedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.forcedLastFromSchedule"
     },
     {
       "apiVersion": 1,
@@ -1903,7 +1903,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1915,7 +1915,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalCooling"
     },
     {
       "apiVersion": 1,
@@ -1927,7 +1927,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1939,7 +1939,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1951,7 +1951,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalHeating"
     },
     {
       "apiVersion": 1,
@@ -1963,7 +1963,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedCooling"
     },
     {
       "apiVersion": 1,
@@ -1975,7 +1975,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1987,7 +1987,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1999,7 +1999,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedHeating"
     },
     {
       "apiVersion": 1,
@@ -2011,7 +2011,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -2027,7 +2027,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.summerEco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.summerEco"
     },
     {
       "apiVersion": 1,
@@ -2039,7 +2039,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:26.264Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.remoteController"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.remoteController"
     },
     {
       "apiVersion": 1,
@@ -2051,7 +2051,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -2063,7 +2063,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -2075,7 +2075,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.temperature"
     },
     {
       "apiVersion": 1,
@@ -2087,7 +2087,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:26.264Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.temperature.levels"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.temperature.levels"
     },
     {
       "apiVersion": 1,
@@ -2099,7 +2099,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:26.264Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.zone.mode"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.zone.mode"
     },
     {
       "apiVersion": 1,
@@ -2111,7 +2111,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3"
     },
     {
       "apiVersion": 1,
@@ -2123,7 +2123,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T16:09:57.180Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -2135,7 +2135,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -2147,7 +2147,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -2159,7 +2159,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -2171,7 +2171,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -2183,7 +2183,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.cooling"
     },
     {
       "apiVersion": 1,
@@ -2195,7 +2195,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -2207,7 +2207,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.heatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.heatingCooling"
     },
     {
       "apiVersion": 1,
@@ -2219,7 +2219,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -2231,7 +2231,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:26.264Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -2243,7 +2243,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortCooling"
     },
     {
       "apiVersion": 1,
@@ -2255,7 +2255,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -2267,7 +2267,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -2279,7 +2279,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortHeating"
     },
     {
       "apiVersion": 1,
@@ -2291,7 +2291,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -2303,7 +2303,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.fixed"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.fixed"
     },
     {
       "apiVersion": 1,
@@ -2315,7 +2315,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.forcedLastFromSchedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.forcedLastFromSchedule"
     },
     {
       "apiVersion": 1,
@@ -2327,7 +2327,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -2339,7 +2339,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalCooling"
     },
     {
       "apiVersion": 1,
@@ -2351,7 +2351,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -2363,7 +2363,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -2375,7 +2375,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalHeating"
     },
     {
       "apiVersion": 1,
@@ -2387,7 +2387,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedCooling"
     },
     {
       "apiVersion": 1,
@@ -2399,7 +2399,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -2411,7 +2411,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -2423,7 +2423,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedHeating"
     },
     {
       "apiVersion": 1,
@@ -2435,7 +2435,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -2451,7 +2451,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.summerEco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.summerEco"
     },
     {
       "apiVersion": 1,
@@ -2463,7 +2463,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:26.264Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.remoteController"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.remoteController"
     },
     {
       "apiVersion": 1,
@@ -2475,7 +2475,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -2487,7 +2487,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -2499,7 +2499,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.temperature"
     },
     {
       "apiVersion": 1,
@@ -2511,7 +2511,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:26.264Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.temperature.levels"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.temperature.levels"
     },
     {
       "apiVersion": 1,
@@ -2523,7 +2523,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:26.264Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.zone.mode"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.zone.mode"
     },
     {
       "apiVersion": 1,
@@ -2542,7 +2542,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors"
     },
     {
       "apiVersion": 1,
@@ -2563,7 +2563,7 @@
         }
       },
       "timestamp": "2024-10-01T16:12:14.713Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0"
     },
     {
       "apiVersion": 1,
@@ -2585,7 +2585,7 @@
         }
       },
       "timestamp": "2024-10-01T16:28:29.219Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0.heat.production.current"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0.heat.production.current"
     },
     {
       "apiVersion": 1,
@@ -2597,7 +2597,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:26.264Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0.power.consumption.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0.power.consumption.cooling"
     },
     {
       "apiVersion": 1,
@@ -2619,7 +2619,7 @@
         }
       },
       "timestamp": "2024-10-01T16:28:29.219Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0.power.consumption.current"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0.power.consumption.current"
     },
     {
       "apiVersion": 1,
@@ -2700,7 +2700,7 @@
         }
       },
       "timestamp": "2024-10-01T12:18:26.686Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0.power.consumption.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0.power.consumption.dhw"
     },
     {
       "apiVersion": 1,
@@ -2781,7 +2781,7 @@
         }
       },
       "timestamp": "2024-10-01T16:27:05.568Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0.power.consumption.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0.power.consumption.heating"
     },
     {
       "apiVersion": 1,
@@ -2862,7 +2862,7 @@
         }
       },
       "timestamp": "2024-10-01T16:27:05.568Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0.power.consumption.total"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0.power.consumption.total"
     },
     {
       "apiVersion": 1,
@@ -2885,7 +2885,7 @@
         }
       },
       "timestamp": "2024-10-01T16:12:54.682Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0.statistics"
     },
     {
       "apiVersion": 1,
@@ -2902,7 +2902,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.device.variant"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.device.variant"
     },
     {
       "apiVersion": 1,
@@ -2923,7 +2923,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw"
     },
     {
       "apiVersion": 1,
@@ -2932,19 +2932,19 @@
           "isExecutable": false,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/activate"
         },
         "disable": {
           "isExecutable": false,
           "name": "disable",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/disable"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/disable"
         },
         "enable": {
           "isExecutable": true,
           "name": "enable",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/enable"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/enable"
         }
       },
       "deviceId": "0",
@@ -2959,7 +2959,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:26.264Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene"
     },
     {
       "apiVersion": 1,
@@ -2971,7 +2971,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene.trigger"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene.trigger"
     },
     {
       "apiVersion": 1,
@@ -2980,13 +2980,13 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/activate"
         },
         "deactivate": {
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -3001,7 +3001,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge"
     },
     {
       "apiVersion": 1,
@@ -3022,7 +3022,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active/commands/setMode"
         }
       },
       "deviceId": "0",
@@ -3037,7 +3037,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:26.139Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -3049,7 +3049,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.balanced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.balanced"
     },
     {
       "apiVersion": 1,
@@ -3066,7 +3066,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:26.139Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.comfort"
     },
     {
       "apiVersion": 1,
@@ -3083,7 +3083,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:26.139Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.eco"
     },
     {
       "apiVersion": 1,
@@ -3100,7 +3100,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.efficient"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.efficient"
     },
     {
       "apiVersion": 1,
@@ -3117,7 +3117,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.efficientWithMinComfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.efficientWithMinComfort"
     },
     {
       "apiVersion": 1,
@@ -3134,7 +3134,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.off"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.off"
     },
     {
       "apiVersion": 1,
@@ -3146,7 +3146,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
     },
     {
       "apiVersion": 1,
@@ -3158,7 +3158,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
     },
     {
       "apiVersion": 1,
@@ -3170,7 +3170,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:26.264Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.secondary"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.secondary"
     },
     {
       "apiVersion": 1,
@@ -3179,7 +3179,7 @@
           "isExecutable": true,
           "name": "resetSchedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule/commands/resetSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule/commands/resetSchedule"
         },
         "setSchedule": {
           "isExecutable": true,
@@ -3199,7 +3199,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -3275,7 +3275,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule"
     },
     {
       "apiVersion": 1,
@@ -3297,7 +3297,7 @@
         }
       },
       "timestamp": "2024-10-01T16:28:40.965Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder"
     },
     {
       "apiVersion": 1,
@@ -3309,7 +3309,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:26.264Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder.middle"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder.middle"
     },
     {
       "apiVersion": 1,
@@ -3321,7 +3321,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T16:28:40.965Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder.top"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder.top"
     },
     {
       "apiVersion": 1,
@@ -3347,7 +3347,7 @@
         }
       },
       "timestamp": "2024-10-01T16:28:40.965Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
     },
     {
       "apiVersion": 1,
@@ -3363,7 +3363,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:26.264Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.middle"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.middle"
     },
     {
       "apiVersion": 1,
@@ -3379,7 +3379,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T16:28:40.965Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.top"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.top"
     },
     {
       "apiVersion": 1,
@@ -3391,7 +3391,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hygiene"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hygiene"
     },
     {
       "apiVersion": 1,
@@ -3410,7 +3410,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresis"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresis"
         },
         "setHysteresisSwitchOffValue": {
           "isExecutable": true,
@@ -3426,7 +3426,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOffValue"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOffValue"
         },
         "setHysteresisSwitchOnValue": {
           "isExecutable": true,
@@ -3442,7 +3442,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOnValue"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOnValue"
         }
       },
       "deviceId": "0",
@@ -3468,7 +3468,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis"
     },
     {
       "apiVersion": 1,
@@ -3496,7 +3496,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.levels"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.levels"
     },
     {
       "apiVersion": 1,
@@ -3517,7 +3517,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
         }
       },
       "deviceId": "0",
@@ -3533,7 +3533,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -3555,7 +3555,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.heatingRod.heat.production.current"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.heatingRod.heat.production.current"
     },
     {
       "apiVersion": 1,
@@ -3577,7 +3577,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:26.264Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.heatingRod.power.consumption.current"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.heatingRod.power.consumption.current"
     },
     {
       "apiVersion": 1,
@@ -3658,7 +3658,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:26.264Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.heatingRod.power.consumption.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.heatingRod.power.consumption.dhw"
     },
     {
       "apiVersion": 1,
@@ -3739,7 +3739,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:26.139Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.heatingRod.power.consumption.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.heatingRod.power.consumption.heating"
     },
     {
       "apiVersion": 1,
@@ -3782,7 +3782,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:26.264Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.heatingRod.power.consumption.summary.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.heatingRod.power.consumption.summary.dhw"
     },
     {
       "apiVersion": 1,
@@ -3825,7 +3825,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:26.139Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.heatingRod.power.consumption.summary.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.heatingRod.power.consumption.summary.heating"
     },
     {
       "apiVersion": 1,
@@ -3906,7 +3906,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:26.264Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.heatingRod.power.consumption.total"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.heatingRod.power.consumption.total"
     },
     {
       "apiVersion": 1,
@@ -3929,7 +3929,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.heatingRod.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.heatingRod.statistics"
     },
     {
       "apiVersion": 1,
@@ -3958,7 +3958,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.heatingRod.status"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.heatingRod.status"
     },
     {
       "apiVersion": 1,
@@ -3976,7 +3976,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
         },
         "schedule": {
           "isExecutable": true,
@@ -3998,13 +3998,13 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/schedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/schedule"
         },
         "unschedule": {
           "isExecutable": true,
           "name": "unschedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
         }
       },
       "deviceId": "0",
@@ -4027,7 +4027,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday"
     },
     {
       "apiVersion": 1,
@@ -4045,7 +4045,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/changeEndDate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/changeEndDate"
         },
         "schedule": {
           "isExecutable": true,
@@ -4067,13 +4067,13 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/schedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/schedule"
         },
         "unschedule": {
           "isExecutable": true,
           "name": "unschedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/unschedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/unschedule"
         }
       },
       "deviceId": "0",
@@ -4096,7 +4096,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome"
     },
     {
       "apiVersion": 1,
@@ -4108,7 +4108,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T00:31:26.264Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.cooling"
     },
     {
       "apiVersion": 1,
@@ -4130,7 +4130,7 @@
         }
       },
       "timestamp": "2024-10-01T16:28:29.219Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.current"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.current"
     },
     {
       "apiVersion": 1,
@@ -4211,7 +4211,7 @@
         }
       },
       "timestamp": "2024-10-01T12:18:26.686Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.dhw"
     },
     {
       "apiVersion": 1,
@@ -4292,7 +4292,7 @@
         }
       },
       "timestamp": "2024-10-01T16:27:05.568Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.heating"
     },
     {
       "apiVersion": 1,
@@ -4335,7 +4335,7 @@
         }
       },
       "timestamp": "2024-10-01T11:46:54.639Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.dhw"
     },
     {
       "apiVersion": 1,
@@ -4378,7 +4378,7 @@
         }
       },
       "timestamp": "2024-10-01T16:27:05.568Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.heating"
     },
     {
       "apiVersion": 1,
@@ -4459,7 +4459,7 @@
         }
       },
       "timestamp": "2024-10-01T16:27:05.568Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.total"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.total"
     },
     {
       "apiVersion": 1,
@@ -4481,7 +4481,7 @@
         }
       },
       "timestamp": "2024-10-01T16:28:36.488Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.primaryCircuit.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.primaryCircuit.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -4503,7 +4503,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.scop.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.scop.dhw"
     },
     {
       "apiVersion": 1,
@@ -4525,7 +4525,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.scop.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.scop.heating"
     },
     {
       "apiVersion": 1,
@@ -4547,7 +4547,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.scop.total"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.scop.total"
     },
     {
       "apiVersion": 1,
@@ -4569,7 +4569,7 @@
         }
       },
       "timestamp": "2024-10-01T16:28:36.488Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.secondaryCircuit.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.secondaryCircuit.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -4591,7 +4591,7 @@
         }
       },
       "timestamp": "2024-10-01T15:06:07.125Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.pressure.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.pressure.supply"
     },
     {
       "apiVersion": 1,
@@ -4613,7 +4613,7 @@
         }
       },
       "timestamp": "2024-10-01T16:28:20.497Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.allengra"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.allengra"
     },
     {
       "apiVersion": 1,
@@ -4625,7 +4625,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-01T16:28:33.694Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.hydraulicSeparator"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.hydraulicSeparator"
     },
     {
       "apiVersion": 1,
@@ -4647,7 +4647,7 @@
         }
       },
       "timestamp": "2024-10-01T16:28:36.488Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.outside"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.outside"
     },
     {
       "apiVersion": 1,
@@ -4669,7 +4669,7 @@
         }
       },
       "timestamp": "2024-10-01T16:28:04.882Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.return"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.return"
     },
     {
       "apiVersion": 1,
@@ -4691,7 +4691,7 @@
         }
       },
       "timestamp": "2024-10-01T16:28:36.488Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.volumetricFlow.allengra"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.volumetricFlow.allengra"
     },
     {
       "apiVersion": 1,
@@ -4709,7 +4709,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.spf.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.spf.dhw"
     },
     {
       "apiVersion": 1,
@@ -4727,7 +4727,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.spf.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.spf.heating"
     },
     {
       "apiVersion": 1,
@@ -4745,7 +4745,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:21.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.spf.total"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.spf.total"
     }
   ]
 }

--- a/tests/response/Vitocal252.json
+++ b/tests/response/Vitocal252.json
@@ -15,7 +15,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.messages.errors.raw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.messages.errors.raw"
     },
     {
       "apiVersion": 1,
@@ -37,7 +37,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.productIdentification"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.productIdentification"
     },
     {
       "apiVersion": 1,
@@ -61,7 +61,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.productMatrix"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.productMatrix"
     },
     {
       "apiVersion": 1,
@@ -78,7 +78,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.serial"
     },
     {
       "apiVersion": 1,
@@ -100,7 +100,7 @@
         }
       },
       "timestamp": "2024-09-02T10:06:37.837Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
     },
     {
       "apiVersion": 1,
@@ -117,7 +117,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
     },
     {
       "apiVersion": 1,
@@ -143,7 +143,7 @@
         }
       },
       "timestamp": "2024-09-02T09:47:44.020Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.buffer.sensors.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.buffer.sensors.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -165,7 +165,7 @@
         }
       },
       "timestamp": "2024-09-02T09:47:44.020Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.bufferCylinder.sensors.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.bufferCylinder.sensors.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -184,7 +184,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits"
     },
     {
       "apiVersion": 1,
@@ -202,7 +202,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0/commands/setName"
         }
       },
       "deviceId": "0",
@@ -225,7 +225,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0"
     },
     {
       "apiVersion": 1,
@@ -242,7 +242,7 @@
         }
       },
       "timestamp": "2024-09-01T18:35:50.159Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -259,7 +259,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -287,7 +287,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve"
         }
       },
       "deviceId": "0",
@@ -308,7 +308,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -317,7 +317,7 @@
           "isExecutable": true,
           "name": "resetSchedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule/commands/resetSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule/commands/resetSchedule"
         },
         "setSchedule": {
           "isExecutable": true,
@@ -338,7 +338,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -498,7 +498,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -516,7 +516,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name/commands/setName"
         }
       },
       "components": [],
@@ -532,7 +532,7 @@
         }
       },
       "timestamp": "2024-08-29T06:20:49.008Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name"
     },
     {
       "apiVersion": 1,
@@ -552,7 +552,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
         }
       },
       "deviceId": "0",
@@ -567,7 +567,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -579,7 +579,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.cooling"
     },
     {
       "apiVersion": 1,
@@ -596,7 +596,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -608,7 +608,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heatingCooling"
     },
     {
       "apiVersion": 1,
@@ -625,7 +625,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -642,7 +642,7 @@
         }
       },
       "timestamp": "2024-09-02T06:57:20.780Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -654,7 +654,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortCooling"
     },
     {
       "apiVersion": 1,
@@ -679,7 +679,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -704,7 +704,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -723,13 +723,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortHeating/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortHeating/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortHeating/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortHeating/commands/deactivate"
         },
         "setTemperature": {
           "isExecutable": true,
@@ -745,7 +745,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortHeating/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortHeating/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -769,7 +769,7 @@
         }
       },
       "timestamp": "2024-09-02T06:57:20.780Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortHeating"
     },
     {
       "apiVersion": 1,
@@ -786,7 +786,7 @@
         }
       },
       "timestamp": "2024-09-02T06:57:20.780Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -803,7 +803,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.fixed"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.fixed"
     },
     {
       "apiVersion": 1,
@@ -812,13 +812,13 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule/commands/activate"
         },
         "deactivate": {
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -833,7 +833,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule"
     },
     {
       "apiVersion": 1,
@@ -850,7 +850,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -862,7 +862,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalCooling"
     },
     {
       "apiVersion": 1,
@@ -887,7 +887,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -912,7 +912,7 @@
         }
       },
       "timestamp": "2024-09-01T18:35:55.889Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -931,13 +931,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalHeating/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalHeating/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalHeating/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalHeating/commands/deactivate"
         },
         "setTemperature": {
           "isExecutable": true,
@@ -953,7 +953,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalHeating/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalHeating/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -977,7 +977,7 @@
         }
       },
       "timestamp": "2024-09-02T06:57:20.780Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalHeating"
     },
     {
       "apiVersion": 1,
@@ -989,7 +989,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedCooling"
     },
     {
       "apiVersion": 1,
@@ -1014,7 +1014,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1039,7 +1039,7 @@
         }
       },
       "timestamp": "2024-09-02T06:57:20.780Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1058,13 +1058,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedHeating/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedHeating/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedHeating/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedHeating/commands/deactivate"
         },
         "setTemperature": {
           "isExecutable": true,
@@ -1080,7 +1080,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedHeating/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedHeating/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -1104,7 +1104,7 @@
         }
       },
       "timestamp": "2024-09-02T03:57:24.114Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedHeating"
     },
     {
       "apiVersion": 1,
@@ -1121,7 +1121,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1142,7 +1142,7 @@
         }
       },
       "timestamp": "2024-09-02T06:57:20.780Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.summerEco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.summerEco"
     },
     {
       "apiVersion": 1,
@@ -1154,7 +1154,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:46.685Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1176,7 +1176,7 @@
         }
       },
       "timestamp": "2024-09-02T09:47:44.020Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1188,7 +1188,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-02T08:38:06.452Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature"
     },
     {
       "apiVersion": 1,
@@ -1216,7 +1216,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setLevels"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setLevels"
         },
         "setMax": {
           "isExecutable": true,
@@ -1232,7 +1232,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setMax"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setMax"
         },
         "setMin": {
           "isExecutable": true,
@@ -1248,7 +1248,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setMin"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setMin"
         }
       },
       "deviceId": "0",
@@ -1269,7 +1269,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:47.015Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels"
     },
     {
       "apiVersion": 1,
@@ -1286,7 +1286,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:47.015Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.zone.mode"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.zone.mode"
     },
     {
       "apiVersion": 1,
@@ -1298,7 +1298,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1"
     },
     {
       "apiVersion": 1,
@@ -1310,7 +1310,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:56:50.160Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -1322,7 +1322,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1334,7 +1334,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -1346,7 +1346,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -1359,7 +1359,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-01-23T17:56:52.522Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.name"
     },
     {
       "apiVersion": 1,
@@ -1371,7 +1371,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -1383,7 +1383,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.cooling"
     },
     {
       "apiVersion": 1,
@@ -1395,7 +1395,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -1407,7 +1407,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heatingCooling"
     },
     {
       "apiVersion": 1,
@@ -1419,7 +1419,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -1431,7 +1431,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:47.015Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1443,7 +1443,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortCooling"
     },
     {
       "apiVersion": 1,
@@ -1455,7 +1455,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1467,7 +1467,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1479,7 +1479,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortHeating"
     },
     {
       "apiVersion": 1,
@@ -1491,7 +1491,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -1503,7 +1503,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.fixed"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.fixed"
     },
     {
       "apiVersion": 1,
@@ -1515,7 +1515,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule"
     },
     {
       "apiVersion": 1,
@@ -1527,7 +1527,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1539,7 +1539,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalCooling"
     },
     {
       "apiVersion": 1,
@@ -1551,7 +1551,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1563,7 +1563,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1575,7 +1575,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalHeating"
     },
     {
       "apiVersion": 1,
@@ -1587,7 +1587,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedCooling"
     },
     {
       "apiVersion": 1,
@@ -1599,7 +1599,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1611,7 +1611,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1623,7 +1623,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedHeating"
     },
     {
       "apiVersion": 1,
@@ -1635,7 +1635,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1651,7 +1651,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.summerEco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.summerEco"
     },
     {
       "apiVersion": 1,
@@ -1663,7 +1663,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:46.685Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1675,7 +1675,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:46.685Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1687,7 +1687,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature"
     },
     {
       "apiVersion": 1,
@@ -1699,7 +1699,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:47.015Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature.levels"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature.levels"
     },
     {
       "apiVersion": 1,
@@ -1711,7 +1711,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:47.015Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.zone.mode"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.zone.mode"
     },
     {
       "apiVersion": 1,
@@ -1723,7 +1723,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2"
     },
     {
       "apiVersion": 1,
@@ -1735,7 +1735,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:56:50.160Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -1747,7 +1747,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1759,7 +1759,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -1771,7 +1771,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -1784,7 +1784,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-01-23T17:56:52.522Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.name"
     },
     {
       "apiVersion": 1,
@@ -1796,7 +1796,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -1808,7 +1808,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.cooling"
     },
     {
       "apiVersion": 1,
@@ -1820,7 +1820,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -1832,7 +1832,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heatingCooling"
     },
     {
       "apiVersion": 1,
@@ -1844,7 +1844,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -1856,7 +1856,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:47.015Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1868,7 +1868,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortCooling"
     },
     {
       "apiVersion": 1,
@@ -1880,7 +1880,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1892,7 +1892,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1904,7 +1904,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfortHeating"
     },
     {
       "apiVersion": 1,
@@ -1916,7 +1916,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -1928,7 +1928,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.fixed"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.fixed"
     },
     {
       "apiVersion": 1,
@@ -1940,7 +1940,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.forcedLastFromSchedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.forcedLastFromSchedule"
     },
     {
       "apiVersion": 1,
@@ -1952,7 +1952,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1964,7 +1964,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalCooling"
     },
     {
       "apiVersion": 1,
@@ -1976,7 +1976,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1988,7 +1988,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -2000,7 +2000,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normalHeating"
     },
     {
       "apiVersion": 1,
@@ -2012,7 +2012,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedCooling"
     },
     {
       "apiVersion": 1,
@@ -2024,7 +2024,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -2036,7 +2036,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -2048,7 +2048,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reducedHeating"
     },
     {
       "apiVersion": 1,
@@ -2060,7 +2060,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -2076,7 +2076,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.summerEco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.summerEco"
     },
     {
       "apiVersion": 1,
@@ -2088,7 +2088,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:46.685Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -2100,7 +2100,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:46.685Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -2112,7 +2112,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.temperature"
     },
     {
       "apiVersion": 1,
@@ -2124,7 +2124,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:47.015Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.temperature.levels"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.temperature.levels"
     },
     {
       "apiVersion": 1,
@@ -2136,7 +2136,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:47.015Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.zone.mode"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.zone.mode"
     },
     {
       "apiVersion": 1,
@@ -2148,7 +2148,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3"
     },
     {
       "apiVersion": 1,
@@ -2160,7 +2160,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:56:50.160Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -2172,7 +2172,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -2184,7 +2184,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -2196,7 +2196,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -2209,7 +2209,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-01-23T17:56:52.522Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.name"
     },
     {
       "apiVersion": 1,
@@ -2221,7 +2221,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -2233,7 +2233,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.cooling"
     },
     {
       "apiVersion": 1,
@@ -2245,7 +2245,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -2257,7 +2257,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.heatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.heatingCooling"
     },
     {
       "apiVersion": 1,
@@ -2269,7 +2269,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -2281,7 +2281,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:47.015Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -2293,7 +2293,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortCooling"
     },
     {
       "apiVersion": 1,
@@ -2305,7 +2305,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -2317,7 +2317,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -2329,7 +2329,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfortHeating"
     },
     {
       "apiVersion": 1,
@@ -2341,7 +2341,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -2353,7 +2353,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.fixed"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.fixed"
     },
     {
       "apiVersion": 1,
@@ -2365,7 +2365,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.forcedLastFromSchedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.forcedLastFromSchedule"
     },
     {
       "apiVersion": 1,
@@ -2377,7 +2377,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -2389,7 +2389,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalCooling"
     },
     {
       "apiVersion": 1,
@@ -2401,7 +2401,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -2413,7 +2413,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -2425,7 +2425,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normalHeating"
     },
     {
       "apiVersion": 1,
@@ -2437,7 +2437,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedCooling"
     },
     {
       "apiVersion": 1,
@@ -2449,7 +2449,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedCoolingEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedCoolingEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -2461,7 +2461,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -2473,7 +2473,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reducedHeating"
     },
     {
       "apiVersion": 1,
@@ -2485,7 +2485,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -2501,7 +2501,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.summerEco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.summerEco"
     },
     {
       "apiVersion": 1,
@@ -2513,7 +2513,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:46.685Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -2525,7 +2525,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:46.685Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -2537,7 +2537,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.temperature"
     },
     {
       "apiVersion": 1,
@@ -2549,7 +2549,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:47.015Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.temperature.levels"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.temperature.levels"
     },
     {
       "apiVersion": 1,
@@ -2561,7 +2561,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:47.015Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.zone.mode"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.3.zone.mode"
     },
     {
       "apiVersion": 1,
@@ -2580,7 +2580,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors"
     },
     {
       "apiVersion": 1,
@@ -2601,7 +2601,7 @@
         }
       },
       "timestamp": "2024-09-01T11:54:51.919Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0"
     },
     {
       "apiVersion": 1,
@@ -2624,7 +2624,7 @@
         }
       },
       "timestamp": "2024-09-01T11:55:41.152Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0.statistics"
     },
     {
       "apiVersion": 1,
@@ -2641,7 +2641,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.device.variant"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.device.variant"
     },
     {
       "apiVersion": 1,
@@ -2662,7 +2662,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw"
     },
     {
       "apiVersion": 1,
@@ -2671,19 +2671,19 @@
           "isExecutable": false,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/activate"
         },
         "disable": {
           "isExecutable": false,
           "name": "disable",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/disable"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/disable"
         },
         "enable": {
           "isExecutable": true,
           "name": "enable",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/enable"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/enable"
         }
       },
       "deviceId": "0",
@@ -2698,7 +2698,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:47.015Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene"
     },
     {
       "apiVersion": 1,
@@ -2710,7 +2710,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene.trigger"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene.trigger"
     },
     {
       "apiVersion": 1,
@@ -2719,13 +2719,13 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/activate"
         },
         "deactivate": {
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -2740,7 +2740,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge"
     },
     {
       "apiVersion": 1,
@@ -2761,7 +2761,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active/commands/setMode"
         }
       },
       "deviceId": "0",
@@ -2776,7 +2776,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:47.015Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -2788,7 +2788,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.balanced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.balanced"
     },
     {
       "apiVersion": 1,
@@ -2805,7 +2805,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:47.015Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.comfort"
     },
     {
       "apiVersion": 1,
@@ -2822,7 +2822,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:47.015Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.eco"
     },
     {
       "apiVersion": 1,
@@ -2839,7 +2839,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.efficient"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.efficient"
     },
     {
       "apiVersion": 1,
@@ -2856,7 +2856,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.efficientWithMinComfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.efficientWithMinComfort"
     },
     {
       "apiVersion": 1,
@@ -2873,7 +2873,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.off"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.off"
     },
     {
       "apiVersion": 1,
@@ -2885,7 +2885,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
     },
     {
       "apiVersion": 1,
@@ -2897,7 +2897,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
     },
     {
       "apiVersion": 1,
@@ -2909,7 +2909,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:47.015Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.secondary"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.secondary"
     },
     {
       "apiVersion": 1,
@@ -2918,7 +2918,7 @@
           "isExecutable": true,
           "name": "resetSchedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule/commands/resetSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule/commands/resetSchedule"
         },
         "setSchedule": {
           "isExecutable": true,
@@ -2938,7 +2938,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -3056,7 +3056,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule"
     },
     {
       "apiVersion": 1,
@@ -3078,7 +3078,7 @@
         }
       },
       "timestamp": "2024-09-02T10:06:46.013Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder"
     },
     {
       "apiVersion": 1,
@@ -3090,7 +3090,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:47.015Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder.middle"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder.middle"
     },
     {
       "apiVersion": 1,
@@ -3102,7 +3102,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-02T10:06:46.013Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder.top"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder.top"
     },
     {
       "apiVersion": 1,
@@ -3128,7 +3128,7 @@
         }
       },
       "timestamp": "2024-09-02T10:06:46.013Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
     },
     {
       "apiVersion": 1,
@@ -3144,7 +3144,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:47.015Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.middle"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.middle"
     },
     {
       "apiVersion": 1,
@@ -3160,7 +3160,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-02T10:06:46.013Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.top"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.top"
     },
     {
       "apiVersion": 1,
@@ -3172,7 +3172,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hygiene"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hygiene"
     },
     {
       "apiVersion": 1,
@@ -3191,7 +3191,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresis"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresis"
         },
         "setHysteresisSwitchOffValue": {
           "isExecutable": true,
@@ -3207,7 +3207,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOffValue"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOffValue"
         },
         "setHysteresisSwitchOnValue": {
           "isExecutable": true,
@@ -3223,7 +3223,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOnValue"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOnValue"
         }
       },
       "deviceId": "0",
@@ -3249,7 +3249,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis"
     },
     {
       "apiVersion": 1,
@@ -3277,7 +3277,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.levels"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.levels"
     },
     {
       "apiVersion": 1,
@@ -3298,7 +3298,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
         }
       },
       "deviceId": "0",
@@ -3314,7 +3314,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -3332,7 +3332,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
         },
         "schedule": {
           "isExecutable": true,
@@ -3354,13 +3354,13 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/schedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/schedule"
         },
         "unschedule": {
           "isExecutable": true,
           "name": "unschedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
         }
       },
       "deviceId": "0",
@@ -3383,7 +3383,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday"
     },
     {
       "apiVersion": 1,
@@ -3401,7 +3401,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/changeEndDate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/changeEndDate"
         },
         "schedule": {
           "isExecutable": true,
@@ -3423,13 +3423,13 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/schedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/schedule"
         },
         "unschedule": {
           "isExecutable": true,
           "name": "unschedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/unschedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/unschedule"
         }
       },
       "deviceId": "0",
@@ -3452,7 +3452,7 @@
         }
       },
       "timestamp": "2024-09-01T11:20:41.179Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome"
     },
     {
       "apiVersion": 1,
@@ -3464,7 +3464,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-01T21:57:17.715Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.cooling"
     },
     {
       "apiVersion": 1,
@@ -3545,7 +3545,7 @@
         }
       },
       "timestamp": "2024-09-01T22:01:14.702Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.dhw"
     },
     {
       "apiVersion": 1,
@@ -3626,7 +3626,7 @@
         }
       },
       "timestamp": "2024-09-01T22:01:14.702Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.heating"
     },
     {
       "apiVersion": 1,
@@ -3669,7 +3669,7 @@
         }
       },
       "timestamp": "2024-09-01T22:01:14.702Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.dhw"
     },
     {
       "apiVersion": 1,
@@ -3712,7 +3712,7 @@
         }
       },
       "timestamp": "2024-09-01T22:01:14.702Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.heating"
     },
     {
       "apiVersion": 1,
@@ -3793,7 +3793,7 @@
         }
       },
       "timestamp": "2024-09-01T22:01:14.702Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.total"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.total"
     },
     {
       "apiVersion": 1,
@@ -3815,7 +3815,7 @@
         }
       },
       "timestamp": "2024-09-02T10:06:29.615Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.primaryCircuit.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.primaryCircuit.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -3837,7 +3837,7 @@
         }
       },
       "timestamp": "2024-09-02T09:48:29.236Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.secondaryCircuit.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.secondaryCircuit.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -3849,7 +3849,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-02T09:47:44.020Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.hydraulicSeparator"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.hydraulicSeparator"
     },
     {
       "apiVersion": 1,
@@ -3871,7 +3871,7 @@
         }
       },
       "timestamp": "2024-09-02T10:00:05.780Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.outside"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.outside"
     },
     {
       "apiVersion": 1,
@@ -3893,7 +3893,7 @@
         }
       },
       "timestamp": "2024-09-02T09:57:06.719Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.return"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.return"
     },
     {
       "apiVersion": 1,
@@ -3915,7 +3915,7 @@
         }
       },
       "timestamp": "2024-09-02T09:40:56.140Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.volumetricFlow.allengra"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.volumetricFlow.allengra"
     }
   ]
 }

--- a/tests/response/Vitocal333G.json
+++ b/tests/response/Vitocal333G.json
@@ -15,7 +15,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.messages.errors.raw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.messages.errors.raw"
     },
     {
       "apiVersion": 1,
@@ -32,7 +32,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.serial"
     },
     {
       "apiVersion": 1,
@@ -49,7 +49,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
     },
     {
       "apiVersion": 1,
@@ -66,7 +66,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
     },
     {
       "apiVersion": 1,
@@ -83,7 +83,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.buffer.sensors.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.buffer.sensors.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -100,7 +100,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.buffer.sensors.temperature.top"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.buffer.sensors.temperature.top"
     },
     {
       "apiVersion": 1,
@@ -117,7 +117,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.bufferCylinder.sensors.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.bufferCylinder.sensors.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -134,7 +134,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.bufferCylinder.sensors.temperature.top"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.bufferCylinder.sensors.temperature.top"
     },
     {
       "apiVersion": 1,
@@ -151,7 +151,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners"
     },
     {
       "apiVersion": 1,
@@ -163,7 +163,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0"
     },
     {
       "apiVersion": 1,
@@ -175,7 +175,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0.modulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0.modulation"
     },
     {
       "apiVersion": 1,
@@ -187,7 +187,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0.statistics"
     },
     {
       "apiVersion": 1,
@@ -206,7 +206,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits"
     },
     {
       "apiVersion": 1,
@@ -224,7 +224,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0/commands/setName"
         }
       },
       "deviceId": "0",
@@ -247,7 +247,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0"
     },
     {
       "apiVersion": 1,
@@ -264,7 +264,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -281,7 +281,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -309,7 +309,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve"
         }
       },
       "deviceId": "0",
@@ -330,7 +330,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -355,7 +355,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -431,7 +431,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -449,7 +449,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name/commands/setName"
         }
       },
       "components": [],
@@ -465,7 +465,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name"
     },
     {
       "apiVersion": 1,
@@ -486,7 +486,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
         }
       },
       "deviceId": "0",
@@ -501,7 +501,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -513,7 +513,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.cooling"
     },
     {
       "apiVersion": 1,
@@ -530,7 +530,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -547,7 +547,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -559,7 +559,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeatingCooling"
     },
     {
       "apiVersion": 1,
@@ -576,7 +576,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.forcedNormal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.forcedNormal"
     },
     {
       "apiVersion": 1,
@@ -593,7 +593,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.forcedReduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.forcedReduced"
     },
     {
       "apiVersion": 1,
@@ -605,7 +605,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -617,7 +617,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heatingCooling"
     },
     {
       "apiVersion": 1,
@@ -634,7 +634,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.normalStandby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.normalStandby"
     },
     {
       "apiVersion": 1,
@@ -651,7 +651,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -668,7 +668,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -687,13 +687,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/activate"
         },
         "deactivate": {
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/deactivate"
         },
         "setTemperature": {
           "isExecutable": true,
@@ -709,7 +709,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -733,7 +733,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -742,13 +742,13 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco/commands/activate"
         },
         "deactivate": {
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -768,7 +768,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -785,7 +785,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.fixed"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.fixed"
     },
     {
       "apiVersion": 1,
@@ -804,7 +804,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -828,7 +828,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -847,7 +847,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -871,7 +871,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -888,7 +888,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -900,7 +900,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -922,7 +922,7 @@
         }
       },
       "timestamp": "2023-12-21T19:28:24.227Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -940,7 +940,7 @@
         }
       },
       "timestamp": "2023-12-21T19:26:34.375Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature"
     },
     {
       "apiVersion": 1,
@@ -968,7 +968,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setLevels"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setLevels"
         },
         "setMax": {
           "isExecutable": true,
@@ -984,7 +984,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setMax"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setMax"
         },
         "setMin": {
           "isExecutable": true,
@@ -1000,7 +1000,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setMin"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setMin"
         }
       },
       "deviceId": "0",
@@ -1021,7 +1021,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels"
     },
     {
       "apiVersion": 1,
@@ -1033,7 +1033,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1"
     },
     {
       "apiVersion": 1,
@@ -1045,7 +1045,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -1057,7 +1057,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1085,7 +1085,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve/commands/setCurve"
         }
       },
       "deviceId": "0",
@@ -1106,7 +1106,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -1118,7 +1118,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -1131,7 +1131,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-10-12T03:17:07.460Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.name"
     },
     {
       "apiVersion": 1,
@@ -1143,7 +1143,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -1155,7 +1155,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.cooling"
     },
     {
       "apiVersion": 1,
@@ -1167,7 +1167,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -1179,7 +1179,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -1191,7 +1191,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeatingCooling"
     },
     {
       "apiVersion": 1,
@@ -1203,7 +1203,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.forcedNormal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.forcedNormal"
     },
     {
       "apiVersion": 1,
@@ -1215,7 +1215,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.forcedReduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.forcedReduced"
     },
     {
       "apiVersion": 1,
@@ -1227,7 +1227,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -1239,7 +1239,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heatingCooling"
     },
     {
       "apiVersion": 1,
@@ -1251,7 +1251,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.normalStandby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.normalStandby"
     },
     {
       "apiVersion": 1,
@@ -1263,7 +1263,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -1275,7 +1275,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1287,7 +1287,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -1299,7 +1299,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -1311,7 +1311,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.fixed"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.fixed"
     },
     {
       "apiVersion": 1,
@@ -1323,7 +1323,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -1335,7 +1335,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -1347,7 +1347,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1359,7 +1359,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1371,7 +1371,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1389,7 +1389,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature"
     },
     {
       "apiVersion": 1,
@@ -1401,7 +1401,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature.levels"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature.levels"
     },
     {
       "apiVersion": 1,
@@ -1413,7 +1413,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2"
     },
     {
       "apiVersion": 1,
@@ -1425,7 +1425,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -1437,7 +1437,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1465,7 +1465,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.curve/commands/setCurve"
         }
       },
       "deviceId": "0",
@@ -1486,7 +1486,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -1498,7 +1498,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -1511,7 +1511,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-10-12T03:17:07.460Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.name"
     },
     {
       "apiVersion": 1,
@@ -1523,7 +1523,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -1535,7 +1535,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.cooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.cooling"
     },
     {
       "apiVersion": 1,
@@ -1547,7 +1547,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -1559,7 +1559,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -1571,7 +1571,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeatingCooling"
     },
     {
       "apiVersion": 1,
@@ -1583,7 +1583,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.forcedNormal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.forcedNormal"
     },
     {
       "apiVersion": 1,
@@ -1595,7 +1595,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.forcedReduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.forcedReduced"
     },
     {
       "apiVersion": 1,
@@ -1607,7 +1607,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -1619,7 +1619,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heatingCooling"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heatingCooling"
     },
     {
       "apiVersion": 1,
@@ -1631,7 +1631,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.normalStandby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.normalStandby"
     },
     {
       "apiVersion": 1,
@@ -1643,7 +1643,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -1655,7 +1655,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1667,7 +1667,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -1679,7 +1679,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -1691,7 +1691,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.fixed"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.fixed"
     },
     {
       "apiVersion": 1,
@@ -1703,7 +1703,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -1715,7 +1715,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -1727,7 +1727,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1739,7 +1739,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1751,7 +1751,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1769,7 +1769,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.temperature"
     },
     {
       "apiVersion": 1,
@@ -1781,7 +1781,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.temperature.levels"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.2.temperature.levels"
     },
     {
       "apiVersion": 1,
@@ -1800,7 +1800,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors"
     },
     {
       "apiVersion": 1,
@@ -1821,7 +1821,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0"
     },
     {
       "apiVersion": 1,
@@ -1844,7 +1844,7 @@
         }
       },
       "timestamp": "2023-12-21T19:23:03.933Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.0.statistics"
     },
     {
       "apiVersion": 1,
@@ -1856,7 +1856,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.1"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.1"
     },
     {
       "apiVersion": 1,
@@ -1868,7 +1868,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.1.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.compressors.1.statistics"
     },
     {
       "apiVersion": 1,
@@ -1887,7 +1887,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.configuration.dhw.temperature.dhwCylinder.max/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.configuration.dhw.temperature.dhwCylinder.max/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -1903,7 +1903,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.configuration.dhw.temperature.dhwCylinder.max"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.configuration.dhw.temperature.dhwCylinder.max"
     },
     {
       "apiVersion": 1,
@@ -1920,7 +1920,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.controller.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.controller.serial"
     },
     {
       "apiVersion": 1,
@@ -1941,7 +1941,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.849Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw"
     },
     {
       "apiVersion": 1,
@@ -1958,7 +1958,7 @@
         }
       },
       "timestamp": "2023-12-21T18:52:11.627Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.charging"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.charging"
     },
     {
       "apiVersion": 1,
@@ -1967,13 +1967,13 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/activate"
         },
         "deactivate": {
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -1988,7 +1988,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge"
     },
     {
       "apiVersion": 1,
@@ -2005,7 +2005,7 @@
         }
       },
       "timestamp": "2023-12-21T18:52:11.627Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
     },
     {
       "apiVersion": 1,
@@ -2030,7 +2030,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -2106,7 +2106,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
     },
     {
       "apiVersion": 1,
@@ -2123,7 +2123,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.849Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.primary"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.primary"
     },
     {
       "apiVersion": 1,
@@ -2148,7 +2148,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -2224,7 +2224,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule"
     },
     {
       "apiVersion": 1,
@@ -2246,7 +2246,7 @@
         }
       },
       "timestamp": "2023-12-21T19:28:24.227Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder"
     },
     {
       "apiVersion": 1,
@@ -2263,7 +2263,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.849Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder.bottom"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder.bottom"
     },
     {
       "apiVersion": 1,
@@ -2285,7 +2285,7 @@
         }
       },
       "timestamp": "2023-12-21T19:28:24.228Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder.top"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder.top"
     },
     {
       "apiVersion": 1,
@@ -2307,7 +2307,7 @@
         }
       },
       "timestamp": "2023-12-21T19:28:24.228Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
     },
     {
       "apiVersion": 1,
@@ -2324,7 +2324,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.849Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.bottom"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.bottom"
     },
     {
       "apiVersion": 1,
@@ -2346,7 +2346,7 @@
         }
       },
       "timestamp": "2023-12-21T19:28:24.228Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.top"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.top"
     },
     {
       "apiVersion": 1,
@@ -2363,7 +2363,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.849Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.outlet"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.outlet"
     },
     {
       "apiVersion": 1,
@@ -2382,7 +2382,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresis"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresis"
         },
         "setHysteresisSwitchOffValue": {
           "isExecutable": true,
@@ -2398,7 +2398,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOffValue"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOffValue"
         },
         "setHysteresisSwitchOnValue": {
           "isExecutable": true,
@@ -2414,7 +2414,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOnValue"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis/commands/setHysteresisSwitchOnValue"
         }
       },
       "deviceId": "0",
@@ -2440,7 +2440,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hysteresis"
     },
     {
       "apiVersion": 1,
@@ -2461,7 +2461,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
         }
       },
       "deviceId": "0",
@@ -2477,7 +2477,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -2496,7 +2496,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.temp2/commands/setTargetTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.temp2/commands/setTargetTemperature"
         }
       },
       "deviceId": "0",
@@ -2512,7 +2512,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.temp2"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.temp2"
     },
     {
       "apiVersion": 1,
@@ -2530,7 +2530,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
         },
         "schedule": {
           "isExecutable": true,
@@ -2552,13 +2552,13 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/schedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/schedule"
         },
         "unschedule": {
           "isExecutable": true,
           "name": "unschedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
         }
       },
       "deviceId": "0",
@@ -2581,7 +2581,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday"
     },
     {
       "apiVersion": 1,
@@ -2603,7 +2603,7 @@
         }
       },
       "timestamp": "2023-12-21T19:24:29.460Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.primaryCircuit.sensors.temperature.return"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.primaryCircuit.sensors.temperature.return"
     },
     {
       "apiVersion": 1,
@@ -2625,7 +2625,7 @@
         }
       },
       "timestamp": "2023-12-21T19:21:33.829Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.primaryCircuit.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.primaryCircuit.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -2647,7 +2647,7 @@
         }
       },
       "timestamp": "2023-12-21T19:28:31.721Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.secondaryCircuit.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.secondaryCircuit.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -2669,7 +2669,7 @@
         }
       },
       "timestamp": "2023-12-21T19:23:38.308Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.outside"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.outside"
     },
     {
       "apiVersion": 1,
@@ -2691,7 +2691,7 @@
         }
       },
       "timestamp": "2023-12-21T19:28:31.721Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.return"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.return"
     },
     {
       "apiVersion": 1,
@@ -2703,7 +2703,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.849Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar"
     },
     {
       "apiVersion": 1,
@@ -2715,7 +2715,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.849Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.power.cumulativeProduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.power.cumulativeProduced"
     },
     {
       "apiVersion": 1,
@@ -2727,7 +2727,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.849Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.power.production"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.power.production"
     },
     {
       "apiVersion": 1,
@@ -2739,7 +2739,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.850Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.pumps.circuit"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.pumps.circuit"
     },
     {
       "apiVersion": 1,
@@ -2751,7 +2751,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.850Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.collector"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.collector"
     },
     {
       "apiVersion": 1,
@@ -2763,7 +2763,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-12-21T16:11:38.850Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.dhw"
     },
     {
       "apiVersion": 1,
@@ -2780,7 +2780,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.850Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation"
     },
     {
       "apiVersion": 1,
@@ -2801,13 +2801,13 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.active/commands/setMode"
         },
         "setModeContinuousSensorOverride": {
           "isExecutable": "false",
           "name": "setModeContinuousSensorOverride",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.active/commands/setModeContinuousSensorOverride"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.active/commands/setModeContinuousSensorOverride"
         }
       },
       "deviceId": "0",
@@ -2822,7 +2822,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -2839,7 +2839,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.850Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.standard"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.standard"
     },
     {
       "apiVersion": 1,
@@ -2856,7 +2856,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.850Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -2873,7 +2873,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.850Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.ventilation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.ventilation"
     },
     {
       "apiVersion": 1,
@@ -2890,7 +2890,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.850Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -2899,13 +2899,13 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.comfort/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.comfort/commands/activate"
         },
         "deactivate": {
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.comfort/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.comfort/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -2920,7 +2920,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -2929,13 +2929,13 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.eco/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.eco/commands/activate"
         },
         "deactivate": {
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.eco/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.eco/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -2950,7 +2950,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -2968,7 +2968,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.holiday/commands/changeEndDate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.holiday/commands/changeEndDate"
         },
         "schedule": {
           "isExecutable": true,
@@ -2990,13 +2990,13 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.holiday/commands/schedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.holiday/commands/schedule"
         },
         "unschedule": {
           "isExecutable": true,
           "name": "unschedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.holiday/commands/unschedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.holiday/commands/unschedule"
         }
       },
       "deviceId": "0",
@@ -3019,7 +3019,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.holiday"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.holiday"
     },
     {
       "apiVersion": 1,
@@ -3036,7 +3036,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.850Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelFour"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelFour"
     },
     {
       "apiVersion": 1,
@@ -3053,7 +3053,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.850Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelOne"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelOne"
     },
     {
       "apiVersion": 1,
@@ -3070,7 +3070,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.850Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelThree"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelThree"
     },
     {
       "apiVersion": 1,
@@ -3087,7 +3087,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.850Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelTwo"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelTwo"
     },
     {
       "apiVersion": 1,
@@ -3109,7 +3109,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.850Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -3134,7 +3134,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -3294,7 +3294,7 @@
         }
       },
       "timestamp": "2023-12-21T16:11:38.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.schedule"
     }
   ]
 }

--- a/tests/response/Vitocharge05.json
+++ b/tests/response/Vitocharge05.json
@@ -15,7 +15,7 @@
         }
       },
       "timestamp": "2024-12-14T19:52:37.544Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/device.messages.errors.raw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/device.messages.errors.raw"
     },
     {
       "apiVersion": 1,
@@ -37,7 +37,7 @@
         }
       },
       "timestamp": "2024-12-14T19:52:37.544Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/device.productIdentification"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/device.productIdentification"
     },
     {
       "apiVersion": 1,
@@ -54,7 +54,7 @@
         }
       },
       "timestamp": "2024-12-14T19:52:37.544Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/device.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/device.serial"
     },
     {
       "apiVersion": 1,
@@ -71,7 +71,7 @@
         }
       },
       "timestamp": "2024-12-18T15:13:53.165Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ess.operationState"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ess.operationState"
     },
     {
       "apiVersion": 1,
@@ -89,7 +89,7 @@
         }
       },
       "timestamp": "2024-12-18T15:13:54.657Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ess.power"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ess.power"
     },
     {
       "apiVersion": 1,
@@ -107,7 +107,7 @@
         }
       },
       "timestamp": "2024-12-18T13:41:08.478Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ess.stateOfCharge"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ess.stateOfCharge"
     },
     {
       "apiVersion": 1,
@@ -145,7 +145,7 @@
         }
       },
       "timestamp": "2024-12-18T15:13:56.163Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ess.transfer.discharge.cumulated"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/ess.transfer.discharge.cumulated"
     },
     {
       "apiVersion": 1,
@@ -162,7 +162,7 @@
         }
       },
       "timestamp": "2024-12-14T19:52:37.544Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/heating.boiler.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/heating.boiler.serial"
     },
     {
       "apiVersion": 1,
@@ -180,7 +180,7 @@
         }
       },
       "timestamp": "2024-12-18T16:54:33.546Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/pcc.transfer.consumption.total"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/pcc.transfer.consumption.total"
     },
     {
       "apiVersion": 1,
@@ -198,7 +198,7 @@
         }
       },
       "timestamp": "2024-12-18T10:00:34.783Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/pcc.transfer.feedIn.total"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/pcc.transfer.feedIn.total"
     },
     {
       "apiVersion": 1,
@@ -216,7 +216,7 @@
         }
       },
       "timestamp": "2024-12-18T16:54:38.941Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/pcc.transfer.power.exchange"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/pcc.transfer.power.exchange"
     },
     {
       "apiVersion": 1,
@@ -254,7 +254,7 @@
         }
       },
       "timestamp": "2024-12-18T15:13:18.692Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/photovoltaic.production.cumulated"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/photovoltaic.production.cumulated"
     },
     {
       "apiVersion": 1,
@@ -272,7 +272,7 @@
         }
       },
       "timestamp": "2024-12-18T15:01:39.005Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/photovoltaic.production.current"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/photovoltaic.production.current"
     },
     {
       "apiVersion": 1,
@@ -289,7 +289,7 @@
         }
       },
       "timestamp": "2024-12-18T14:55:21.555Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/photovoltaic.status"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/################/features/photovoltaic.status"
     }
   ]
 }

--- a/tests/response/VitochargeVX3.json
+++ b/tests/response/VitochargeVX3.json
@@ -15,7 +15,7 @@
         }
       },
       "timestamp": "2023-05-25T14:43:26.622Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/device.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/device.serial"
     },
     {
       "apiVersion": 1,
@@ -32,7 +32,7 @@
         }
       },
       "timestamp": "2023-05-26T18:33:10.937Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/ess.operationState"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/ess.operationState"
     },
     {
       "apiVersion": 1,
@@ -50,7 +50,7 @@
         }
       },
       "timestamp": "2023-05-26T20:21:12.542Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/ess.power"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/ess.power"
     },
     {
       "apiVersion": 1,
@@ -68,7 +68,7 @@
         }
       },
       "timestamp": "2023-05-26T20:20:30.651Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/ess.stateOfCharge"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/ess.stateOfCharge"
     },
     {
       "apiVersion": 1,
@@ -106,7 +106,7 @@
         }
       },
       "timestamp": "2023-05-26T20:21:05.602Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/ess.transfer.discharge.cumulated"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/ess.transfer.discharge.cumulated"
     },
     {
       "apiVersion": 1,
@@ -123,7 +123,7 @@
         }
       },
       "timestamp": "2023-05-25T14:43:26.623Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
     },
     {
       "apiVersion": 1,
@@ -141,7 +141,7 @@
         }
       },
       "timestamp": "2023-05-25T16:55:44.150Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/pcc.transfer.consumption.total"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/pcc.transfer.consumption.total"
     },
     {
       "apiVersion": 1,
@@ -159,7 +159,7 @@
         }
       },
       "timestamp": "2023-05-26T18:19:16.330Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/pcc.transfer.feedIn.total"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/pcc.transfer.feedIn.total"
     },
     {
       "apiVersion": 1,
@@ -177,7 +177,7 @@
         }
       },
       "timestamp": "2023-05-26T20:21:05.602Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/pcc.transfer.power.exchange"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/pcc.transfer.power.exchange"
     },
     {
       "apiVersion": 1,
@@ -215,7 +215,7 @@
         }
       },
       "timestamp": "2023-05-26T19:22:09.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/photovoltaic.production.cumulated"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/photovoltaic.production.cumulated"
     },
     {
       "apiVersion": 1,
@@ -233,7 +233,7 @@
         }
       },
       "timestamp": "2023-05-26T19:19:13.292Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/photovoltaic.production.current"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/photovoltaic.production.current"
     },
     {
       "apiVersion": 1,
@@ -250,7 +250,7 @@
         }
       },
       "timestamp": "2023-05-26T19:10:36.637Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/photovoltaic.status"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/photovoltaic.status"
     }
   ]
 }

--- a/tests/response/VitoconnectOpto1.json
+++ b/tests/response/VitoconnectOpto1.json
@@ -42,7 +42,7 @@
         }
       },
       "timestamp": "2023-12-25T04:01:00.448Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/features/gateway.devices"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/features/gateway.devices"
     },
     {
       "apiVersion": 1,
@@ -59,7 +59,7 @@
         }
       },
       "timestamp": "2023-12-26T20:44:41.417Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/features/gateway.wifi"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/features/gateway.wifi"
     }
   ]
 }

--- a/tests/response/VitoconnectOpto2.json
+++ b/tests/response/VitoconnectOpto2.json
@@ -102,7 +102,7 @@
         }
       },
       "timestamp": "2024-03-28T05:06:02.633Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/######/gateways/##############/features/gateway.devices"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/######/gateways/##############/features/gateway.devices"
     },
     {
       "apiVersion": 1,
@@ -119,7 +119,7 @@
         }
       },
       "timestamp": "2024-03-30T17:31:57.758Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/######/gateways/##############/features/gateway.wifi"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/######/gateways/##############/features/gateway.wifi"
     }
   ]
 }

--- a/tests/response/Vitodens050W.json
+++ b/tests/response/Vitodens050W.json
@@ -15,7 +15,7 @@
         }
       },
       "timestamp": "2025-01-17T14:42:40.580Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.messages.errors.raw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.messages.errors.raw"
     },
     {
       "apiVersion": 1,
@@ -32,7 +32,7 @@
         }
       },
       "timestamp": "2025-01-17T14:42:40.580Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.serial"
     },
     {
       "apiVersion": 1,
@@ -54,7 +54,7 @@
         }
       },
       "timestamp": "2025-01-18T09:56:18.569Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
     },
     {
       "apiVersion": 1,
@@ -71,7 +71,7 @@
         }
       },
       "timestamp": "2025-01-17T14:42:40.580Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
     },
     {
       "apiVersion": 1,
@@ -89,7 +89,7 @@
         }
       },
       "timestamp": "2025-01-17T14:42:40.580Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.temperature"
     },
     {
       "apiVersion": 1,
@@ -108,7 +108,7 @@
         }
       },
       "timestamp": "2025-01-17T14:42:40.580Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners"
     },
     {
       "apiVersion": 1,
@@ -125,7 +125,7 @@
         }
       },
       "timestamp": "2025-01-18T09:32:48.963Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0"
     },
     {
       "apiVersion": 1,
@@ -143,7 +143,7 @@
         }
       },
       "timestamp": "2025-01-18T09:32:31.435Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0.modulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0.modulation"
     },
     {
       "apiVersion": 1,
@@ -166,7 +166,7 @@
         }
       },
       "timestamp": "2025-01-18T09:32:11.976Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0.statistics"
     },
     {
       "apiVersion": 1,
@@ -185,7 +185,7 @@
         }
       },
       "timestamp": "2025-01-17T14:42:40.580Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits"
     },
     {
       "apiVersion": 1,
@@ -203,7 +203,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0/commands/setName"
         }
       },
       "deviceId": "0",
@@ -226,7 +226,7 @@
         }
       },
       "timestamp": "2025-01-17T14:42:40.580Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0"
     },
     {
       "apiVersion": 1,
@@ -243,7 +243,7 @@
         }
       },
       "timestamp": "2025-01-17T14:42:40.580Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -261,7 +261,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name/commands/setName"
         }
       },
       "components": [],
@@ -277,7 +277,7 @@
         }
       },
       "timestamp": "2025-01-17T14:42:40.580Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name"
     },
     {
       "apiVersion": 1,
@@ -297,7 +297,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
         }
       },
       "deviceId": "0",
@@ -312,7 +312,7 @@
         }
       },
       "timestamp": "2025-01-18T09:10:33.195Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -329,7 +329,7 @@
         }
       },
       "timestamp": "2025-01-18T09:10:33.195Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -346,7 +346,7 @@
         }
       },
       "timestamp": "2025-01-18T09:10:33.195Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -363,7 +363,7 @@
         }
       },
       "timestamp": "2025-01-18T09:10:49.159Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -388,7 +388,7 @@
         }
       },
       "timestamp": "2025-01-18T09:10:49.159Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -409,7 +409,7 @@
         }
       },
       "timestamp": "2025-01-18T09:10:49.159Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.noDemand"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.noDemand"
     },
     {
       "apiVersion": 1,
@@ -428,7 +428,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -452,7 +452,7 @@
         }
       },
       "timestamp": "2025-01-18T09:10:49.159Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -477,7 +477,7 @@
         }
       },
       "timestamp": "2025-01-18T09:10:49.159Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -502,7 +502,7 @@
         }
       },
       "timestamp": "2025-01-18T09:10:49.159Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -524,7 +524,7 @@
         }
       },
       "timestamp": "2025-01-18T09:56:15.153Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -542,7 +542,7 @@
         }
       },
       "timestamp": "2025-01-18T09:10:34.183Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature"
     },
     {
       "apiVersion": 1,
@@ -570,7 +570,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setLevels"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setLevels"
         },
         "setMax": {
           "isExecutable": false,
@@ -586,7 +586,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setMax"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setMax"
         },
         "setMin": {
           "isExecutable": false,
@@ -602,7 +602,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setMin"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setMin"
         }
       },
       "deviceId": "0",
@@ -623,7 +623,7 @@
         }
       },
       "timestamp": "2025-01-17T14:42:40.580Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels"
     },
     {
       "apiVersion": 1,
@@ -644,7 +644,7 @@
         }
       },
       "timestamp": "2025-01-17T14:42:40.580Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw"
     },
     {
       "apiVersion": 1,
@@ -654,14 +654,14 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.comfort/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.comfort/commands/activate"
         },
         "deactivate": {
           "isDeprecated": true,
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.comfort/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.comfort/commands/deactivate"
         }
       },
       "deprecated": {
@@ -680,7 +680,7 @@
         }
       },
       "timestamp": "2025-01-17T14:42:40.580Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.comfort"
     },
     {
       "apiVersion": 1,
@@ -701,7 +701,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active/commands/setMode"
         }
       },
       "deviceId": "0",
@@ -716,7 +716,7 @@
         }
       },
       "timestamp": "2025-01-17T14:42:40.580Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -733,7 +733,7 @@
         }
       },
       "timestamp": "2024-09-23T10:42:35.347Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.balanced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.balanced"
     },
     {
       "apiVersion": 1,
@@ -750,7 +750,7 @@
         }
       },
       "timestamp": "2025-01-17T14:42:40.580Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.comfort"
     },
     {
       "apiVersion": 1,
@@ -767,7 +767,7 @@
         }
       },
       "timestamp": "2025-01-17T14:42:40.580Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.eco"
     },
     {
       "apiVersion": 1,
@@ -784,7 +784,7 @@
         }
       },
       "timestamp": "2025-01-17T14:42:40.580Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.off"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.off"
     },
     {
       "apiVersion": 1,
@@ -801,7 +801,7 @@
         }
       },
       "timestamp": "2024-09-23T10:42:35.347Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
     },
     {
       "apiVersion": 1,
@@ -813,7 +813,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-01-17T14:42:40.580Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.primary"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.primary"
     },
     {
       "apiVersion": 1,
@@ -825,7 +825,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-01-17T14:42:40.580Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.secondary"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.secondary"
     },
     {
       "apiVersion": 1,
@@ -847,7 +847,7 @@
         }
       },
       "timestamp": "2025-01-18T09:55:09.319Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder"
     },
     {
       "apiVersion": 1,
@@ -873,7 +873,7 @@
         }
       },
       "timestamp": "2025-01-18T09:55:09.319Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
     },
     {
       "apiVersion": 1,
@@ -895,7 +895,7 @@
         }
       },
       "timestamp": "2025-01-18T09:57:22.114Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.outlet"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.outlet"
     },
     {
       "apiVersion": 1,
@@ -916,7 +916,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
         }
       },
       "deviceId": "0",
@@ -932,7 +932,7 @@
         }
       },
       "timestamp": "2025-01-17T14:42:40.580Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -975,7 +975,7 @@
         }
       },
       "timestamp": "2025-01-18T08:57:31.203Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.summary.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.summary.dhw"
     },
     {
       "apiVersion": 1,
@@ -1018,7 +1018,7 @@
         }
       },
       "timestamp": "2025-01-18T08:13:28.058Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.summary.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.summary.heating"
     },
     {
       "apiVersion": 1,
@@ -1061,7 +1061,7 @@
         }
       },
       "timestamp": "2025-01-17T22:47:56.081Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.dhw"
     },
     {
       "apiVersion": 1,
@@ -1104,7 +1104,7 @@
         }
       },
       "timestamp": "2025-01-18T08:33:07.017Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.heating"
     },
     {
       "apiVersion": 1,
@@ -1116,7 +1116,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2025-01-17T14:42:40.580Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar"
     }
   ]
 }

--- a/tests/response/Vitodens100NA.json
+++ b/tests/response/Vitodens100NA.json
@@ -15,7 +15,7 @@
         }
       },
       "timestamp": "2024-09-30T10:50:12.522Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/device.messages.errors.raw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/device.messages.errors.raw"
     },
     {
       "apiVersion": 1,
@@ -32,7 +32,7 @@
         }
       },
       "timestamp": "2024-09-30T10:50:12.522Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/device.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/device.serial"
     },
     {
       "apiVersion": 1,
@@ -54,7 +54,7 @@
         }
       },
       "timestamp": "2024-10-01T06:49:40.978Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
     },
     {
       "apiVersion": 1,
@@ -71,7 +71,7 @@
         }
       },
       "timestamp": "2024-09-30T10:50:12.522Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
     },
     {
       "apiVersion": 1,
@@ -89,7 +89,7 @@
         }
       },
       "timestamp": "2024-09-30T10:50:12.522Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.boiler.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.boiler.temperature"
     },
     {
       "apiVersion": 1,
@@ -108,7 +108,7 @@
         }
       },
       "timestamp": "2024-09-30T10:50:12.522Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.burners"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.burners"
     },
     {
       "apiVersion": 1,
@@ -125,7 +125,7 @@
         }
       },
       "timestamp": "2024-10-01T05:25:55.843Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.burners.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.burners.0"
     },
     {
       "apiVersion": 1,
@@ -143,7 +143,7 @@
         }
       },
       "timestamp": "2024-10-01T05:25:50.985Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.burners.0.modulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.burners.0.modulation"
     },
     {
       "apiVersion": 1,
@@ -166,7 +166,7 @@
         }
       },
       "timestamp": "2024-10-01T05:18:14.515Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.burners.0.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.burners.0.statistics"
     },
     {
       "apiVersion": 1,
@@ -187,7 +187,7 @@
         }
       },
       "timestamp": "2024-09-30T10:50:12.522Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw"
     },
     {
       "apiVersion": 1,
@@ -196,13 +196,13 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/activate"
         },
         "deactivate": {
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -217,7 +217,7 @@
         }
       },
       "timestamp": "2024-09-30T10:50:12.522Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge"
     },
     {
       "apiVersion": 1,
@@ -237,7 +237,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active/commands/setMode"
         }
       },
       "deviceId": "0",
@@ -252,7 +252,7 @@
         }
       },
       "timestamp": "2024-09-30T10:50:12.522Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -269,7 +269,7 @@
         }
       },
       "timestamp": "2024-09-30T10:50:12.522Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.balanced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.balanced"
     },
     {
       "apiVersion": 1,
@@ -286,7 +286,7 @@
         }
       },
       "timestamp": "2024-09-30T10:50:12.522Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.off"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.off"
     },
     {
       "apiVersion": 1,
@@ -303,7 +303,7 @@
         }
       },
       "timestamp": "2024-09-30T10:50:15.836Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.primary"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.primary"
     },
     {
       "apiVersion": 1,
@@ -315,7 +315,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-09-30T10:50:15.836Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.secondary"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.secondary"
     },
     {
       "apiVersion": 1,
@@ -324,7 +324,7 @@
           "isExecutable": true,
           "name": "resetSchedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule/commands/resetSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule/commands/resetSchedule"
         },
         "setSchedule": {
           "isExecutable": true,
@@ -344,7 +344,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -420,7 +420,7 @@
         }
       },
       "timestamp": "2024-09-30T10:50:12.522Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule"
     },
     {
       "apiVersion": 1,
@@ -442,7 +442,7 @@
         }
       },
       "timestamp": "2024-10-01T05:28:27.772Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder"
     },
     {
       "apiVersion": 1,
@@ -468,7 +468,7 @@
         }
       },
       "timestamp": "2024-10-01T05:28:27.772Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
     },
     {
       "apiVersion": 1,
@@ -485,7 +485,7 @@
         }
       },
       "timestamp": "2024-09-30T10:50:14.479Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.outlet"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.outlet"
     },
     {
       "apiVersion": 1,
@@ -506,7 +506,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
         }
       },
       "deviceId": "0",
@@ -522,7 +522,7 @@
         }
       },
       "timestamp": "2024-09-30T10:50:12.522Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -603,7 +603,7 @@
         }
       },
       "timestamp": "2024-10-01T05:19:23.801Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.dhw"
     },
     {
       "apiVersion": 1,
@@ -684,7 +684,7 @@
         }
       },
       "timestamp": "2024-10-01T02:59:16.438Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.heating"
     },
     {
       "apiVersion": 1,
@@ -727,7 +727,7 @@
         }
       },
       "timestamp": "2024-10-01T05:19:23.801Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.summary.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.summary.dhw"
     },
     {
       "apiVersion": 1,
@@ -770,7 +770,7 @@
         }
       },
       "timestamp": "2024-09-30T10:50:12.522Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.summary.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.summary.heating"
     },
     {
       "apiVersion": 1,
@@ -851,7 +851,7 @@
         }
       },
       "timestamp": "2024-10-01T05:19:23.801Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.total"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.total"
     },
     {
       "apiVersion": 1,
@@ -932,7 +932,7 @@
         }
       },
       "timestamp": "2024-10-01T03:00:31.916Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.dhw"
     },
     {
       "apiVersion": 1,
@@ -1013,7 +1013,7 @@
         }
       },
       "timestamp": "2024-10-01T03:00:31.916Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.heating"
     },
     {
       "apiVersion": 1,
@@ -1056,7 +1056,7 @@
         }
       },
       "timestamp": "2024-10-01T03:00:31.916Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.dhw"
     },
     {
       "apiVersion": 1,
@@ -1099,7 +1099,7 @@
         }
       },
       "timestamp": "2024-10-01T03:00:31.916Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.heating"
     },
     {
       "apiVersion": 1,
@@ -1180,7 +1180,7 @@
         }
       },
       "timestamp": "2024-10-01T03:00:31.916Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.total"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.total"
     },
     {
       "apiVersion": 1,
@@ -1202,7 +1202,7 @@
         }
       },
       "timestamp": "2024-10-01T06:20:14.125Z",
-      "uri": "https://api.viessmann.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.outside"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.outside"
     }
   ]
 }

--- a/tests/response/Vitodens100W.json
+++ b/tests/response/Vitodens100W.json
@@ -13,7 +13,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:29.783Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/device"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/device"
     },
     {
       "apiVersion": 1,
@@ -31,7 +31,7 @@
         }
       },
       "timestamp": "2021-12-09T20:39:43.724Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/device.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/device.serial"
     },
     {
       "apiVersion": 1,
@@ -52,7 +52,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:29.783Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating"
     },
     {
       "apiVersion": 1,
@@ -69,7 +69,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:29.783Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler"
     },
     {
       "apiVersion": 1,
@@ -82,7 +82,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:29.783Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors"
     },
     {
       "apiVersion": 1,
@@ -109,7 +109,7 @@
         }
       },
       "timestamp": "2021-12-09T20:55:21.037Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
     },
     {
       "apiVersion": 1,
@@ -127,7 +127,7 @@
         }
       },
       "timestamp": "2021-12-09T20:39:53.170Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
     },
     {
       "apiVersion": 1,
@@ -150,7 +150,7 @@
         }
       },
       "timestamp": "2021-12-09T20:39:43.845Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.temperature"
     },
     {
       "apiVersion": 1,
@@ -165,7 +165,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:29.783Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners"
     },
     {
       "apiVersion": 1,
@@ -186,7 +186,7 @@
         }
       },
       "timestamp": "2021-12-09T20:51:10.031Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners.0"
     },
     {
       "apiVersion": 1,
@@ -209,7 +209,7 @@
         }
       },
       "timestamp": "2021-12-09T20:51:01.120Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners.0.modulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners.0.modulation"
     },
     {
       "apiVersion": 1,
@@ -237,7 +237,7 @@
         }
       },
       "timestamp": "2021-12-09T20:45:42.800Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners.0.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners.0.statistics"
     },
     {
       "apiVersion": 1,
@@ -260,7 +260,7 @@
         }
       },
       "timestamp": "2021-12-09T20:39:44.623Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits"
     },
     {
       "apiVersion": 1,
@@ -278,7 +278,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0/commands/setName"
         }
       },
       "components": [
@@ -308,7 +308,7 @@
         }
       },
       "timestamp": "2021-12-09T20:39:44.438Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0"
     },
     {
       "apiVersion": 1,
@@ -321,7 +321,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:29.783Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.circulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.circulation"
     },
     {
       "apiVersion": 1,
@@ -339,7 +339,7 @@
         }
       },
       "timestamp": "2021-12-09T20:39:47.581Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -357,7 +357,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name/commands/setName"
         }
       },
       "components": [],
@@ -373,7 +373,7 @@
         }
       },
       "timestamp": "2021-12-09T20:39:44.438Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name"
     },
     {
       "apiVersion": 1,
@@ -389,7 +389,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:29.783Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating"
     },
     {
       "apiVersion": 1,
@@ -408,7 +408,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:29.783Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes"
     },
     {
       "apiVersion": 1,
@@ -430,7 +430,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
         }
       },
       "components": [],
@@ -446,7 +446,7 @@
         }
       },
       "timestamp": "2021-12-09T20:39:57.928Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -464,7 +464,7 @@
         }
       },
       "timestamp": "2021-12-09T20:39:57.871Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -482,7 +482,7 @@
         }
       },
       "timestamp": "2021-12-09T20:39:48.505Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -500,7 +500,7 @@
         }
       },
       "timestamp": "2021-12-09T20:39:48.982Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -518,7 +518,7 @@
         }
       },
       "timestamp": "2021-12-09T20:39:47.814Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -538,7 +538,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:29.783Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs"
     },
     {
       "apiVersion": 1,
@@ -556,7 +556,7 @@
         }
       },
       "timestamp": "2021-12-09T20:50:49.231Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -582,7 +582,7 @@
         }
       },
       "timestamp": "2021-12-09T20:39:48.870Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -602,7 +602,7 @@
         }
       },
       "timestamp": "2021-12-09T20:50:49.243Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.noDemand"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.noDemand"
     },
     {
       "apiVersion": 1,
@@ -629,7 +629,7 @@
         }
       },
       "timestamp": "2021-12-09T20:39:49.807Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.noDemand.hmiState"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.noDemand.hmiState"
     },
     {
       "apiVersion": 1,
@@ -648,7 +648,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature"
         }
       },
       "components": [],
@@ -673,7 +673,7 @@
         }
       },
       "timestamp": "2021-12-09T20:50:49.239Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -699,7 +699,7 @@
         }
       },
       "timestamp": "2021-12-09T20:50:49.110Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -725,7 +725,7 @@
         }
       },
       "timestamp": "2021-12-09T20:50:48.979Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -740,7 +740,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:29.783Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors"
     },
     {
       "apiVersion": 1,
@@ -755,7 +755,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:29.783Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature"
     },
     {
       "apiVersion": 1,
@@ -782,7 +782,7 @@
         }
       },
       "timestamp": "2021-12-09T20:55:19.921Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -805,7 +805,7 @@
         }
       },
       "timestamp": "2021-12-09T20:50:50.993Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature"
     },
     {
       "apiVersion": 1,
@@ -823,7 +823,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:44.605Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1"
     },
     {
       "apiVersion": 1,
@@ -836,7 +836,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:47.632Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -849,7 +849,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-11-29T14:55:09.761Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.name"
     },
     {
       "apiVersion": 1,
@@ -865,7 +865,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:29.783Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating"
     },
     {
       "apiVersion": 1,
@@ -884,7 +884,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:29.783Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes"
     },
     {
       "apiVersion": 1,
@@ -897,7 +897,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:40:00.165Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -910,7 +910,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:40:00.138Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -923,7 +923,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:48.618Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -936,7 +936,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:49.157Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -949,7 +949,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:48.027Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -969,7 +969,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:29.783Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs"
     },
     {
       "apiVersion": 1,
@@ -982,7 +982,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:56.969Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -995,7 +995,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:48.910Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1015,7 +1015,7 @@
         }
       },
       "timestamp": "2021-12-09T20:39:57.659Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.noDemand"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.noDemand"
     },
     {
       "apiVersion": 1,
@@ -1028,7 +1028,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:49.854Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.noDemand.hmiState"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.noDemand.hmiState"
     },
     {
       "apiVersion": 1,
@@ -1041,7 +1041,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:57.350Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -1054,7 +1054,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:48.838Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1067,7 +1067,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:48.804Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -1082,7 +1082,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:29.783Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors"
     },
     {
       "apiVersion": 1,
@@ -1097,7 +1097,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:29.783Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature"
     },
     {
       "apiVersion": 1,
@@ -1110,7 +1110,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:50.133Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1123,7 +1123,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:47.474Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature"
     },
     {
       "apiVersion": 1,
@@ -1138,7 +1138,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:29.783Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.configuration"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.configuration"
     },
     {
       "apiVersion": 1,
@@ -1156,7 +1156,7 @@
         }
       },
       "timestamp": "2021-12-09T20:39:49.915Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.configuration.multiFamilyHouse"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.configuration.multiFamilyHouse"
     },
     {
       "apiVersion": 1,
@@ -1182,7 +1182,7 @@
         }
       },
       "timestamp": "2021-12-09T20:39:54.589Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw"
     },
     {
       "apiVersion": 1,
@@ -1195,7 +1195,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:45.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.comfort"
     },
     {
       "apiVersion": 1,
@@ -1210,7 +1210,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:54.386Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
     },
     {
       "apiVersion": 1,
@@ -1223,7 +1223,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:54.650Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
     },
     {
       "apiVersion": 1,
@@ -1241,7 +1241,7 @@
         }
       },
       "timestamp": "2021-12-09T20:39:47.522Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.primary"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.primary"
     },
     {
       "apiVersion": 1,
@@ -1254,7 +1254,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:47.552Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.secondary"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.secondary"
     },
     {
       "apiVersion": 1,
@@ -1267,7 +1267,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:29.783Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors"
     },
     {
       "apiVersion": 1,
@@ -1294,7 +1294,7 @@
         }
       },
       "timestamp": "2021-12-09T20:54:19.963Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
     },
     {
       "apiVersion": 1,
@@ -1316,7 +1316,7 @@
         }
       },
       "timestamp": "2021-12-09T20:39:45.393Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.outlet"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.outlet"
     },
     {
       "apiVersion": 1,
@@ -1331,7 +1331,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:29.783Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature"
     },
     {
       "apiVersion": 1,
@@ -1352,7 +1352,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
         }
       },
       "components": [],
@@ -1369,7 +1369,7 @@
         }
       },
       "timestamp": "2021-12-09T20:39:47.493Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -1417,7 +1417,7 @@
         }
       },
       "timestamp": "2021-12-09T20:39:50.252Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.summary.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.summary.dhw"
     },
     {
       "apiVersion": 1,
@@ -1465,7 +1465,7 @@
         }
       },
       "timestamp": "2021-12-09T20:40:04.601Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.summary.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.summary.heating"
     },
     {
       "apiVersion": 1,
@@ -1478,7 +1478,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:29.783Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption"
     },
     {
       "apiVersion": 1,
@@ -1526,7 +1526,7 @@
         }
       },
       "timestamp": "2021-12-09T20:39:50.535Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.dhw"
     },
     {
       "apiVersion": 1,
@@ -1574,7 +1574,7 @@
         }
       },
       "timestamp": "2021-12-09T20:54:32.928Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.heating"
     },
     {
       "apiVersion": 1,
@@ -1587,7 +1587,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:29.783Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors"
     },
     {
       "apiVersion": 1,
@@ -1602,7 +1602,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:50.612Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar"
     },
     {
       "apiVersion": 1,
@@ -1617,7 +1617,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:29.783Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.sensors"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.sensors"
     },
     {
       "apiVersion": 1,
@@ -1633,7 +1633,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:29.783Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature"
     },
     {
       "apiVersion": 1,
@@ -1646,7 +1646,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:51.307Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.collector"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.collector"
     },
     {
       "apiVersion": 1,
@@ -1659,7 +1659,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-12-09T20:39:51.398Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.dhw"
     }
   ]
 }

--- a/tests/response/Vitodens100W_B1HC-26.json
+++ b/tests/response/Vitodens100W_B1HC-26.json
@@ -20,7 +20,7 @@
         }
       },
       "timestamp": "2023-01-04T21:13:08.143Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
     },
     {
       "apiVersion": 1,
@@ -39,7 +39,7 @@
         }
       },
       "timestamp": "2023-01-04T09:41:00.575Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners"
     },
     {
       "apiVersion": 1,
@@ -56,7 +56,7 @@
         }
       },
       "timestamp": "2023-01-04T20:30:47.554Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners.0"
     },
     {
       "apiVersion": 1,
@@ -79,7 +79,7 @@
         }
       },
       "timestamp": "2023-01-04T20:35:47.590Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners.0.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners.0.statistics"
     },
     {
       "apiVersion": 1,
@@ -98,7 +98,7 @@
         }
       },
       "timestamp": "2023-01-04T09:40:59.356Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits"
     },
     {
       "apiVersion": 1,
@@ -116,7 +116,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0/commands/setName"
         }
       },
       "deviceId": "0",
@@ -139,7 +139,7 @@
         }
       },
       "timestamp": "2023-01-04T09:40:59.356Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0"
     },
     {
       "apiVersion": 1,
@@ -163,7 +163,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -239,7 +239,7 @@
         }
       },
       "timestamp": "2023-01-04T09:40:59.356Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -257,7 +257,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.name/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.name/commands/setName"
         }
       },
       "components": [],
@@ -273,7 +273,7 @@
         }
       },
       "timestamp": "2023-01-04T09:40:59.356Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.name"
     },
     {
       "apiVersion": 1,
@@ -294,7 +294,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
         }
       },
       "deviceId": "0",
@@ -309,7 +309,7 @@
         }
       },
       "timestamp": "2023-01-04T09:41:01.669Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -326,7 +326,7 @@
         }
       },
       "timestamp": "2023-01-04T09:40:59.356Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -343,7 +343,7 @@
         }
       },
       "timestamp": "2023-01-04T09:40:59.356Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -360,7 +360,7 @@
         }
       },
       "timestamp": "2023-01-04T09:40:59.356Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -377,7 +377,7 @@
         }
       },
       "timestamp": "2023-01-04T09:41:01.711Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -396,13 +396,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/deactivate"
         },
         "setTemperature": {
           "isExecutable": true,
@@ -418,7 +418,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -442,7 +442,7 @@
         }
       },
       "timestamp": "2023-01-04T09:40:59.356Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -461,13 +461,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.manual/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.manual/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.manual/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.manual/commands/deactivate"
         },
         "setTemperature": {
           "isExecutable": true,
@@ -483,7 +483,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.manual/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.manual/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -498,7 +498,7 @@
         }
       },
       "timestamp": "2023-01-04T09:40:59.356Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.manual"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.manual"
     },
     {
       "apiVersion": 1,
@@ -517,7 +517,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -541,7 +541,7 @@
         }
       },
       "timestamp": "2023-01-04T09:40:59.356Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -560,7 +560,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -584,7 +584,7 @@
         }
       },
       "timestamp": "2023-01-04T09:40:59.356Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -601,7 +601,7 @@
         }
       },
       "timestamp": "2023-01-04T09:40:59.356Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -623,7 +623,7 @@
         }
       },
       "timestamp": "2023-01-04T21:07:34.261Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -651,7 +651,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setLevels"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setLevels"
         },
         "setMax": {
           "isExecutable": true,
@@ -667,7 +667,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setMax"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setMax"
         },
         "setMin": {
           "isExecutable": false,
@@ -683,7 +683,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setMin"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setMin"
         }
       },
       "deviceId": "0",
@@ -712,7 +712,7 @@
         }
       },
       "timestamp": "2023-01-04T09:40:59.356Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels"
     },
     {
       "apiVersion": 1,
@@ -733,7 +733,7 @@
         }
       },
       "timestamp": "2023-01-04T09:40:59.356Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw"
     },
     {
       "apiVersion": 1,
@@ -756,7 +756,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -832,7 +832,7 @@
         }
       },
       "timestamp": "2023-01-04T09:40:59.356Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.schedule"
     },
     {
       "apiVersion": 1,
@@ -854,7 +854,7 @@
         }
       },
       "timestamp": "2023-01-04T21:10:41.473Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
     },
     {
       "apiVersion": 1,
@@ -875,7 +875,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
         }
       },
       "deviceId": "0",
@@ -891,7 +891,7 @@
         }
       },
       "timestamp": "2023-01-04T09:40:59.356Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -913,7 +913,7 @@
         }
       },
       "timestamp": "2023-01-04T21:07:45.240Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.sensors.temperature.outside"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.sensors.temperature.outside"
     }
   ]
 }

--- a/tests/response/Vitodens200W_2.json
+++ b/tests/response/Vitodens200W_2.json
@@ -15,7 +15,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:36.784Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/device.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/device.serial"
     },
     {
       "apiVersion": 1,
@@ -27,7 +27,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:36.760Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
     },
     {
       "apiVersion": 1,
@@ -49,7 +49,7 @@
         }
       },
       "timestamp": "2022-09-03T20:33:27.920Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.boiler.sensors.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.boiler.sensors.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -66,7 +66,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:36.774Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.boiler.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.boiler.serial"
     },
     {
       "apiVersion": 1,
@@ -84,7 +84,7 @@
         }
       },
       "timestamp": "2022-09-03T19:44:10.422Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.boiler.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.boiler.temperature"
     },
     {
       "apiVersion": 1,
@@ -103,7 +103,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:36.821Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.burners"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.burners"
     },
     {
       "apiVersion": 1,
@@ -120,7 +120,7 @@
         }
       },
       "timestamp": "2022-09-03T19:44:19.039Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.burners.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.burners.0"
     },
     {
       "apiVersion": 1,
@@ -138,7 +138,7 @@
         }
       },
       "timestamp": "2022-09-03T19:44:10.532Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.burners.0.modulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.burners.0.modulation"
     },
     {
       "apiVersion": 1,
@@ -161,7 +161,7 @@
         }
       },
       "timestamp": "2022-09-03T20:10:51.030Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.burners.0.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.burners.0.statistics"
     },
     {
       "apiVersion": 1,
@@ -181,7 +181,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits"
     },
     {
       "apiVersion": 1,
@@ -199,7 +199,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0/commands/setName"
         }
       },
       "deviceId": "0",
@@ -222,7 +222,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0"
     },
     {
       "apiVersion": 1,
@@ -239,7 +239,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:49.438Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -251,7 +251,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.dhw.pumps.circulation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.dhw.pumps.circulation.schedule"
     },
     {
       "apiVersion": 1,
@@ -263,7 +263,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.dhw.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.dhw.schedule"
     },
     {
       "apiVersion": 1,
@@ -280,7 +280,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:37.001Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -308,7 +308,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve"
         }
       },
       "deviceId": "0",
@@ -329,7 +329,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -352,7 +352,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -428,7 +428,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -446,7 +446,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.name/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.name/commands/setName"
         }
       },
       "components": [],
@@ -462,7 +462,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.name"
     },
     {
       "apiVersion": 1,
@@ -485,7 +485,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
         }
       },
       "deviceId": "0",
@@ -500,7 +500,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:49.659Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -517,7 +517,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -534,7 +534,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -546,7 +546,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -563,7 +563,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -580,7 +580,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:49.517Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -599,13 +599,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/deactivate"
         },
         "setTemperature": {
           "isExecutable": true,
@@ -621,7 +621,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -645,7 +645,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -654,13 +654,13 @@
           "isExecutable": false,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -680,7 +680,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -702,7 +702,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.external"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.external"
     },
     {
       "apiVersion": 1,
@@ -714,7 +714,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.holiday"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.holiday"
     },
     {
       "apiVersion": 1,
@@ -733,7 +733,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -757,7 +757,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -776,7 +776,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -800,7 +800,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -817,7 +817,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -829,7 +829,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:47.954Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -851,7 +851,7 @@
         }
       },
       "timestamp": "2022-09-03T20:33:37.533Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -869,7 +869,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1/commands/setName"
         }
       },
       "deviceId": "0",
@@ -892,7 +892,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1"
     },
     {
       "apiVersion": 1,
@@ -909,7 +909,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:49.455Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -921,7 +921,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.dhw.pumps.circulation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.dhw.pumps.circulation.schedule"
     },
     {
       "apiVersion": 1,
@@ -933,7 +933,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.dhw.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.dhw.schedule"
     },
     {
       "apiVersion": 1,
@@ -950,7 +950,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:37.011Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -978,7 +978,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.heating.curve/commands/setCurve"
         }
       },
       "deviceId": "0",
@@ -999,7 +999,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -1022,7 +1022,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.heating.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.heating.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -1098,7 +1098,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -1116,7 +1116,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.name/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.name/commands/setName"
         }
       },
       "components": [],
@@ -1132,7 +1132,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.name"
     },
     {
       "apiVersion": 1,
@@ -1155,7 +1155,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active/commands/setMode"
         }
       },
       "deviceId": "0",
@@ -1170,7 +1170,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:49.975Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -1187,7 +1187,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -1204,7 +1204,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -1216,7 +1216,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -1233,7 +1233,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -1250,7 +1250,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:49.546Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1269,13 +1269,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort/commands/deactivate"
         },
         "setTemperature": {
           "isExecutable": true,
@@ -1291,7 +1291,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -1315,7 +1315,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -1324,13 +1324,13 @@
           "isExecutable": false,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.eco/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.eco/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.eco/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.eco/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -1350,7 +1350,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -1372,7 +1372,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.external"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.external"
     },
     {
       "apiVersion": 1,
@@ -1384,7 +1384,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.holiday"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.holiday"
     },
     {
       "apiVersion": 1,
@@ -1403,7 +1403,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -1427,7 +1427,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -1446,7 +1446,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -1470,7 +1470,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -1487,7 +1487,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1499,7 +1499,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:48.010Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1521,7 +1521,7 @@
         }
       },
       "timestamp": "2022-09-03T15:58:35.610Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1533,7 +1533,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2"
     },
     {
       "apiVersion": 1,
@@ -1545,7 +1545,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:49.481Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -1557,7 +1557,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.dhw.pumps.circulation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.dhw.pumps.circulation.schedule"
     },
     {
       "apiVersion": 1,
@@ -1569,7 +1569,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.dhw.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.dhw.schedule"
     },
     {
       "apiVersion": 1,
@@ -1581,7 +1581,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:37.019Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1609,7 +1609,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.heating.curve/commands/setCurve"
         }
       },
       "deviceId": "0",
@@ -1630,7 +1630,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -1642,7 +1642,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -1655,7 +1655,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-11-30T10:35:46.635Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.name"
     },
     {
       "apiVersion": 1,
@@ -1667,7 +1667,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:50.328Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -1679,7 +1679,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -1691,7 +1691,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -1703,7 +1703,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -1715,7 +1715,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -1727,7 +1727,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:49.574Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1739,7 +1739,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -1751,7 +1751,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -1763,7 +1763,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.programs.external"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.programs.external"
     },
     {
       "apiVersion": 1,
@@ -1775,7 +1775,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.programs.holiday"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.programs.holiday"
     },
     {
       "apiVersion": 1,
@@ -1787,7 +1787,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -1799,7 +1799,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -1811,7 +1811,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1823,7 +1823,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:48.082Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1835,7 +1835,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:48.738Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1852,7 +1852,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:48.780Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.controller.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.controller.serial"
     },
     {
       "apiVersion": 1,
@@ -1873,7 +1873,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw"
     },
     {
       "apiVersion": 1,
@@ -1890,7 +1890,7 @@
         }
       },
       "timestamp": "2022-09-03T19:44:23.356Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.charging"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.charging"
     },
     {
       "apiVersion": 1,
@@ -1899,13 +1899,13 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -1920,7 +1920,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.oneTimeCharge"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.oneTimeCharge"
     },
     {
       "apiVersion": 1,
@@ -1937,7 +1937,7 @@
         }
       },
       "timestamp": "2022-09-03T02:32:28.187Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
     },
     {
       "apiVersion": 1,
@@ -1960,7 +1960,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -2036,7 +2036,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
     },
     {
       "apiVersion": 1,
@@ -2053,7 +2053,7 @@
         }
       },
       "timestamp": "2022-09-03T19:46:10.677Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.pumps.primary"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.pumps.primary"
     },
     {
       "apiVersion": 1,
@@ -2076,7 +2076,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -2152,7 +2152,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.schedule"
     },
     {
       "apiVersion": 1,
@@ -2174,7 +2174,7 @@
         }
       },
       "timestamp": "2022-09-03T20:34:28.320Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
     },
     {
       "apiVersion": 1,
@@ -2191,7 +2191,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:49.415Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.sensors.temperature.outlet"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.sensors.temperature.outlet"
     },
     {
       "apiVersion": 1,
@@ -2212,7 +2212,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
         }
       },
       "deviceId": "0",
@@ -2228,7 +2228,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:36.304Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.dhw.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -2358,7 +2358,7 @@
         }
       },
       "timestamp": "2022-09-03T19:41:26.111Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.gas.consumption.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.gas.consumption.dhw"
     },
     {
       "apiVersion": 1,
@@ -2488,7 +2488,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:49.041Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.gas.consumption.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.gas.consumption.heating"
     },
     {
       "apiVersion": 1,
@@ -2618,7 +2618,7 @@
         }
       },
       "timestamp": "2022-09-03T19:41:26.163Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.gas.consumption.total"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.gas.consumption.total"
     },
     {
       "apiVersion": 1,
@@ -2636,7 +2636,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
         },
         "schedule": {
           "isExecutable": true,
@@ -2658,13 +2658,13 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/schedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/schedule"
         },
         "unschedule": {
           "isExecutable": true,
           "name": "unschedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
         }
       },
       "deviceId": "0",
@@ -2687,7 +2687,7 @@
         }
       },
       "timestamp": "2022-09-02T08:10:32.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.operating.programs.holiday"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.operating.programs.holiday"
     },
     {
       "apiVersion": 1,
@@ -2817,7 +2817,7 @@
         }
       },
       "timestamp": "2022-09-03T20:32:10.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.power.consumption.total"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.power.consumption.total"
     },
     {
       "apiVersion": 1,
@@ -2839,7 +2839,7 @@
         }
       },
       "timestamp": "2022-09-03T20:11:30.650Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.sensors.temperature.outside"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.sensors.temperature.outside"
     },
     {
       "apiVersion": 1,
@@ -2851,7 +2851,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:51.113Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.solar"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.solar"
     },
     {
       "apiVersion": 1,
@@ -2863,7 +2863,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:51.155Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.solar.power.cumulativeProduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.solar.power.cumulativeProduced"
     },
     {
       "apiVersion": 1,
@@ -2875,7 +2875,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:49.284Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.solar.power.production"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.solar.power.production"
     },
     {
       "apiVersion": 1,
@@ -2887,7 +2887,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:51.272Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.solar.pumps.circuit"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.solar.pumps.circuit"
     },
     {
       "apiVersion": 1,
@@ -2899,7 +2899,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:51.131Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.solar.sensors.temperature.collector"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.solar.sensors.temperature.collector"
     },
     {
       "apiVersion": 1,
@@ -2911,7 +2911,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-02T08:10:49.219Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.solar.sensors.temperature.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/85896/gateways/################/devices/0/features/heating.solar.sensors.temperature.dhw"
     }
   ]
 }

--- a/tests/response/Vitodens200W_B2HA.json
+++ b/tests/response/Vitodens200W_B2HA.json
@@ -15,7 +15,7 @@
         }
       },
       "timestamp": "2022-09-19T05:49:05.601Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/device.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/device.serial"
     },
     {
       "apiVersion": 1,
@@ -27,7 +27,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.599Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
     },
     {
       "apiVersion": 1,
@@ -49,7 +49,7 @@
         }
       },
       "timestamp": "2022-09-20T12:40:54.076Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -66,7 +66,7 @@
         }
       },
       "timestamp": "2022-09-19T05:49:05.600Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
     },
     {
       "apiVersion": 1,
@@ -84,7 +84,7 @@
         }
       },
       "timestamp": "2022-09-20T11:12:49.679Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.temperature"
     },
     {
       "apiVersion": 1,
@@ -103,7 +103,7 @@
         }
       },
       "timestamp": "2022-09-19T05:49:05.605Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners"
     },
     {
       "apiVersion": 1,
@@ -120,7 +120,7 @@
         }
       },
       "timestamp": "2022-09-20T10:20:53.315Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners.0"
     },
     {
       "apiVersion": 1,
@@ -138,7 +138,7 @@
         }
       },
       "timestamp": "2022-09-20T10:21:04.856Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners.0.modulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners.0.modulation"
     },
     {
       "apiVersion": 1,
@@ -161,7 +161,7 @@
         }
       },
       "timestamp": "2022-09-20T10:18:12.311Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners.0.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners.0.statistics"
     },
     {
       "apiVersion": 1,
@@ -180,7 +180,7 @@
         }
       },
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits"
     },
     {
       "apiVersion": 1,
@@ -198,7 +198,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0/commands/setName"
         }
       },
       "deviceId": "0",
@@ -221,7 +221,7 @@
         }
       },
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0"
     },
     {
       "apiVersion": 1,
@@ -238,7 +238,7 @@
         }
       },
       "timestamp": "2022-09-20T11:12:49.717Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -250,7 +250,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.dhw.pumps.circulation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.dhw.pumps.circulation.schedule"
     },
     {
       "apiVersion": 1,
@@ -262,7 +262,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.dhw.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.dhw.schedule"
     },
     {
       "apiVersion": 1,
@@ -279,7 +279,7 @@
         }
       },
       "timestamp": "2022-09-19T05:49:05.623Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -307,7 +307,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve"
         }
       },
       "deviceId": "0",
@@ -328,7 +328,7 @@
         }
       },
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -351,7 +351,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -427,7 +427,7 @@
         }
       },
       "timestamp": "2022-09-20T11:12:33.702Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -445,7 +445,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name/commands/setName"
         }
       },
       "components": [],
@@ -461,7 +461,7 @@
         }
       },
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name"
     },
     {
       "apiVersion": 1,
@@ -484,7 +484,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
         }
       },
       "deviceId": "0",
@@ -499,7 +499,7 @@
         }
       },
       "timestamp": "2022-09-20T11:12:33.840Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -516,7 +516,7 @@
         }
       },
       "timestamp": "2022-09-20T11:12:33.807Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -533,7 +533,7 @@
         }
       },
       "timestamp": "2022-09-20T11:12:33.825Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -545,7 +545,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -562,7 +562,7 @@
         }
       },
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -579,7 +579,7 @@
         }
       },
       "timestamp": "2022-09-20T11:12:37.150Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -598,13 +598,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/deactivate"
         },
         "setTemperature": {
           "isExecutable": true,
@@ -620,7 +620,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -644,7 +644,7 @@
         }
       },
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -653,13 +653,13 @@
           "isExecutable": false,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -679,7 +679,7 @@
         }
       },
       "timestamp": "2022-09-19T07:43:51.864Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -701,7 +701,7 @@
         }
       },
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.external"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.external"
     },
     {
       "apiVersion": 1,
@@ -713,7 +713,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.holiday"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.holiday"
     },
     {
       "apiVersion": 1,
@@ -732,7 +732,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -756,7 +756,7 @@
         }
       },
       "timestamp": "2022-09-19T07:44:06.771Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -775,7 +775,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -799,7 +799,7 @@
         }
       },
       "timestamp": "2022-09-20T11:12:37.120Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -816,7 +816,7 @@
         }
       },
       "timestamp": "2022-09-20T11:12:37.149Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -828,7 +828,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.873Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -850,7 +850,7 @@
         }
       },
       "timestamp": "2022-09-20T12:41:04.276Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -862,7 +862,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1"
     },
     {
       "apiVersion": 1,
@@ -874,7 +874,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.890Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -886,7 +886,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.dhw.pumps.circulation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.dhw.pumps.circulation.schedule"
     },
     {
       "apiVersion": 1,
@@ -898,7 +898,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.dhw.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.dhw.schedule"
     },
     {
       "apiVersion": 1,
@@ -910,7 +910,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.624Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -938,7 +938,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve/commands/setCurve"
         }
       },
       "deviceId": "0",
@@ -959,7 +959,7 @@
         }
       },
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -971,7 +971,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -984,7 +984,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-08-25T20:19:37.216Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.name"
     },
     {
       "apiVersion": 1,
@@ -996,7 +996,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.905Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -1008,7 +1008,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -1020,7 +1020,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -1032,7 +1032,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -1044,7 +1044,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -1056,7 +1056,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.892Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1068,7 +1068,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -1080,7 +1080,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -1092,7 +1092,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.external"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.external"
     },
     {
       "apiVersion": 1,
@@ -1104,7 +1104,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.holiday"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.holiday"
     },
     {
       "apiVersion": 1,
@@ -1116,7 +1116,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -1128,7 +1128,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -1140,7 +1140,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1152,7 +1152,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.874Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1164,7 +1164,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.877Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1176,7 +1176,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2"
     },
     {
       "apiVersion": 1,
@@ -1188,7 +1188,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.890Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -1200,7 +1200,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.dhw.pumps.circulation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.dhw.pumps.circulation.schedule"
     },
     {
       "apiVersion": 1,
@@ -1212,7 +1212,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.dhw.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.dhw.schedule"
     },
     {
       "apiVersion": 1,
@@ -1224,7 +1224,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.625Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1252,7 +1252,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.curve/commands/setCurve"
         }
       },
       "deviceId": "0",
@@ -1273,7 +1273,7 @@
         }
       },
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -1285,7 +1285,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -1298,7 +1298,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-08-25T20:19:37.218Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.name"
     },
     {
       "apiVersion": 1,
@@ -1310,7 +1310,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.913Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -1322,7 +1322,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -1334,7 +1334,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -1346,7 +1346,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -1358,7 +1358,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -1370,7 +1370,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.893Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1382,7 +1382,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -1394,7 +1394,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -1406,7 +1406,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.external"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.external"
     },
     {
       "apiVersion": 1,
@@ -1418,7 +1418,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.holiday"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.holiday"
     },
     {
       "apiVersion": 1,
@@ -1430,7 +1430,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -1442,7 +1442,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -1454,7 +1454,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1466,7 +1466,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.875Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1478,7 +1478,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.877Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1495,7 +1495,7 @@
         }
       },
       "timestamp": "2022-09-19T05:49:05.878Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.controller.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.controller.serial"
     },
     {
       "apiVersion": 1,
@@ -1516,7 +1516,7 @@
         }
       },
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw"
     },
     {
       "apiVersion": 1,
@@ -1533,7 +1533,7 @@
         }
       },
       "timestamp": "2022-09-20T06:19:55.830Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.charging"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.charging"
     },
     {
       "apiVersion": 1,
@@ -1550,7 +1550,7 @@
         }
       },
       "timestamp": "2022-09-20T04:26:06.212Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
     },
     {
       "apiVersion": 1,
@@ -1573,7 +1573,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -1649,7 +1649,7 @@
         }
       },
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
     },
     {
       "apiVersion": 1,
@@ -1666,7 +1666,7 @@
         }
       },
       "timestamp": "2022-09-20T06:21:59.060Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.primary"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.primary"
     },
     {
       "apiVersion": 1,
@@ -1689,7 +1689,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -1807,7 +1807,7 @@
         }
       },
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule"
     },
     {
       "apiVersion": 1,
@@ -1829,7 +1829,7 @@
         }
       },
       "timestamp": "2022-09-20T11:47:47.222Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
     },
     {
       "apiVersion": 1,
@@ -1846,7 +1846,7 @@
         }
       },
       "timestamp": "2022-09-19T05:49:05.888Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.outlet"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.outlet"
     },
     {
       "apiVersion": 1,
@@ -1867,7 +1867,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
         }
       },
       "deviceId": "0",
@@ -1883,7 +1883,7 @@
         }
       },
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -1901,7 +1901,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
         },
         "schedule": {
           "isExecutable": true,
@@ -1923,13 +1923,13 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/schedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/schedule"
         },
         "unschedule": {
           "isExecutable": true,
           "name": "unschedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
         }
       },
       "deviceId": "0",
@@ -1952,7 +1952,7 @@
         }
       },
       "timestamp": "2022-09-19T05:49:05.340Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday"
     },
     {
       "apiVersion": 1,
@@ -1974,7 +1974,7 @@
         }
       },
       "timestamp": "2022-09-20T11:21:11.152Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.outside"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.outside"
     },
     {
       "apiVersion": 1,
@@ -1986,7 +1986,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.929Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar"
     },
     {
       "apiVersion": 1,
@@ -1998,7 +1998,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.931Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.power.cumulativeProduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.power.cumulativeProduced"
     },
     {
       "apiVersion": 1,
@@ -2010,7 +2010,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.929Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.power.production"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.power.production"
     },
     {
       "apiVersion": 1,
@@ -2022,7 +2022,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.934Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.pumps.circuit"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.pumps.circuit"
     },
     {
       "apiVersion": 1,
@@ -2034,7 +2034,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.931Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.collector"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.collector"
     },
     {
       "apiVersion": 1,
@@ -2046,7 +2046,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-09-19T05:49:05.928Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.dhw"
     }
   ]
 }

--- a/tests/response/Vitodens222W.json
+++ b/tests/response/Vitodens222W.json
@@ -13,7 +13,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.034Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/device"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/device"
     },
     {
       "apiVersion": 1,
@@ -31,7 +31,7 @@
         }
       },
       "timestamp": "2021-09-22T01:32:40.518Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/device.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/device.serial"
     },
     {
       "apiVersion": 1,
@@ -54,7 +54,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.034Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating"
     },
     {
       "apiVersion": 1,
@@ -71,7 +71,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.036Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler"
     },
     {
       "apiVersion": 1,
@@ -84,7 +84,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.036Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler.sensors"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler.sensors"
     },
     {
       "apiVersion": 1,
@@ -111,7 +111,7 @@
         }
       },
       "timestamp": "2021-09-30T15:02:21.505Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
     },
     {
       "apiVersion": 1,
@@ -129,7 +129,7 @@
         }
       },
       "timestamp": "2021-09-22T01:32:39.657Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler.serial"
     },
     {
       "apiVersion": 1,
@@ -152,7 +152,7 @@
         }
       },
       "timestamp": "2021-09-22T01:32:41.617Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler.temperature"
     },
     {
       "apiVersion": 1,
@@ -167,7 +167,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.036Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners"
     },
     {
       "apiVersion": 1,
@@ -188,7 +188,7 @@
         }
       },
       "timestamp": "2021-09-30T14:40:10.515Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners.0"
     },
     {
       "apiVersion": 1,
@@ -211,7 +211,7 @@
         }
       },
       "timestamp": "2021-09-30T15:03:14.128Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners.0.modulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners.0.modulation"
     },
     {
       "apiVersion": 1,
@@ -235,7 +235,7 @@
         }
       },
       "timestamp": "2021-09-30T14:44:33.768Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners.0.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners.0.statistics"
     },
     {
       "apiVersion": 1,
@@ -260,7 +260,7 @@
         }
       },
       "timestamp": "2021-09-22T01:32:47.835Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits"
     },
     {
       "apiVersion": 1,
@@ -278,7 +278,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0/commands/setName"
         }
       },
       "components": [
@@ -309,7 +309,7 @@
         }
       },
       "timestamp": "2021-09-22T01:32:44.526Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0"
     },
     {
       "apiVersion": 1,
@@ -324,7 +324,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.035Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.circulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.circulation"
     },
     {
       "apiVersion": 1,
@@ -342,7 +342,7 @@
         }
       },
       "timestamp": "2021-09-30T05:50:28.483Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -360,7 +360,7 @@
         }
       },
       "timestamp": "2021-09-22T01:33:03.823Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -376,7 +376,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.035Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating"
     },
     {
       "apiVersion": 1,
@@ -404,7 +404,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve"
         }
       },
       "components": [],
@@ -426,7 +426,7 @@
         }
       },
       "timestamp": "2021-09-30T12:31:49.238Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -450,7 +450,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule"
         }
       },
       "components": [],
@@ -527,7 +527,7 @@
         }
       },
       "timestamp": "2021-09-30T05:50:27.166Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -543,7 +543,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.035Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating"
     },
     {
       "apiVersion": 1,
@@ -562,7 +562,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.036Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes"
     },
     {
       "apiVersion": 1,
@@ -584,7 +584,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
         }
       },
       "components": [],
@@ -600,7 +600,7 @@
         }
       },
       "timestamp": "2021-09-30T05:50:47.728Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -618,7 +618,7 @@
         }
       },
       "timestamp": "2021-09-22T01:32:52.923Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -636,7 +636,7 @@
         }
       },
       "timestamp": "2021-09-30T05:50:47.198Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -654,7 +654,7 @@
         }
       },
       "timestamp": "2021-09-30T05:50:47.727Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -672,7 +672,7 @@
         }
       },
       "timestamp": "2021-09-30T05:50:27.127Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -692,7 +692,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.035Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs"
     },
     {
       "apiVersion": 1,
@@ -710,7 +710,7 @@
         }
       },
       "timestamp": "2021-09-30T05:50:43.048Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -729,13 +729,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/deactivate"
         },
         "setTemperature": {
           "isExecutable": true,
@@ -751,7 +751,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/setTemperature"
         }
       },
       "components": [],
@@ -776,7 +776,7 @@
         }
       },
       "timestamp": "2021-09-29T00:17:32.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -785,13 +785,13 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule/commands/deactivate"
         }
       },
       "components": [],
@@ -807,7 +807,7 @@
         }
       },
       "timestamp": "2021-09-30T05:50:47.740Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule"
     },
     {
       "apiVersion": 1,
@@ -826,7 +826,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature"
         }
       },
       "components": [],
@@ -851,7 +851,7 @@
         }
       },
       "timestamp": "2021-09-30T05:50:43.040Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -870,7 +870,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced/commands/setTemperature"
         }
       },
       "components": [],
@@ -895,7 +895,7 @@
         }
       },
       "timestamp": "2021-09-29T00:17:32.830Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -913,7 +913,7 @@
         }
       },
       "timestamp": "2021-09-30T05:50:43.015Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -928,7 +928,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.037Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.sensors"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.sensors"
     },
     {
       "apiVersion": 1,
@@ -944,7 +944,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.037Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature"
     },
     {
       "apiVersion": 1,
@@ -957,7 +957,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:33:02.104Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -984,7 +984,7 @@
         }
       },
       "timestamp": "2021-09-30T15:02:19.289Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -997,7 +997,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:49.093Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.temperature"
     },
     {
       "apiVersion": 1,
@@ -1017,7 +1017,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:45.615Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1"
     },
     {
       "apiVersion": 1,
@@ -1032,7 +1032,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.037Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.circulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.circulation"
     },
     {
       "apiVersion": 1,
@@ -1045,7 +1045,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:44.469Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -1058,7 +1058,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:33:03.843Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1074,7 +1074,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.035Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.heating"
     },
     {
       "apiVersion": 1,
@@ -1102,7 +1102,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.heating.curve/commands/setCurve"
         }
       },
       "components": [],
@@ -1124,7 +1124,7 @@
         }
       },
       "timestamp": "2021-09-22T01:33:02.887Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -1137,7 +1137,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:33:01.047Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -1153,7 +1153,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.035Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating"
     },
     {
       "apiVersion": 1,
@@ -1172,7 +1172,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.036Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes"
     },
     {
       "apiVersion": 1,
@@ -1185,7 +1185,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-30T05:50:47.742Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -1198,7 +1198,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:53.428Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -1211,7 +1211,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:54.126Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -1224,7 +1224,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:58.316Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -1237,7 +1237,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:51.843Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -1257,7 +1257,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.035Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs"
     },
     {
       "apiVersion": 1,
@@ -1270,7 +1270,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:33:04.992Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1283,7 +1283,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-29T00:17:32.730Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -1296,7 +1296,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-30T05:50:47.756Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule"
     },
     {
       "apiVersion": 1,
@@ -1309,7 +1309,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-29T00:17:32.745Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -1322,7 +1322,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-29T00:17:32.830Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -1335,7 +1335,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:49.776Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1350,7 +1350,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.037Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.sensors"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.sensors"
     },
     {
       "apiVersion": 1,
@@ -1366,7 +1366,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.037Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature"
     },
     {
       "apiVersion": 1,
@@ -1379,7 +1379,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:33:02.152Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1392,7 +1392,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:33:02.272Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1405,7 +1405,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:49.355Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.temperature"
     },
     {
       "apiVersion": 1,
@@ -1425,7 +1425,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:46.565Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2"
     },
     {
       "apiVersion": 1,
@@ -1440,7 +1440,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.037Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.circulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.circulation"
     },
     {
       "apiVersion": 1,
@@ -1453,7 +1453,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:44.483Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -1466,7 +1466,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:33:03.854Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1482,7 +1482,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.036Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.heating"
     },
     {
       "apiVersion": 1,
@@ -1510,7 +1510,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.heating.curve/commands/setCurve"
         }
       },
       "components": [],
@@ -1532,7 +1532,7 @@
         }
       },
       "timestamp": "2021-09-22T01:33:02.924Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -1545,7 +1545,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:33:01.067Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -1561,7 +1561,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.035Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating"
     },
     {
       "apiVersion": 1,
@@ -1580,7 +1580,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.036Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes"
     },
     {
       "apiVersion": 1,
@@ -1593,7 +1593,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-30T05:50:47.758Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -1606,7 +1606,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:53.567Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -1619,7 +1619,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:54.891Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -1632,7 +1632,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:59.969Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -1645,7 +1645,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:52.460Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -1665,7 +1665,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.035Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs"
     },
     {
       "apiVersion": 1,
@@ -1678,7 +1678,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:33:05.013Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1691,7 +1691,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-29T00:17:32.730Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -1704,7 +1704,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-30T05:50:47.770Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.forcedLastFromSchedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.forcedLastFromSchedule"
     },
     {
       "apiVersion": 1,
@@ -1717,7 +1717,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-29T00:17:32.745Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -1730,7 +1730,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-29T00:17:32.831Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -1743,7 +1743,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:49.790Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1758,7 +1758,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.038Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.sensors"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.sensors"
     },
     {
       "apiVersion": 1,
@@ -1774,7 +1774,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.038Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature"
     },
     {
       "apiVersion": 1,
@@ -1787,7 +1787,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:33:02.193Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1800,7 +1800,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:33:02.394Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1813,7 +1813,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:49.417Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.temperature"
     },
     {
       "apiVersion": 1,
@@ -1833,7 +1833,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:47.827Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3"
     },
     {
       "apiVersion": 1,
@@ -1848,7 +1848,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.037Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.circulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.circulation"
     },
     {
       "apiVersion": 1,
@@ -1861,7 +1861,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:44.501Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -1874,7 +1874,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:33:03.885Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1890,7 +1890,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.036Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.heating"
     },
     {
       "apiVersion": 1,
@@ -1918,7 +1918,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.heating.curve/commands/setCurve"
         }
       },
       "components": [],
@@ -1940,7 +1940,7 @@
         }
       },
       "timestamp": "2021-09-22T01:33:03.001Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -1953,7 +1953,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:33:01.088Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -1969,7 +1969,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.035Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating"
     },
     {
       "apiVersion": 1,
@@ -1988,7 +1988,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.036Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.modes"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.modes"
     },
     {
       "apiVersion": 1,
@@ -2001,7 +2001,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-30T05:50:47.773Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -2014,7 +2014,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:53.711Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -2027,7 +2027,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:55.649Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -2040,7 +2040,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:33:00.857Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -2053,7 +2053,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:52.811Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -2073,7 +2073,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.035Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs"
     },
     {
       "apiVersion": 1,
@@ -2086,7 +2086,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:33:05.024Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -2099,7 +2099,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-29T00:17:32.730Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -2112,7 +2112,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-30T05:50:47.785Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.forcedLastFromSchedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.forcedLastFromSchedule"
     },
     {
       "apiVersion": 1,
@@ -2125,7 +2125,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-29T00:17:32.745Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -2138,7 +2138,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-29T00:17:32.831Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -2151,7 +2151,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:49.805Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -2166,7 +2166,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.038Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.sensors"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.sensors"
     },
     {
       "apiVersion": 1,
@@ -2182,7 +2182,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.038Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature"
     },
     {
       "apiVersion": 1,
@@ -2195,7 +2195,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:33:02.213Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -2208,7 +2208,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:33:02.494Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -2221,7 +2221,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:49.435Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.temperature"
     },
     {
       "apiVersion": 1,
@@ -2236,7 +2236,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.034Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.configuration"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.configuration"
     },
     {
       "apiVersion": 1,
@@ -2254,7 +2254,7 @@
         }
       },
       "timestamp": "2021-09-22T01:33:01.096Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.configuration.multiFamilyHouse"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.configuration.multiFamilyHouse"
     },
     {
       "apiVersion": 1,
@@ -2269,7 +2269,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.036Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.device"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.device"
     },
     {
       "apiVersion": 1,
@@ -2284,7 +2284,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.036Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.device.time"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.device.time"
     },
     {
       "apiVersion": 1,
@@ -2303,7 +2303,7 @@
         }
       },
       "timestamp": "2021-09-26T22:04:12.871Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.device.time.offset"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.device.time.offset"
     },
     {
       "apiVersion": 1,
@@ -2331,7 +2331,7 @@
         }
       },
       "timestamp": "2021-09-30T05:50:47.068Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw"
     },
     {
       "apiVersion": 1,
@@ -2340,19 +2340,19 @@
           "isExecutable": false,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/activate"
         },
         "disable": {
           "isExecutable": false,
           "name": "disable",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/disable"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/disable"
         },
         "enable": {
           "isExecutable": true,
           "name": "enable",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/enable"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/enable"
         }
       },
       "components": [
@@ -2370,7 +2370,7 @@
         }
       },
       "timestamp": "2021-09-22T01:33:03.918Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.hygiene"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.hygiene"
     },
     {
       "apiVersion": 1,
@@ -2383,7 +2383,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:33:03.965Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.hygiene.trigger"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.hygiene.trigger"
     },
     {
       "apiVersion": 1,
@@ -2392,13 +2392,13 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate"
         }
       },
       "components": [],
@@ -2414,7 +2414,7 @@
         }
       },
       "timestamp": "2021-09-22T01:33:01.993Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge"
     },
     {
       "apiVersion": 1,
@@ -2434,7 +2434,7 @@
         }
       },
       "timestamp": "2021-09-30T06:16:26.721Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
     },
     {
       "apiVersion": 1,
@@ -2457,7 +2457,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/setSchedule"
         }
       },
       "components": [],
@@ -2576,7 +2576,7 @@
         }
       },
       "timestamp": "2021-09-30T05:50:47.069Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
     },
     {
       "apiVersion": 1,
@@ -2594,7 +2594,7 @@
         }
       },
       "timestamp": "2021-09-22T01:32:42.228Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.pumps.primary"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.pumps.primary"
     },
     {
       "apiVersion": 1,
@@ -2617,7 +2617,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule"
         }
       },
       "components": [],
@@ -2736,7 +2736,7 @@
         }
       },
       "timestamp": "2021-09-30T05:50:47.786Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.schedule"
     },
     {
       "apiVersion": 1,
@@ -2749,7 +2749,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.036Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.sensors"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.sensors"
     },
     {
       "apiVersion": 1,
@@ -2776,7 +2776,7 @@
         }
       },
       "timestamp": "2021-09-30T15:03:02.629Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
     },
     {
       "apiVersion": 1,
@@ -2803,7 +2803,7 @@
         }
       },
       "timestamp": "2021-09-30T15:02:51.240Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.outlet"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.outlet"
     },
     {
       "apiVersion": 1,
@@ -2819,7 +2819,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.035Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.temperature"
     },
     {
       "apiVersion": 1,
@@ -2832,7 +2832,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:33:03.933Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.temperature.hygiene"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.temperature.hygiene"
     },
     {
       "apiVersion": 1,
@@ -2853,7 +2853,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
         }
       },
       "components": [],
@@ -2870,7 +2870,7 @@
         }
       },
       "timestamp": "2021-09-22T01:32:49.732Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -2956,7 +2956,7 @@
         }
       },
       "timestamp": "2021-09-30T07:57:07.078Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.gas.consumption.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.gas.consumption.dhw"
     },
     {
       "apiVersion": 1,
@@ -3042,7 +3042,7 @@
         }
       },
       "timestamp": "2021-09-30T14:25:09.690Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.gas.consumption.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.gas.consumption.heating"
     },
     {
       "apiVersion": 1,
@@ -3128,7 +3128,7 @@
         }
       },
       "timestamp": "2021-09-30T14:25:09.773Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.gas.consumption.total"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.gas.consumption.total"
     },
     {
       "apiVersion": 1,
@@ -3143,7 +3143,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.035Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating"
     },
     {
       "apiVersion": 1,
@@ -3159,7 +3159,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.035Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs"
     },
     {
       "apiVersion": 1,
@@ -3177,7 +3177,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
         },
         "schedule": {
           "isExecutable": true,
@@ -3199,13 +3199,13 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/schedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/schedule"
         },
         "unschedule": {
           "isExecutable": true,
           "name": "unschedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
         }
       },
       "components": [],
@@ -3229,7 +3229,7 @@
         }
       },
       "timestamp": "2021-09-22T01:33:03.230Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holiday"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holiday"
     },
     {
       "apiVersion": 1,
@@ -3247,7 +3247,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/changeEndDate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/changeEndDate"
         },
         "schedule": {
           "isExecutable": true,
@@ -3269,13 +3269,13 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/schedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/schedule"
         },
         "unschedule": {
           "isExecutable": true,
           "name": "unschedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/unschedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/unschedule"
         }
       },
       "components": [],
@@ -3299,7 +3299,7 @@
         }
       },
       "timestamp": "2021-09-22T01:33:03.721Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome"
     },
     {
       "apiVersion": 1,
@@ -3316,7 +3316,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.037Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.power.consumption"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.power.consumption"
     },
     {
       "apiVersion": 1,
@@ -3402,7 +3402,7 @@
         }
       },
       "timestamp": "2021-09-29T00:17:35.303Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.power.consumption.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.power.consumption.dhw"
     },
     {
       "apiVersion": 1,
@@ -3488,7 +3488,7 @@
         }
       },
       "timestamp": "2021-09-30T14:56:23.104Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.power.consumption.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.power.consumption.heating"
     },
     {
       "apiVersion": 1,
@@ -3574,7 +3574,7 @@
         }
       },
       "timestamp": "2021-09-30T14:56:23.163Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.power.consumption.total"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.power.consumption.total"
     },
     {
       "apiVersion": 1,
@@ -3589,7 +3589,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.035Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.sensors"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.sensors"
     },
     {
       "apiVersion": 1,
@@ -3604,7 +3604,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.037Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.sensors.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.sensors.temperature"
     },
     {
       "apiVersion": 1,
@@ -3631,7 +3631,7 @@
         }
       },
       "timestamp": "2021-09-30T15:03:23.602Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.sensors.temperature.outside"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.sensors.temperature.outside"
     },
     {
       "apiVersion": 1,
@@ -3647,7 +3647,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:43.700Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar"
     },
     {
       "apiVersion": 1,
@@ -3660,7 +3660,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:43.731Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.power.production"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.power.production"
     },
     {
       "apiVersion": 1,
@@ -3675,7 +3675,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.037Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.pumps"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.pumps"
     },
     {
       "apiVersion": 1,
@@ -3688,7 +3688,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:43.740Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.pumps.circuit"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.pumps.circuit"
     },
     {
       "apiVersion": 1,
@@ -3703,7 +3703,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.036Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.sensors"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.sensors"
     },
     {
       "apiVersion": 1,
@@ -3719,7 +3719,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:19.037Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.sensors.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.sensors.temperature"
     },
     {
       "apiVersion": 1,
@@ -3732,7 +3732,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:43.722Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.sensors.temperature.collector"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.sensors.temperature.collector"
     },
     {
       "apiVersion": 1,
@@ -3745,7 +3745,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-09-22T01:32:43.778Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.sensors.temperature.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.sensors.temperature.dhw"
     }
   ]
 }

--- a/tests/response/Vitodens343F_B3UF.json
+++ b/tests/response/Vitodens343F_B3UF.json
@@ -15,7 +15,7 @@
         }
       },
       "timestamp": "2023-01-13T03:39:47.222Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/device.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/device.serial"
     },
     {
       "apiVersion": 1,
@@ -37,7 +37,7 @@
         }
       },
       "timestamp": "2023-01-13T17:36:50.651Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
     },
     {
       "apiVersion": 1,
@@ -54,7 +54,7 @@
         }
       },
       "timestamp": "2023-01-13T03:40:06.136Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler.serial"
     },
     {
       "apiVersion": 1,
@@ -72,7 +72,7 @@
         }
       },
       "timestamp": "2023-01-13T03:39:47.549Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.boiler.temperature"
     },
     {
       "apiVersion": 1,
@@ -84,7 +84,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:39:47.586Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.buffer.sensors.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.buffer.sensors.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -103,7 +103,7 @@
         }
       },
       "timestamp": "2023-01-13T03:39:47.916Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners"
     },
     {
       "apiVersion": 1,
@@ -120,7 +120,7 @@
         }
       },
       "timestamp": "2023-01-13T17:14:21.463Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners.0"
     },
     {
       "apiVersion": 1,
@@ -138,7 +138,7 @@
         }
       },
       "timestamp": "2023-01-13T17:36:43.906Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners.0.modulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners.0.modulation"
     },
     {
       "apiVersion": 1,
@@ -161,7 +161,7 @@
         }
       },
       "timestamp": "2023-01-13T17:32:12.050Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners.0.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.burners.0.statistics"
     },
     {
       "apiVersion": 1,
@@ -180,7 +180,7 @@
         }
       },
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits"
     },
     {
       "apiVersion": 1,
@@ -198,7 +198,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0/commands/setName"
         }
       },
       "deviceId": "0",
@@ -221,7 +221,7 @@
         }
       },
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0"
     },
     {
       "apiVersion": 1,
@@ -238,7 +238,7 @@
         }
       },
       "timestamp": "2023-01-13T14:01:53.329Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -255,7 +255,7 @@
         }
       },
       "timestamp": "2023-01-13T03:39:51.658Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -283,7 +283,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve"
         }
       },
       "deviceId": "0",
@@ -304,7 +304,7 @@
         }
       },
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -328,7 +328,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -446,7 +446,7 @@
         }
       },
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -464,7 +464,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.name/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.name/commands/setName"
         }
       },
       "components": [],
@@ -480,7 +480,7 @@
         }
       },
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.name"
     },
     {
       "apiVersion": 1,
@@ -500,7 +500,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
         }
       },
       "deviceId": "0",
@@ -515,7 +515,7 @@
         }
       },
       "timestamp": "2023-01-13T03:39:58.071Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -532,7 +532,7 @@
         }
       },
       "timestamp": "2023-01-12T22:58:15.138Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -549,7 +549,7 @@
         }
       },
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -566,7 +566,7 @@
         }
       },
       "timestamp": "2023-01-13T14:01:53.414Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -585,13 +585,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/deactivate"
         },
         "setTemperature": {
           "isExecutable": true,
@@ -607,7 +607,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -631,7 +631,7 @@
         }
       },
       "timestamp": "2023-01-13T14:01:53.399Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -640,13 +640,13 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -661,7 +661,7 @@
         }
       },
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule"
     },
     {
       "apiVersion": 1,
@@ -680,7 +680,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -704,7 +704,7 @@
         }
       },
       "timestamp": "2023-01-13T03:40:07.401Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -723,7 +723,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -747,7 +747,7 @@
         }
       },
       "timestamp": "2023-01-13T03:40:07.998Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -764,7 +764,7 @@
         }
       },
       "timestamp": "2023-01-13T14:01:53.411Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -776,7 +776,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:39:56.495Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -798,7 +798,7 @@
         }
       },
       "timestamp": "2023-01-13T17:36:50.703Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -810,7 +810,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T15:13:10.022Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.0.temperature"
     },
     {
       "apiVersion": 1,
@@ -822,7 +822,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1"
     },
     {
       "apiVersion": 1,
@@ -834,7 +834,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T14:01:53.355Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -846,7 +846,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:39:51.689Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -874,7 +874,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.heating.curve/commands/setCurve"
         }
       },
       "deviceId": "0",
@@ -895,7 +895,7 @@
         }
       },
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -907,7 +907,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -920,7 +920,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-11-30T14:09:59.965Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.name"
     },
     {
       "apiVersion": 1,
@@ -932,7 +932,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:39:58.961Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -944,7 +944,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -956,7 +956,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -968,7 +968,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:40:10.950Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -980,7 +980,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:40:06.830Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -992,7 +992,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule"
     },
     {
       "apiVersion": 1,
@@ -1004,7 +1004,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:40:07.404Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -1016,7 +1016,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:40:07.998Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -1028,7 +1028,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1040,7 +1040,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:39:56.500Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1052,7 +1052,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:39:56.529Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1064,7 +1064,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:39:56.590Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.1.temperature"
     },
     {
       "apiVersion": 1,
@@ -1076,7 +1076,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2"
     },
     {
       "apiVersion": 1,
@@ -1088,7 +1088,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T14:01:53.378Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -1100,7 +1100,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:39:51.706Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1128,7 +1128,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.heating.curve/commands/setCurve"
         }
       },
       "deviceId": "0",
@@ -1149,7 +1149,7 @@
         }
       },
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -1161,7 +1161,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -1174,7 +1174,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-11-30T14:10:00.065Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.name"
     },
     {
       "apiVersion": 1,
@@ -1186,7 +1186,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:39:59.102Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -1198,7 +1198,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-12T22:58:13.797Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -1210,7 +1210,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -1222,7 +1222,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:40:11.148Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1234,7 +1234,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:40:06.833Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -1246,7 +1246,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.forcedLastFromSchedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.forcedLastFromSchedule"
     },
     {
       "apiVersion": 1,
@@ -1258,7 +1258,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:40:07.407Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -1270,7 +1270,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:40:07.998Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -1282,7 +1282,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1294,7 +1294,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:39:56.508Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1306,7 +1306,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:39:56.532Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1318,7 +1318,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:39:56.612Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.2.temperature"
     },
     {
       "apiVersion": 1,
@@ -1330,7 +1330,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3"
     },
     {
       "apiVersion": 1,
@@ -1342,7 +1342,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T14:01:53.384Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -1354,7 +1354,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:39:51.720Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1382,7 +1382,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.heating.curve/commands/setCurve"
         }
       },
       "deviceId": "0",
@@ -1403,7 +1403,7 @@
         }
       },
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -1415,7 +1415,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -1428,7 +1428,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-11-30T14:10:00.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.name"
     },
     {
       "apiVersion": 1,
@@ -1440,7 +1440,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:39:59.623Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -1452,7 +1452,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -1464,7 +1464,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -1476,7 +1476,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:40:11.326Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1488,7 +1488,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:40:06.833Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -1500,7 +1500,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.forcedLastFromSchedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.forcedLastFromSchedule"
     },
     {
       "apiVersion": 1,
@@ -1512,7 +1512,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:40:07.407Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -1524,7 +1524,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:40:07.998Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -1536,7 +1536,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1548,7 +1548,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:39:56.520Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1560,7 +1560,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:39:56.538Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1572,7 +1572,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:39:56.649Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.circuits.3.temperature"
     },
     {
       "apiVersion": 1,
@@ -1593,7 +1593,7 @@
         }
       },
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw"
     },
     {
       "apiVersion": 1,
@@ -1602,19 +1602,19 @@
           "isExecutable": false,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/activate"
         },
         "disable": {
           "isExecutable": false,
           "name": "disable",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/disable"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/disable"
         },
         "enable": {
           "isExecutable": true,
           "name": "enable",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/enable"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/enable"
         }
       },
       "deviceId": "0",
@@ -1629,7 +1629,7 @@
         }
       },
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.hygiene"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.hygiene"
     },
     {
       "apiVersion": 1,
@@ -1641,7 +1641,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.hygiene.trigger"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.hygiene.trigger"
     },
     {
       "apiVersion": 1,
@@ -1650,13 +1650,13 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -1671,7 +1671,7 @@
         }
       },
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge"
     },
     {
       "apiVersion": 1,
@@ -1683,7 +1683,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:39:59.958Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
     },
     {
       "apiVersion": 1,
@@ -1695,7 +1695,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
     },
     {
       "apiVersion": 1,
@@ -1707,7 +1707,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T03:39:59.977Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.pumps.primary"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.pumps.primary"
     },
     {
       "apiVersion": 1,
@@ -1719,7 +1719,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-13T14:47:37.922Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.pumps.secondary"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.pumps.secondary"
     },
     {
       "apiVersion": 1,
@@ -1742,7 +1742,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -1860,7 +1860,7 @@
         }
       },
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.schedule"
     },
     {
       "apiVersion": 1,
@@ -1882,7 +1882,7 @@
         }
       },
       "timestamp": "2023-01-13T17:36:42.722Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
     },
     {
       "apiVersion": 1,
@@ -1904,7 +1904,7 @@
         }
       },
       "timestamp": "2023-01-13T17:36:50.754Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.outlet"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.outlet"
     },
     {
       "apiVersion": 1,
@@ -1916,7 +1916,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.temperature.hygiene"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.temperature.hygiene"
     },
     {
       "apiVersion": 1,
@@ -1937,7 +1937,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
         }
       },
       "deviceId": "0",
@@ -1953,7 +1953,7 @@
         }
       },
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.dhw.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -2035,7 +2035,7 @@
         }
       },
       "timestamp": "2023-01-13T14:39:29.961Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.gas.consumption.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.gas.consumption.dhw"
     },
     {
       "apiVersion": 1,
@@ -2117,7 +2117,7 @@
         }
       },
       "timestamp": "2023-01-13T16:07:29.336Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.gas.consumption.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.gas.consumption.heating"
     },
     {
       "apiVersion": 1,
@@ -2160,7 +2160,7 @@
         }
       },
       "timestamp": "2023-01-13T14:39:29.973Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.gas.consumption.summary.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.gas.consumption.summary.dhw"
     },
     {
       "apiVersion": 1,
@@ -2203,7 +2203,7 @@
         }
       },
       "timestamp": "2023-01-13T16:07:29.379Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.gas.consumption.summary.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.gas.consumption.summary.heating"
     },
     {
       "apiVersion": 1,
@@ -2285,7 +2285,7 @@
         }
       },
       "timestamp": "2023-01-13T16:07:29.433Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.gas.consumption.total"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.gas.consumption.total"
     },
     {
       "apiVersion": 1,
@@ -2303,7 +2303,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
         },
         "schedule": {
           "isExecutable": true,
@@ -2325,13 +2325,13 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/schedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/schedule"
         },
         "unschedule": {
           "isExecutable": true,
           "name": "unschedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
         }
       },
       "deviceId": "0",
@@ -2354,7 +2354,7 @@
         }
       },
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holiday"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holiday"
     },
     {
       "apiVersion": 1,
@@ -2372,7 +2372,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/changeEndDate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/changeEndDate"
         },
         "schedule": {
           "isExecutable": true,
@@ -2394,13 +2394,13 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/schedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/schedule"
         },
         "unschedule": {
           "isExecutable": true,
           "name": "unschedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/unschedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/unschedule"
         }
       },
       "deviceId": "0",
@@ -2423,7 +2423,7 @@
         }
       },
       "timestamp": "2023-01-12T22:58:13.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome"
     },
     {
       "apiVersion": 1,
@@ -2505,7 +2505,7 @@
         }
       },
       "timestamp": "2023-01-13T14:39:40.075Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.power.consumption.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.power.consumption.dhw"
     },
     {
       "apiVersion": 1,
@@ -2587,7 +2587,7 @@
         }
       },
       "timestamp": "2023-01-13T17:03:31.035Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.power.consumption.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.power.consumption.heating"
     },
     {
       "apiVersion": 1,
@@ -2630,7 +2630,7 @@
         }
       },
       "timestamp": "2023-01-13T14:39:40.104Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.power.consumption.summary.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.power.consumption.summary.dhw"
     },
     {
       "apiVersion": 1,
@@ -2673,7 +2673,7 @@
         }
       },
       "timestamp": "2023-01-13T17:04:47.014Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.power.consumption.summary.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.power.consumption.summary.heating"
     },
     {
       "apiVersion": 1,
@@ -2755,7 +2755,7 @@
         }
       },
       "timestamp": "2023-01-13T17:04:47.016Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.power.consumption.total"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.power.consumption.total"
     },
     {
       "apiVersion": 1,
@@ -2777,7 +2777,7 @@
         }
       },
       "timestamp": "2023-01-13T17:23:31.938Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.sensors.temperature.outside"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.sensors.temperature.outside"
     },
     {
       "apiVersion": 1,
@@ -2799,7 +2799,7 @@
         }
       },
       "timestamp": "2023-01-13T17:36:54.838Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.sensors.volumetricFlow.allengra"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.sensors.volumetricFlow.allengra"
     },
     {
       "apiVersion": 1,
@@ -2816,7 +2816,7 @@
         }
       },
       "timestamp": "2023-01-13T03:40:02.959Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar"
     },
     {
       "apiVersion": 1,
@@ -2898,7 +2898,7 @@
         }
       },
       "timestamp": "2023-01-13T13:41:25.012Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.power.production"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.power.production"
     },
     {
       "apiVersion": 1,
@@ -2915,7 +2915,7 @@
         }
       },
       "timestamp": "2023-01-13T12:12:22.630Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.pumps.circuit"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.pumps.circuit"
     },
     {
       "apiVersion": 1,
@@ -2937,7 +2937,7 @@
         }
       },
       "timestamp": "2023-01-13T17:36:26.908Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.sensors.temperature.collector"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.sensors.temperature.collector"
     },
     {
       "apiVersion": 1,
@@ -2959,7 +2959,7 @@
         }
       },
       "timestamp": "2023-01-13T17:36:03.408Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.sensors.temperature.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/######/gateways/################/devices/0/features/heating.solar.sensors.temperature.dhw"
     }
   ]
 }

--- a/tests/response/Vitodens_100_BHC_0421.json
+++ b/tests/response/Vitodens_100_BHC_0421.json
@@ -15,7 +15,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.messages.errors.raw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.messages.errors.raw"
     },
     {
       "apiVersion": 1,
@@ -32,7 +32,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.serial"
     },
     {
       "apiVersion": 1,
@@ -54,7 +54,7 @@
         }
       },
       "timestamp": "2024-07-16T21:13:43.127Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
     },
     {
       "apiVersion": 1,
@@ -71,7 +71,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
     },
     {
       "apiVersion": 1,
@@ -89,7 +89,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.temperature"
     },
     {
       "apiVersion": 1,
@@ -108,7 +108,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners"
     },
     {
       "apiVersion": 1,
@@ -125,7 +125,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0"
     },
     {
       "apiVersion": 1,
@@ -143,7 +143,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0.modulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0.modulation"
     },
     {
       "apiVersion": 1,
@@ -166,7 +166,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.burners.0.statistics"
     },
     {
       "apiVersion": 1,
@@ -185,7 +185,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits"
     },
     {
       "apiVersion": 1,
@@ -203,7 +203,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0/commands/setName"
         }
       },
       "deviceId": "0",
@@ -226,7 +226,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0"
     },
     {
       "apiVersion": 1,
@@ -243,7 +243,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -261,7 +261,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name/commands/setName"
         }
       },
       "components": [],
@@ -277,7 +277,7 @@
         }
       },
       "timestamp": "2024-07-16T02:22:33.991Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name"
     },
     {
       "apiVersion": 1,
@@ -297,7 +297,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
         }
       },
       "deviceId": "0",
@@ -312,7 +312,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -329,7 +329,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -346,7 +346,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -363,7 +363,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -388,7 +388,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfortEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -409,7 +409,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.noDemand"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.noDemand"
     },
     {
       "apiVersion": 1,
@@ -428,7 +428,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -452,7 +452,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -477,7 +477,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normalEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -502,7 +502,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reducedEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -524,7 +524,7 @@
         }
       },
       "timestamp": "2024-07-16T21:00:10.065Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -542,7 +542,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature"
     },
     {
       "apiVersion": 1,
@@ -570,7 +570,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setLevels"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setLevels"
         },
         "setMax": {
           "isExecutable": false,
@@ -586,7 +586,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setMax"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setMax"
         },
         "setMin": {
           "isExecutable": false,
@@ -602,7 +602,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setMin"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels/commands/setMin"
         }
       },
       "deviceId": "0",
@@ -623,7 +623,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature.levels"
     },
     {
       "apiVersion": 1,
@@ -635,7 +635,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1"
     },
     {
       "apiVersion": 1,
@@ -647,7 +647,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -660,7 +660,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-01-20T09:10:33.978Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.name"
     },
     {
       "apiVersion": 1,
@@ -672,7 +672,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -684,7 +684,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -696,7 +696,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -708,7 +708,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -720,7 +720,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfortEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -736,7 +736,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.noDemand"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.noDemand"
     },
     {
       "apiVersion": 1,
@@ -748,7 +748,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -760,7 +760,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normalEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -772,7 +772,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedEnergySaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reducedEnergySaving"
     },
     {
       "apiVersion": 1,
@@ -784,7 +784,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -796,7 +796,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature"
     },
     {
       "apiVersion": 1,
@@ -808,7 +808,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature.levels"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature.levels"
     },
     {
       "apiVersion": 1,
@@ -829,7 +829,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw"
     },
     {
       "apiVersion": 1,
@@ -845,7 +845,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.comfort"
     },
     {
       "apiVersion": 1,
@@ -865,7 +865,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active/commands/setMode"
         }
       },
       "deviceId": "0",
@@ -880,7 +880,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -897,7 +897,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.balanced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.balanced"
     },
     {
       "apiVersion": 1,
@@ -909,7 +909,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.comfort"
     },
     {
       "apiVersion": 1,
@@ -921,7 +921,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.eco"
     },
     {
       "apiVersion": 1,
@@ -938,7 +938,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.off"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.off"
     },
     {
       "apiVersion": 1,
@@ -955,7 +955,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
     },
     {
       "apiVersion": 1,
@@ -964,7 +964,7 @@
           "isExecutable": false,
           "name": "resetSchedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/resetSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/resetSchedule"
         },
         "setSchedule": {
           "isExecutable": true,
@@ -984,7 +984,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -1060,7 +1060,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
     },
     {
       "apiVersion": 1,
@@ -1077,7 +1077,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.primary"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.primary"
     },
     {
       "apiVersion": 1,
@@ -1089,7 +1089,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.secondary"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.secondary"
     },
     {
       "apiVersion": 1,
@@ -1111,7 +1111,7 @@
         }
       },
       "timestamp": "2024-07-16T21:05:18.941Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.dhwCylinder"
     },
     {
       "apiVersion": 1,
@@ -1137,7 +1137,7 @@
         }
       },
       "timestamp": "2024-07-16T21:05:18.941Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
     },
     {
       "apiVersion": 1,
@@ -1154,7 +1154,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.outlet"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.outlet"
     },
     {
       "apiVersion": 1,
@@ -1175,7 +1175,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
         }
       },
       "deviceId": "0",
@@ -1191,7 +1191,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -1224,7 +1224,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.summary.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.summary.dhw"
     },
     {
       "apiVersion": 1,
@@ -1257,7 +1257,7 @@
         }
       },
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.summary.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.summary.heating"
     },
     {
       "apiVersion": 1,
@@ -1290,7 +1290,7 @@
         }
       },
       "timestamp": "2024-07-16T21:18:03.988Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.dhw"
     },
     {
       "apiVersion": 1,
@@ -1323,7 +1323,7 @@
         }
       },
       "timestamp": "2024-07-16T21:18:03.988Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.heating"
     },
     {
       "apiVersion": 1,
@@ -1335,7 +1335,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar"
     },
     {
       "apiVersion": 1,
@@ -1347,7 +1347,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.pumps.circuit"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.pumps.circuit"
     },
     {
       "apiVersion": 1,
@@ -1359,7 +1359,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.collector"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.collector"
     },
     {
       "apiVersion": 1,
@@ -1371,7 +1371,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-07-16T17:44:22.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.dhw"
     }
   ]
 }

--- a/tests/response/VitolaUniferral.json
+++ b/tests/response/VitolaUniferral.json
@@ -11,7 +11,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.730Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/device"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/device"
     },
     {
       "apiVersion": 1,
@@ -34,7 +34,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating"
     },
     {
       "apiVersion": 1,
@@ -49,7 +49,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.boiler"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.boiler"
     },
     {
       "apiVersion": 1,
@@ -62,7 +62,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.boiler.sensors"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.boiler.sensors"
     },
     {
       "apiVersion": 1,
@@ -89,7 +89,7 @@
         }
       },
       "timestamp": "2021-10-18T19:22:28.058Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.boiler.sensors.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.boiler.sensors.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -104,7 +104,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.burners"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.burners"
     },
     {
       "apiVersion": 1,
@@ -124,7 +124,7 @@
         }
       },
       "timestamp": "2021-10-18T19:40:24.191Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.burners.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.burners.0"
     },
     {
       "apiVersion": 1,
@@ -148,7 +148,7 @@
         }
       },
       "timestamp": "2021-10-18T18:53:03.338Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.burners.0.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.burners.0.statistics"
     },
     {
       "apiVersion": 1,
@@ -171,7 +171,7 @@
         }
       },
       "timestamp": "2021-10-18T12:53:01.056Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits"
     },
     {
       "apiVersion": 1,
@@ -189,7 +189,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0/commands/setName"
         }
       },
       "components": [
@@ -220,7 +220,7 @@
         }
       },
       "timestamp": "2021-10-18T12:53:01.051Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0"
     },
     {
       "apiVersion": 1,
@@ -235,7 +235,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.circulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.circulation"
     },
     {
       "apiVersion": 1,
@@ -253,7 +253,7 @@
         }
       },
       "timestamp": "2021-10-18T15:31:47.865Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -269,7 +269,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.dhw"
     },
     {
       "apiVersion": 1,
@@ -284,7 +284,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.dhw.pumps"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.dhw.pumps"
     },
     {
       "apiVersion": 1,
@@ -299,7 +299,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.dhw.pumps.circulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.dhw.pumps.circulation"
     },
     {
       "apiVersion": 1,
@@ -312,7 +312,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:01.060Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.dhw.pumps.circulation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.dhw.pumps.circulation.schedule"
     },
     {
       "apiVersion": 1,
@@ -325,7 +325,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:01.078Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.dhw.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.dhw.schedule"
     },
     {
       "apiVersion": 1,
@@ -343,7 +343,7 @@
         }
       },
       "timestamp": "2021-10-18T12:53:01.086Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -360,7 +360,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.heating"
     },
     {
       "apiVersion": 1,
@@ -388,7 +388,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve"
         }
       },
       "components": [],
@@ -410,7 +410,7 @@
         }
       },
       "timestamp": "2021-10-18T12:53:01.093Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -429,7 +429,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.heating.roomInfluenceFactor/commands/setValue"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.heating.roomInfluenceFactor/commands/setValue"
         }
       },
       "components": [],
@@ -446,7 +446,7 @@
         }
       },
       "timestamp": "2021-10-18T12:53:01.982Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.heating.roomInfluenceFactor"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.heating.roomInfluenceFactor"
     },
     {
       "apiVersion": 1,
@@ -469,7 +469,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule"
         }
       },
       "components": [],
@@ -546,7 +546,7 @@
         }
       },
       "timestamp": "2021-10-18T19:40:00.855Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -562,7 +562,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating"
     },
     {
       "apiVersion": 1,
@@ -581,7 +581,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.modes"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.modes"
     },
     {
       "apiVersion": 1,
@@ -604,7 +604,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode"
         }
       },
       "components": [],
@@ -620,7 +620,7 @@
         }
       },
       "timestamp": "2021-10-18T19:40:00.966Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -638,7 +638,7 @@
         }
       },
       "timestamp": "2021-10-18T12:53:01.112Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -656,7 +656,7 @@
         }
       },
       "timestamp": "2021-10-18T19:40:00.884Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -669,7 +669,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:01.898Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -687,7 +687,7 @@
         }
       },
       "timestamp": "2021-10-18T12:53:01.564Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -708,7 +708,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.programs"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.programs"
     },
     {
       "apiVersion": 1,
@@ -726,7 +726,7 @@
         }
       },
       "timestamp": "2021-10-18T19:40:09.297Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -745,13 +745,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/deactivate"
         },
         "setTemperature": {
           "isExecutable": true,
@@ -767,7 +767,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/setTemperature"
         }
       },
       "components": [],
@@ -792,7 +792,7 @@
         }
       },
       "timestamp": "2021-10-18T12:53:01.024Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -801,13 +801,13 @@
           "isExecutable": false,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.programs.eco/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.programs.eco/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.programs.eco/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.programs.eco/commands/deactivate"
         }
       },
       "components": [],
@@ -828,7 +828,7 @@
         }
       },
       "timestamp": "2021-10-18T19:40:09.143Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -841,7 +841,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:01.701Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.programs.holiday"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.programs.holiday"
     },
     {
       "apiVersion": 1,
@@ -860,7 +860,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature"
         }
       },
       "components": [],
@@ -885,7 +885,7 @@
         }
       },
       "timestamp": "2021-10-18T19:40:09.029Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -904,7 +904,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.programs.reduced/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.programs.reduced/commands/setTemperature"
         }
       },
       "components": [],
@@ -929,7 +929,7 @@
         }
       },
       "timestamp": "2021-10-18T19:40:09.263Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -947,7 +947,7 @@
         }
       },
       "timestamp": "2021-10-18T12:53:01.773Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -962,7 +962,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.sensors"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.sensors"
     },
     {
       "apiVersion": 1,
@@ -978,7 +978,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.sensors.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.sensors.temperature"
     },
     {
       "apiVersion": 1,
@@ -1005,7 +1005,7 @@
         }
       },
       "timestamp": "2021-10-18T19:23:24.762Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1032,7 +1032,7 @@
         }
       },
       "timestamp": "2021-10-18T12:53:01.783Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.0.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1052,7 +1052,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:01.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1"
     },
     {
       "apiVersion": 1,
@@ -1067,7 +1067,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.circulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.circulation"
     },
     {
       "apiVersion": 1,
@@ -1080,7 +1080,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:01.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -1096,7 +1096,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.dhw"
     },
     {
       "apiVersion": 1,
@@ -1111,7 +1111,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.dhw.pumps"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.dhw.pumps"
     },
     {
       "apiVersion": 1,
@@ -1126,7 +1126,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.dhw.pumps.circulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.dhw.pumps.circulation"
     },
     {
       "apiVersion": 1,
@@ -1139,7 +1139,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:01.070Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.dhw.pumps.circulation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.dhw.pumps.circulation.schedule"
     },
     {
       "apiVersion": 1,
@@ -1152,7 +1152,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:01.082Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.dhw.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.dhw.schedule"
     },
     {
       "apiVersion": 1,
@@ -1165,7 +1165,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:01.090Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1182,7 +1182,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.heating"
     },
     {
       "apiVersion": 1,
@@ -1210,7 +1210,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.heating.curve/commands/setCurve"
         }
       },
       "components": [],
@@ -1232,7 +1232,7 @@
         }
       },
       "timestamp": "2021-10-18T12:53:01.097Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -1251,7 +1251,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.heating.roomInfluenceFactor/commands/setValue"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.heating.roomInfluenceFactor/commands/setValue"
         }
       },
       "components": [],
@@ -1268,7 +1268,7 @@
         }
       },
       "timestamp": "2021-10-18T12:53:01.986Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.heating.roomInfluenceFactor"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.heating.roomInfluenceFactor"
     },
     {
       "apiVersion": 1,
@@ -1281,7 +1281,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:01.103Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -1297,7 +1297,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.operating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.operating"
     },
     {
       "apiVersion": 1,
@@ -1316,7 +1316,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.operating.modes"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.operating.modes"
     },
     {
       "apiVersion": 1,
@@ -1329,7 +1329,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T19:40:00.947Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -1342,7 +1342,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:01.117Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -1355,7 +1355,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:01.126Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -1368,7 +1368,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:01.922Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -1381,7 +1381,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:01.671Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -1402,7 +1402,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.operating.programs"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.operating.programs"
     },
     {
       "apiVersion": 1,
@@ -1415,7 +1415,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:01.853Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1428,7 +1428,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:01.027Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -1441,7 +1441,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:01.941Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.operating.programs.eco"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.operating.programs.eco"
     },
     {
       "apiVersion": 1,
@@ -1454,7 +1454,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:01.714Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.operating.programs.holiday"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.operating.programs.holiday"
     },
     {
       "apiVersion": 1,
@@ -1467,7 +1467,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:01.748Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -1480,7 +1480,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:01.768Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -1493,7 +1493,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:01.775Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1508,7 +1508,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.sensors"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.sensors"
     },
     {
       "apiVersion": 1,
@@ -1524,7 +1524,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.sensors.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.sensors.temperature"
     },
     {
       "apiVersion": 1,
@@ -1537,7 +1537,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:01.781Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1550,7 +1550,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:01.785Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.circuits.1.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1565,7 +1565,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.configuration"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.configuration"
     },
     {
       "apiVersion": 1,
@@ -1583,7 +1583,7 @@
         }
       },
       "timestamp": "2021-10-18T12:53:01.891Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.configuration.multiFamilyHouse"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.configuration.multiFamilyHouse"
     },
     {
       "apiVersion": 1,
@@ -1598,7 +1598,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.device"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.device"
     },
     {
       "apiVersion": 1,
@@ -1613,7 +1613,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.device.time"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.device.time"
     },
     {
       "apiVersion": 1,
@@ -1632,7 +1632,7 @@
         }
       },
       "timestamp": "2021-10-18T12:53:02.046Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.device.time.offset"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.device.time.offset"
     },
     {
       "apiVersion": 1,
@@ -1659,7 +1659,7 @@
         }
       },
       "timestamp": "2021-10-18T19:40:00.929Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.dhw"
     },
     {
       "apiVersion": 1,
@@ -1677,7 +1677,7 @@
         }
       },
       "timestamp": "2021-10-18T15:31:16.955Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.dhw.charging"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.dhw.charging"
     },
     {
       "apiVersion": 1,
@@ -1697,7 +1697,7 @@
         }
       },
       "timestamp": "2021-10-18T19:40:09.958Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.dhw.pumps.circulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.dhw.pumps.circulation"
     },
     {
       "apiVersion": 1,
@@ -1720,7 +1720,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/setSchedule"
         }
       },
       "components": [],
@@ -1748,7 +1748,7 @@
         }
       },
       "timestamp": "2021-10-18T19:40:00.931Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.dhw.pumps.circulation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.dhw.pumps.circulation.schedule"
     },
     {
       "apiVersion": 1,
@@ -1766,7 +1766,7 @@
         }
       },
       "timestamp": "2021-10-18T15:31:49.785Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.dhw.pumps.primary"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.dhw.pumps.primary"
     },
     {
       "apiVersion": 1,
@@ -1789,7 +1789,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.dhw.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.dhw.schedule/commands/setSchedule"
         }
       },
       "components": [],
@@ -1908,7 +1908,7 @@
         }
       },
       "timestamp": "2021-10-18T19:40:00.933Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.dhw.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.dhw.schedule"
     },
     {
       "apiVersion": 1,
@@ -1921,7 +1921,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.dhw.sensors"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.dhw.sensors"
     },
     {
       "apiVersion": 1,
@@ -1948,7 +1948,7 @@
         }
       },
       "timestamp": "2021-10-18T19:39:40.224Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
     },
     {
       "apiVersion": 1,
@@ -1970,7 +1970,7 @@
         }
       },
       "timestamp": "2021-10-18T12:53:01.841Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.dhw.sensors.temperature.outlet"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.dhw.sensors.temperature.outlet"
     },
     {
       "apiVersion": 1,
@@ -1985,7 +1985,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.dhw.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.dhw.temperature"
     },
     {
       "apiVersion": 1,
@@ -2006,7 +2006,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
         }
       },
       "components": [],
@@ -2023,7 +2023,7 @@
         }
       },
       "timestamp": "2021-10-18T12:53:01.017Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.dhw.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.dhw.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -2038,7 +2038,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.operating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.operating"
     },
     {
       "apiVersion": 1,
@@ -2053,7 +2053,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.operating.programs"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.operating.programs"
     },
     {
       "apiVersion": 1,
@@ -2071,7 +2071,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
         },
         "schedule": {
           "isExecutable": true,
@@ -2093,13 +2093,13 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.operating.programs.holiday/commands/schedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.operating.programs.holiday/commands/schedule"
         },
         "unschedule": {
           "isExecutable": true,
           "name": "unschedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
         }
       },
       "components": [],
@@ -2123,7 +2123,7 @@
         }
       },
       "timestamp": "2021-10-18T12:53:01.975Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.operating.programs.holiday"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.operating.programs.holiday"
     },
     {
       "apiVersion": 1,
@@ -2138,7 +2138,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.sensors"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.sensors"
     },
     {
       "apiVersion": 1,
@@ -2153,7 +2153,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.sensors.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.sensors.temperature"
     },
     {
       "apiVersion": 1,
@@ -2180,7 +2180,7 @@
         }
       },
       "timestamp": "2021-10-18T17:46:19.807Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.sensors.temperature.outside"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.sensors.temperature.outside"
     },
     {
       "apiVersion": 1,
@@ -2196,7 +2196,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:01.945Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.solar"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.solar"
     },
     {
       "apiVersion": 1,
@@ -2211,7 +2211,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.solar.pumps"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.solar.pumps"
     },
     {
       "apiVersion": 1,
@@ -2224,7 +2224,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:01.971Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.solar.pumps.circuit"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.solar.pumps.circuit"
     },
     {
       "apiVersion": 1,
@@ -2239,7 +2239,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.solar.sensors"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.solar.sensors"
     },
     {
       "apiVersion": 1,
@@ -2255,7 +2255,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:00.729Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.solar.sensors.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.solar.sensors.temperature"
     },
     {
       "apiVersion": 1,
@@ -2268,7 +2268,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:01.948Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.solar.sensors.temperature.collector"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.solar.sensors.temperature.collector"
     },
     {
       "apiVersion": 1,
@@ -2281,7 +2281,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-10-18T12:53:01.963Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.solar.sensors.temperature.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/xxxxx/gateways/xxxxx/devices/0/features/heating.solar.sensors.temperature.dhw"
     }
   ]
 }

--- a/tests/response/Vitopure350.json
+++ b/tests/response/Vitopure350.json
@@ -15,7 +15,7 @@
         }
       },
       "timestamp": "2024-10-28T11:38:44.150Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.messages.errors.raw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.messages.errors.raw"
     },
     {
       "apiVersion": 1,
@@ -37,7 +37,7 @@
         }
       },
       "timestamp": "2024-10-28T11:38:44.150Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.productIdentification"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.productIdentification"
     },
     {
       "apiVersion": 1,
@@ -61,13 +61,13 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.time.daylightSaving/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.time.daylightSaving/commands/activate"
         },
         "deactivate": {
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.time.daylightSaving/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.time.daylightSaving/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -82,7 +82,7 @@
         }
       },
       "timestamp": "2024-10-28T11:38:51.162Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.time.daylightSaving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.time.daylightSaving"
     },
     {
       "apiVersion": 1,
@@ -99,7 +99,7 @@
         }
       },
       "timestamp": "2024-10-28T11:38:44.150Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
     },
     {
       "apiVersion": 1,
@@ -116,7 +116,7 @@
         }
       },
       "timestamp": "2024-10-28T11:38:44.150Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.device.variant"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/heating.device.variant"
     },
     {
       "apiVersion": 1,
@@ -133,7 +133,7 @@
         }
       },
       "timestamp": "2024-10-28T11:38:44.150Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation"
     },
     {
       "apiVersion": 1,
@@ -145,7 +145,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-28T11:38:44.150Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.levels.levelFour"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.levels.levelFour"
     },
     {
       "apiVersion": 1,
@@ -157,7 +157,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-28T11:38:44.150Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.levels.levelOne"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.levels.levelOne"
     },
     {
       "apiVersion": 1,
@@ -169,7 +169,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-28T11:38:44.150Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.levels.levelThree"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.levels.levelThree"
     },
     {
       "apiVersion": 1,
@@ -181,7 +181,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-28T11:38:44.150Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.levels.levelTwo"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.levels.levelTwo"
     },
     {
       "apiVersion": 1,
@@ -202,13 +202,13 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.active/commands/setMode"
         },
         "setModeContinuousSensorOverride": {
           "isExecutable": false,
           "name": "setModeContinuousSensorOverride",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.active/commands/setModeContinuousSensorOverride"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.active/commands/setModeContinuousSensorOverride"
         }
       },
       "deviceId": "0",
@@ -223,7 +223,7 @@
         }
       },
       "timestamp": "2024-10-28T11:38:51.162Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -240,7 +240,7 @@
         }
       },
       "timestamp": "2024-10-28T11:38:44.150Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.filterChange"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.filterChange"
     },
     {
       "apiVersion": 1,
@@ -262,7 +262,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.permanent/commands/setLevel"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.permanent/commands/setLevel"
         }
       },
       "deviceId": "0",
@@ -277,7 +277,7 @@
         }
       },
       "timestamp": "2024-10-28T11:38:44.150Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.permanent"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.permanent"
     },
     {
       "apiVersion": 1,
@@ -294,7 +294,7 @@
         }
       },
       "timestamp": "2024-10-28T11:38:44.150Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.sensorDriven"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.sensorDriven"
     },
     {
       "apiVersion": 1,
@@ -311,7 +311,7 @@
         }
       },
       "timestamp": "2024-10-28T11:38:44.150Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.ventilation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.modes.ventilation"
     },
     {
       "apiVersion": 1,
@@ -328,7 +328,7 @@
         }
       },
       "timestamp": "2024-10-28T11:38:44.150Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -348,14 +348,14 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.forcedLevelFour/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.forcedLevelFour/commands/activate"
         },
         "deactivate": {
           "isDeprecated": true,
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.forcedLevelFour/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.forcedLevelFour/commands/deactivate"
         },
         "setDefaultRuntime": {
           "isDeprecated": true,
@@ -372,7 +372,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.forcedLevelFour/commands/setDefaultRuntime"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.forcedLevelFour/commands/setDefaultRuntime"
         },
         "setTimeout": {
           "isDeprecated": true,
@@ -389,7 +389,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.forcedLevelFour/commands/setTimeout"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.forcedLevelFour/commands/setTimeout"
         }
       },
       "deprecated": {
@@ -417,7 +417,7 @@
         }
       },
       "timestamp": "2024-10-28T11:38:51.162Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.forcedLevelFour"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.forcedLevelFour"
     },
     {
       "apiVersion": 1,
@@ -433,7 +433,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-28T11:38:44.150Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelFour"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelFour"
     },
     {
       "apiVersion": 1,
@@ -449,7 +449,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-28T11:38:44.150Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelOne"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelOne"
     },
     {
       "apiVersion": 1,
@@ -465,7 +465,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-28T11:38:44.150Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelThree"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelThree"
     },
     {
       "apiVersion": 1,
@@ -481,7 +481,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2024-10-28T11:38:44.150Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelTwo"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.levelTwo"
     },
     {
       "apiVersion": 1,
@@ -501,14 +501,14 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.silent/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.silent/commands/activate"
         },
         "deactivate": {
           "isDeprecated": true,
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.silent/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.silent/commands/deactivate"
         },
         "setDefaultRuntime": {
           "isDeprecated": true,
@@ -525,7 +525,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.silent/commands/setDefaultRuntime"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.silent/commands/setDefaultRuntime"
         },
         "setTimeout": {
           "isDeprecated": true,
@@ -542,7 +542,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.silent/commands/setTimeout"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.silent/commands/setTimeout"
         }
       },
       "deprecated": {
@@ -570,7 +570,7 @@
         }
       },
       "timestamp": "2024-10-28T11:38:51.162Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.silent"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.silent"
     },
     {
       "apiVersion": 1,
@@ -592,7 +592,7 @@
         }
       },
       "timestamp": "2024-10-28T11:38:44.150Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -617,7 +617,7 @@
         }
       },
       "timestamp": "2024-10-28T11:38:44.150Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.state"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.operating.state"
     },
     {
       "apiVersion": 1,
@@ -636,13 +636,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.forcedLevelFour/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.forcedLevelFour/commands/activate"
         },
         "deactivate": {
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.forcedLevelFour/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.forcedLevelFour/commands/deactivate"
         },
         "setDefaultRuntime": {
           "isExecutable": true,
@@ -658,7 +658,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.forcedLevelFour/commands/setDefaultRuntime"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.forcedLevelFour/commands/setDefaultRuntime"
         },
         "setTimeout": {
           "isExecutable": true,
@@ -674,7 +674,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.forcedLevelFour/commands/setTimeout"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.forcedLevelFour/commands/setTimeout"
         }
       },
       "deviceId": "0",
@@ -698,7 +698,7 @@
         }
       },
       "timestamp": "2024-10-28T11:38:51.162Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.forcedLevelFour"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.forcedLevelFour"
     },
     {
       "apiVersion": 1,
@@ -717,13 +717,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.silent/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.silent/commands/activate"
         },
         "deactivate": {
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.silent/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.silent/commands/deactivate"
         },
         "setDefaultRuntime": {
           "isExecutable": true,
@@ -739,7 +739,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.silent/commands/setDefaultRuntime"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.silent/commands/setDefaultRuntime"
         },
         "setTimeout": {
           "isExecutable": true,
@@ -755,7 +755,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.silent/commands/setTimeout"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.silent/commands/setTimeout"
         }
       },
       "deviceId": "0",
@@ -779,7 +779,7 @@
         }
       },
       "timestamp": "2024-10-28T11:38:51.162Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.silent"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.silent"
     },
     {
       "apiVersion": 1,
@@ -788,13 +788,13 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.standby/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.standby/commands/activate"
         },
         "deactivate": {
           "isExecutable": true,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.standby/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.standby/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -809,7 +809,7 @@
         }
       },
       "timestamp": "2024-10-28T11:38:44.150Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.quickmodes.standby"
     },
     {
       "apiVersion": 1,
@@ -818,7 +818,7 @@
           "isExecutable": false,
           "name": "resetSchedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.schedule/commands/resetSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.schedule/commands/resetSchedule"
         },
         "setSchedule": {
           "isExecutable": true,
@@ -841,7 +841,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -917,7 +917,7 @@
         }
       },
       "timestamp": "2024-10-28T11:38:44.150Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ventilation.schedule"
     }
   ]
 }

--- a/tests/response/VitovalorPT2.json
+++ b/tests/response/VitovalorPT2.json
@@ -15,7 +15,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:57.629Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/device.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/device.serial"
     },
     {
       "apiVersion": 1,
@@ -37,7 +37,7 @@
         }
       },
       "timestamp": "2022-11-18T06:41:13.934Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.sensors.temperature.commonSupply"
     },
     {
       "apiVersion": 1,
@@ -54,7 +54,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:57.486Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
     },
     {
       "apiVersion": 1,
@@ -66,7 +66,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T06:52:46.561Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.buffer.sensors.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.buffer.sensors.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -85,7 +85,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:58.860Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners"
     },
     {
       "apiVersion": 1,
@@ -102,7 +102,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:58.862Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners.0"
     },
     {
       "apiVersion": 1,
@@ -120,7 +120,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:57.635Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners.0.modulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners.0.modulation"
     },
     {
       "apiVersion": 1,
@@ -143,7 +143,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:57.634Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners.0.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.burners.0.statistics"
     },
     {
       "apiVersion": 1,
@@ -162,7 +162,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits"
     },
     {
       "apiVersion": 1,
@@ -174,7 +174,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0"
     },
     {
       "apiVersion": 1,
@@ -186,7 +186,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:57.702Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -198,7 +198,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:58.868Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -226,7 +226,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve"
         }
       },
       "deviceId": "0",
@@ -247,7 +247,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -259,7 +259,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -272,7 +272,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-11-30T07:47:28.956Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.name"
     },
     {
       "apiVersion": 1,
@@ -284,7 +284,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:58.752Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -296,7 +296,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -308,7 +308,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -320,7 +320,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -332,7 +332,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -344,7 +344,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:59.630Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -356,7 +356,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:28:01.277Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -368,7 +368,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule"
     },
     {
       "apiVersion": 1,
@@ -380,7 +380,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:28:01.283Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -392,7 +392,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:28:01.289Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -404,7 +404,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -416,7 +416,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:58.844Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -428,7 +428,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T06:57:05.438Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -440,7 +440,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:57.712Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.0.temperature"
     },
     {
       "apiVersion": 1,
@@ -458,7 +458,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1/commands/setName"
         }
       },
       "deviceId": "0",
@@ -481,7 +481,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1"
     },
     {
       "apiVersion": 1,
@@ -498,7 +498,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:57.703Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -515,7 +515,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:58.869Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -543,7 +543,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve/commands/setCurve"
         }
       },
       "deviceId": "0",
@@ -564,7 +564,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -588,7 +588,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -664,7 +664,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -682,7 +682,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.name/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.name/commands/setName"
         }
       },
       "components": [],
@@ -698,7 +698,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.name"
     },
     {
       "apiVersion": 1,
@@ -720,7 +720,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active/commands/setMode"
         }
       },
       "deviceId": "0",
@@ -735,7 +735,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:58.772Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -752,7 +752,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -769,7 +769,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -786,7 +786,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -803,7 +803,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -820,7 +820,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:59.631Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -839,13 +839,13 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort/commands/deactivate"
         },
         "setTemperature": {
           "isExecutable": true,
@@ -861,7 +861,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -885,7 +885,7 @@
         }
       },
       "timestamp": "2022-11-18T04:28:01.278Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -894,13 +894,13 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -915,7 +915,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule"
     },
     {
       "apiVersion": 1,
@@ -934,7 +934,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -958,7 +958,7 @@
         }
       },
       "timestamp": "2022-11-18T04:28:01.283Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -977,7 +977,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -1001,7 +1001,7 @@
         }
       },
       "timestamp": "2022-11-18T04:28:01.289Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -1018,7 +1018,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1030,7 +1030,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:58.846Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1052,7 +1052,7 @@
         }
       },
       "timestamp": "2022-11-18T06:57:05.481Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1064,7 +1064,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T05:06:28.908Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.1.temperature"
     },
     {
       "apiVersion": 1,
@@ -1076,7 +1076,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2"
     },
     {
       "apiVersion": 1,
@@ -1088,7 +1088,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:57.704Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -1100,7 +1100,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:58.870Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1128,7 +1128,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.curve/commands/setCurve"
         }
       },
       "deviceId": "0",
@@ -1149,7 +1149,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -1161,7 +1161,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -1174,7 +1174,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-11-30T07:47:29.309Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.name"
     },
     {
       "apiVersion": 1,
@@ -1186,7 +1186,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:58.793Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -1198,7 +1198,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -1210,7 +1210,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -1222,7 +1222,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -1234,7 +1234,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -1246,7 +1246,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:59.632Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1258,7 +1258,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:28:01.278Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -1270,7 +1270,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.forcedLastFromSchedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.forcedLastFromSchedule"
     },
     {
       "apiVersion": 1,
@@ -1282,7 +1282,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:28:01.283Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -1294,7 +1294,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:28:01.289Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -1306,7 +1306,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1318,7 +1318,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:58.847Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1330,7 +1330,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:58.852Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1342,7 +1342,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:57.714Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.2.temperature"
     },
     {
       "apiVersion": 1,
@@ -1354,7 +1354,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3"
     },
     {
       "apiVersion": 1,
@@ -1366,7 +1366,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:57.704Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.circulation.pump"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.circulation.pump"
     },
     {
       "apiVersion": 1,
@@ -1378,7 +1378,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:58.871Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.frostprotection"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.frostprotection"
     },
     {
       "apiVersion": 1,
@@ -1406,7 +1406,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.heating.curve/commands/setCurve"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.heating.curve/commands/setCurve"
         }
       },
       "deviceId": "0",
@@ -1427,7 +1427,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.heating.curve"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.heating.curve"
     },
     {
       "apiVersion": 1,
@@ -1439,7 +1439,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.heating.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.heating.schedule"
     },
     {
       "apiVersion": 1,
@@ -1452,7 +1452,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2021-11-30T07:47:29.373Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.name"
     },
     {
       "apiVersion": 1,
@@ -1464,7 +1464,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:58.814Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -1476,7 +1476,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.dhw"
     },
     {
       "apiVersion": 1,
@@ -1488,7 +1488,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.dhwAndHeating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.dhwAndHeating"
     },
     {
       "apiVersion": 1,
@@ -1500,7 +1500,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.heating"
     },
     {
       "apiVersion": 1,
@@ -1512,7 +1512,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -1524,7 +1524,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:59.634Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.active"
     },
     {
       "apiVersion": 1,
@@ -1536,7 +1536,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:28:01.278Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfort"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.comfort"
     },
     {
       "apiVersion": 1,
@@ -1548,7 +1548,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.forcedLastFromSchedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.forcedLastFromSchedule"
     },
     {
       "apiVersion": 1,
@@ -1560,7 +1560,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:28:01.284Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normal"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.normal"
     },
     {
       "apiVersion": 1,
@@ -1572,7 +1572,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:28:01.289Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reduced"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.reduced"
     },
     {
       "apiVersion": 1,
@@ -1584,7 +1584,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.operating.programs.standby"
     },
     {
       "apiVersion": 1,
@@ -1596,7 +1596,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:58.848Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.room"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.room"
     },
     {
       "apiVersion": 1,
@@ -1608,7 +1608,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:58.853Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -1620,7 +1620,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:57.715Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.circuits.3.temperature"
     },
     {
       "apiVersion": 1,
@@ -1632,7 +1632,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:57.673Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.co2.saving"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.co2.saving"
     },
     {
       "apiVersion": 1,
@@ -1653,7 +1653,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw"
     },
     {
       "apiVersion": 1,
@@ -1662,19 +1662,19 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/activate"
         },
         "disable": {
           "isExecutable": true,
           "name": "disable",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/disable"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/disable"
         },
         "enable": {
           "isExecutable": false,
           "name": "enable",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/enable"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene/commands/enable"
         }
       },
       "deviceId": "0",
@@ -1693,7 +1693,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene"
     },
     {
       "apiVersion": 1,
@@ -1721,7 +1721,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene.trigger/commands/triggerDaily"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene.trigger/commands/triggerDaily"
         },
         "triggerOncePerWeek": {
           "isExecutable": true,
@@ -1761,7 +1761,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene.trigger/commands/triggerOncePerWeek"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene.trigger/commands/triggerOncePerWeek"
         }
       },
       "deviceId": "0",
@@ -1788,7 +1788,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene.trigger"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.hygiene.trigger"
     },
     {
       "apiVersion": 1,
@@ -1797,13 +1797,13 @@
           "isExecutable": true,
           "name": "activate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/activate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/activate"
         },
         "deactivate": {
           "isExecutable": false,
           "name": "deactivate",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate"
         }
       },
       "deviceId": "0",
@@ -1818,7 +1818,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.oneTimeCharge"
     },
     {
       "apiVersion": 1,
@@ -1835,7 +1835,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:57.638Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.off"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.operating.modes.off"
     },
     {
       "apiVersion": 1,
@@ -1852,7 +1852,7 @@
         }
       },
       "timestamp": "2022-11-18T05:01:11.793Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation"
     },
     {
       "apiVersion": 1,
@@ -1875,7 +1875,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -1951,7 +1951,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.circulation.schedule"
     },
     {
       "apiVersion": 1,
@@ -1963,7 +1963,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:57.651Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.primary"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.primary"
     },
     {
       "apiVersion": 1,
@@ -1975,7 +1975,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:57.652Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.secondary"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.pumps.secondary"
     },
     {
       "apiVersion": 1,
@@ -1998,7 +1998,7 @@
               "type": "Schedule"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule/commands/setSchedule"
         }
       },
       "deviceId": "0",
@@ -2074,7 +2074,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.schedule"
     },
     {
       "apiVersion": 1,
@@ -2096,7 +2096,7 @@
         }
       },
       "timestamp": "2022-11-18T06:54:52.735Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage"
     },
     {
       "apiVersion": 1,
@@ -2118,7 +2118,7 @@
         }
       },
       "timestamp": "2022-11-18T06:51:16.055Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.bottom"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.bottom"
     },
     {
       "apiVersion": 1,
@@ -2140,7 +2140,7 @@
         }
       },
       "timestamp": "2022-11-18T06:54:52.860Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.top"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage.top"
     },
     {
       "apiVersion": 1,
@@ -2159,7 +2159,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hygiene/commands/setTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hygiene/commands/setTemperature"
         }
       },
       "deviceId": "0",
@@ -2175,7 +2175,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hygiene"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.hygiene"
     },
     {
       "apiVersion": 1,
@@ -2203,7 +2203,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:57.794Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.levels"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.levels"
     },
     {
       "apiVersion": 1,
@@ -2224,7 +2224,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature"
         }
       },
       "deviceId": "0",
@@ -2240,7 +2240,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.dhw.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -2262,7 +2262,7 @@
         }
       },
       "timestamp": "2022-11-18T06:54:52.906Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.flue.sensors.temperature.main"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.flue.sensors.temperature.main"
     },
     {
       "apiVersion": 1,
@@ -2285,7 +2285,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.operating.modes.active/commands/setMode"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.operating.modes.active/commands/setMode"
         }
       },
       "deviceId": "0",
@@ -2300,7 +2300,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.operating.modes.active"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.operating.modes.active"
     },
     {
       "apiVersion": 1,
@@ -2317,7 +2317,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:57.800Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.operating.modes.ecological"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.operating.modes.ecological"
     },
     {
       "apiVersion": 1,
@@ -2334,7 +2334,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:57.801Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.operating.modes.economical"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.operating.modes.economical"
     },
     {
       "apiVersion": 1,
@@ -2351,7 +2351,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:57.799Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.operating.modes.heatControlled"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.operating.modes.heatControlled"
     },
     {
       "apiVersion": 1,
@@ -2368,7 +2368,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:57.798Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.operating.modes.maintenance"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.operating.modes.maintenance"
     },
     {
       "apiVersion": 1,
@@ -2385,7 +2385,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:57.797Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.operating.modes.standby"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.operating.modes.standby"
     },
     {
       "apiVersion": 1,
@@ -2402,7 +2402,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:57.796Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.operating.phase"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.operating.phase"
     },
     {
       "apiVersion": 1,
@@ -2485,7 +2485,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:57.666Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.power.production"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.power.production"
     },
     {
       "apiVersion": 1,
@@ -2507,7 +2507,7 @@
         }
       },
       "timestamp": "2022-11-18T06:55:53.994Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.sensors.temperature.return"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.sensors.temperature.return"
     },
     {
       "apiVersion": 1,
@@ -2529,7 +2529,7 @@
         }
       },
       "timestamp": "2022-11-18T06:56:51.275Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.sensors.temperature.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.sensors.temperature.supply"
     },
     {
       "apiVersion": 1,
@@ -2557,7 +2557,7 @@
         }
       },
       "timestamp": "2022-11-18T06:36:22.222Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.fuelCell.statistics"
     },
     {
       "apiVersion": 1,
@@ -2640,7 +2640,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:57.664Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.dhw"
     },
     {
       "apiVersion": 1,
@@ -2723,7 +2723,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:57.665Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.fuelCell"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.fuelCell"
     },
     {
       "apiVersion": 1,
@@ -2806,7 +2806,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:57.663Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.heating"
     },
     {
       "apiVersion": 1,
@@ -2849,7 +2849,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:58.877Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.summary.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.summary.dhw"
     },
     {
       "apiVersion": 1,
@@ -2892,7 +2892,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:58.875Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.summary.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.summary.heating"
     },
     {
       "apiVersion": 1,
@@ -2975,7 +2975,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:59.626Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.total"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.gas.consumption.total"
     },
     {
       "apiVersion": 1,
@@ -2993,7 +2993,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate"
         },
         "schedule": {
           "isExecutable": true,
@@ -3015,13 +3015,13 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/schedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/schedule"
         },
         "unschedule": {
           "isExecutable": true,
           "name": "unschedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday/commands/unschedule"
         }
       },
       "deviceId": "0",
@@ -3044,7 +3044,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holiday"
     },
     {
       "apiVersion": 1,
@@ -3062,7 +3062,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/changeEndDate"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/changeEndDate"
         },
         "schedule": {
           "isExecutable": true,
@@ -3084,13 +3084,13 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/schedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/schedule"
         },
         "unschedule": {
           "isExecutable": true,
           "name": "unschedule",
           "params": {},
-          "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/unschedule"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome/commands/unschedule"
         }
       },
       "deviceId": "0",
@@ -3113,7 +3113,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.operating.programs.holidayAtHome"
     },
     {
       "apiVersion": 1,
@@ -3196,7 +3196,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:57.676Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.dhw"
     },
     {
       "apiVersion": 1,
@@ -3279,7 +3279,7 @@
         }
       },
       "timestamp": "2022-11-18T06:39:43.880Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.heating"
     },
     {
       "apiVersion": 1,
@@ -3322,7 +3322,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:58.881Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.dhw"
     },
     {
       "apiVersion": 1,
@@ -3365,7 +3365,7 @@
         }
       },
       "timestamp": "2022-11-18T06:39:44.018Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.heating"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.summary.heating"
     },
     {
       "apiVersion": 1,
@@ -3448,7 +3448,7 @@
         }
       },
       "timestamp": "2022-11-18T06:39:43.954Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.total"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.consumption.total"
     },
     {
       "apiVersion": 1,
@@ -3466,7 +3466,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:57.716Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.production.cumulative"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.production.cumulative"
     },
     {
       "apiVersion": 1,
@@ -3488,7 +3488,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:57.669Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.production.current"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.production.current"
     },
     {
       "apiVersion": 1,
@@ -3506,7 +3506,7 @@
         }
       },
       "timestamp": "2022-11-18T06:52:34.117Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.purchase.cumulative"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.purchase.cumulative"
     },
     {
       "apiVersion": 1,
@@ -3524,7 +3524,7 @@
         }
       },
       "timestamp": "2022-11-18T06:56:51.249Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.purchase.current"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.purchase.current"
     },
     {
       "apiVersion": 1,
@@ -3542,7 +3542,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:57.721Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.sold.cumulative"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.sold.cumulative"
     },
     {
       "apiVersion": 1,
@@ -3560,7 +3560,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:57.672Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.sold.current"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.power.sold.current"
     },
     {
       "apiVersion": 1,
@@ -3582,7 +3582,7 @@
         }
       },
       "timestamp": "2022-11-18T04:27:55.360Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.pressure.supply"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.pressure.supply"
     },
     {
       "apiVersion": 1,
@@ -3604,7 +3604,7 @@
         }
       },
       "timestamp": "2022-11-18T06:42:45.885Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.allengra"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.allengra"
     },
     {
       "apiVersion": 1,
@@ -3626,7 +3626,7 @@
         }
       },
       "timestamp": "2022-11-18T06:52:46.507Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.hydraulicSeparator"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.hydraulicSeparator"
     },
     {
       "apiVersion": 1,
@@ -3648,7 +3648,7 @@
         }
       },
       "timestamp": "2022-11-18T06:57:00.381Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.outside"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.outside"
     },
     {
       "apiVersion": 1,
@@ -3670,7 +3670,7 @@
         }
       },
       "timestamp": "2022-11-18T06:56:34.985Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.return"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.temperature.return"
     },
     {
       "apiVersion": 1,
@@ -3692,7 +3692,7 @@
         }
       },
       "timestamp": "2022-11-18T06:57:07.569Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.volumetricFlow.allengra"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.sensors.volumetricFlow.allengra"
     },
     {
       "apiVersion": 1,
@@ -3704,7 +3704,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:59.610Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar"
     },
     {
       "apiVersion": 1,
@@ -3716,7 +3716,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:59.618Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.power.production"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.power.production"
     },
     {
       "apiVersion": 1,
@@ -3728,7 +3728,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:59.621Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.pumps.circuit"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.pumps.circuit"
     },
     {
       "apiVersion": 1,
@@ -3740,7 +3740,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:59.622Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.rechargeSuppression"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.rechargeSuppression"
     },
     {
       "apiVersion": 1,
@@ -3752,7 +3752,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:59.611Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.collector"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.collector"
     },
     {
       "apiVersion": 1,
@@ -3764,7 +3764,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:59.620Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.dhw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.sensors.temperature.dhw"
     },
     {
       "apiVersion": 1,
@@ -3776,7 +3776,7 @@
       "isReady": true,
       "properties": {},
       "timestamp": "2022-11-18T04:27:59.619Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.statistics"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.solar.statistics"
     }
   ]
 }

--- a/tests/response/deviceerrors/F.1100.json
+++ b/tests/response/deviceerrors/F.1100.json
@@ -32,7 +32,7 @@
         }
       },
       "timestamp": "2024-10-30T08:53:23.913Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.messages.errors.raw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/device.messages.errors.raw"
     }
   ]
 }

--- a/tests/response/zigbee_Smart_Device_eTRV_generic_50.json
+++ b/tests/response/zigbee_Smart_Device_eTRV_generic_50.json
@@ -22,7 +22,7 @@
         }
       },
       "timestamp": "2025-02-03T02:30:52.129Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-048727fffeb429ae/features/device.messages.errors.raw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-048727fffeb429ae/features/device.messages.errors.raw"
     },
     {
       "apiVersion": 1,
@@ -41,7 +41,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-048727fffeb429ae/features/device.name/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-048727fffeb429ae/features/device.name/commands/setName"
         }
       },
       "deviceId": "zigbee-048727fffeb429ae",
@@ -56,7 +56,7 @@
         }
       },
       "timestamp": "2025-02-03T02:30:52.129Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-048727fffeb429ae/features/device.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-048727fffeb429ae/features/device.name"
     },
     {
       "apiVersion": 1,
@@ -74,7 +74,7 @@
         }
       },
       "timestamp": "2025-02-03T02:30:52.129Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-048727fffeb429ae/features/device.power.battery"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-048727fffeb429ae/features/device.power.battery"
     },
     {
       "apiVersion": 1,
@@ -96,7 +96,7 @@
         }
       },
       "timestamp": "2025-02-03T14:14:15.095Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-048727fffeb429ae/features/device.sensors.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-048727fffeb429ae/features/device.sensors.temperature"
     },
     {
       "apiVersion": 1,
@@ -115,7 +115,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-048727fffeb429ae/features/trv.temperature/commands/setTargetTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-048727fffeb429ae/features/trv.temperature/commands/setTargetTemperature"
         }
       },
       "deviceId": "zigbee-048727fffeb429ae",
@@ -131,7 +131,7 @@
         }
       },
       "timestamp": "2025-02-03T13:57:19.872Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-048727fffeb429ae/features/trv.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-048727fffeb429ae/features/trv.temperature"
     }
   ]
 }

--- a/tests/response/zigbee_Smart_cs_generic_50.json
+++ b/tests/response/zigbee_Smart_cs_generic_50.json
@@ -15,7 +15,7 @@
         }
       },
       "timestamp": "2025-02-03T02:30:52.279Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-f082c0fffe43d8cd/features/device.messages.errors.raw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-f082c0fffe43d8cd/features/device.messages.errors.raw"
     },
     {
       "apiVersion": 1,
@@ -34,7 +34,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-f082c0fffe43d8cd/features/device.name/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-f082c0fffe43d8cd/features/device.name/commands/setName"
         }
       },
       "deviceId": "zigbee-f082c0fffe43d8cd",
@@ -49,7 +49,7 @@
         }
       },
       "timestamp": "2025-02-03T02:30:52.279Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-f082c0fffe43d8cd/features/device.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-f082c0fffe43d8cd/features/device.name"
     },
     {
       "apiVersion": 1,
@@ -67,7 +67,7 @@
         }
       },
       "timestamp": "2025-02-03T02:30:52.279Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-f082c0fffe43d8cd/features/device.power.battery"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-f082c0fffe43d8cd/features/device.power.battery"
     },
     {
       "apiVersion": 1,
@@ -89,7 +89,7 @@
         }
       },
       "timestamp": "2025-02-03T14:04:41.737Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-f082c0fffe43d8cd/features/device.sensors.humidity"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-f082c0fffe43d8cd/features/device.sensors.humidity"
     },
     {
       "apiVersion": 1,
@@ -111,7 +111,7 @@
         }
       },
       "timestamp": "2025-02-03T14:17:36.528Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-f082c0fffe43d8cd/features/device.sensors.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-f082c0fffe43d8cd/features/device.sensors.temperature"
     }
   ]
 }

--- a/tests/response/zigbee_zk03839.json
+++ b/tests/response/zigbee_zk03839.json
@@ -20,7 +20,7 @@
         }
       },
       "timestamp": "2023-01-05T20:20:44.130Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/zigbee-2c1165fffe977770/features/device.sensors.humidity"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/zigbee-2c1165fffe977770/features/device.sensors.humidity"
     },
     {
       "apiVersion": 1,
@@ -42,7 +42,7 @@
         }
       },
       "timestamp": "2023-01-05T21:43:19.578Z",
-      "uri": "https://api.viessmann.com/iot/v1/equipment/installations/#######/gateways/################/devices/zigbee-2c1165fffe977770/features/device.sensors.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/zigbee-2c1165fffe977770/features/device.sensors.temperature"
     }
   ]
 }

--- a/tests/response/zigbee_zk03840_trv.json
+++ b/tests/response/zigbee_zk03840_trv.json
@@ -15,7 +15,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:25.906Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-048727fffe196e03/features/device.messages.errors.raw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-048727fffe196e03/features/device.messages.errors.raw"
     },
     {
       "apiVersion": 1,
@@ -34,7 +34,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-048727fffe196e03/features/device.name/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-048727fffe196e03/features/device.name/commands/setName"
         }
       },
       "deviceId": "zigbee-048727fffe196e03",
@@ -49,7 +49,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:25.906Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-048727fffe196e03/features/device.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-048727fffe196e03/features/device.name"
     },
     {
       "apiVersion": 1,
@@ -71,7 +71,7 @@
         }
       },
       "timestamp": "2024-10-01T15:31:33.915Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-048727fffe196e03/features/device.sensors.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-048727fffe196e03/features/device.sensors.temperature"
     },
     {
       "apiVersion": 1,
@@ -90,7 +90,7 @@
               "type": "number"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-048727fffe196e03/features/trv.temperature/commands/setTargetTemperature"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-048727fffe196e03/features/trv.temperature/commands/setTargetTemperature"
         }
       },
       "deviceId": "zigbee-048727fffe196e03",
@@ -106,7 +106,7 @@
         }
       },
       "timestamp": "2024-10-01T08:44:50.292Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-048727fffe196e03/features/trv.temperature"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-048727fffe196e03/features/trv.temperature"
     }
   ]
 }

--- a/tests/response/zigbee_zk05390_repeater.json
+++ b/tests/response/zigbee_zk05390_repeater.json
@@ -15,7 +15,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:25.951Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-142d41fffe8797bd/features/device.messages.errors.raw"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-142d41fffe8797bd/features/device.messages.errors.raw"
     },
     {
       "apiVersion": 1,
@@ -34,7 +34,7 @@
               "type": "string"
             }
           },
-          "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-142d41fffe8797bd/features/device.name/commands/setName"
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-142d41fffe8797bd/features/device.name/commands/setName"
         }
       },
       "deviceId": "zigbee-142d41fffe8797bd",
@@ -49,7 +49,7 @@
         }
       },
       "timestamp": "2024-10-01T00:31:25.951Z",
-      "uri": "https://api.viessmann.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-142d41fffe8797bd/features/device.name"
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/zigbee-142d41fffe8797bd/features/device.name"
     }
   ]
 }


### PR DESCRIPTION
I received this email by Viessmann:
<img width="796" height="1520" alt="image" src="https://github.com/user-attachments/assets/f7cb5012-28ee-4446-b7b6-87274a7993a8" />

TL;DR in Q4/2025, the url `viessmann.com` won't be usable for the API services anymore. All API services will live under `viessmann-climatesolutions.com`.

For this reason, I changed all the URLs in this library to the new URL (which is already live), namely `api.viessmann-climatesolutions.com` and `iam.viessmann-climatesolutions.com`.

I tested the changes with my Viessmann Developer Account, everything (auth and API calls) works as expected with the new URLs.