### PR TITLE
feat: expose common supply temp sensor for all heating devices

### DIFF
--- a/PyViCare/PyViCareGazBoiler.py
+++ b/PyViCare/PyViCareGazBoiler.py
@@ -104,10 +104,6 @@ class GazBoiler(HeatingDevice):
         return self.service.getProperty("heating.dhw.charging.level")["properties"]["value"]["value"]
 
     @handleNotSupported
-    def getBoilerCommonSupplyTemperature(self):
-        return self.service.getProperty("heating.boiler.sensors.temperature.commonSupply")["properties"]["value"]["value"]
-
-    @handleNotSupported
     def getPowerConsumptionUnit(self):
         return self.service.getProperty("heating.power.consumption.total")["properties"]["day"]["unit"]
 

--- a/PyViCare/PyViCareHeatingDevice.py
+++ b/PyViCare/PyViCareHeatingDevice.py
@@ -364,6 +364,10 @@ class HeatingDevice(Device):
         return self.service.getProperty("heating.secondaryCircuit.sensors.temperature.return")["properties"]["value"][
             "value"]
 
+    @handleNotSupported
+    def getBoilerCommonSupplyTemperature(self):
+        return self.service.getProperty("heating.boiler.sensors.temperature.commonSupply")["properties"]["value"]["value"]
+
 
 class HeatingDeviceWithComponent:
     """This is the base class for all heating components"""
@@ -520,10 +524,6 @@ class HeatingCircuit(HeatingDeviceWithComponent):
 
     def deactivateComfort(self):
         return self.deactivateProgram("comfort")
-
-    @handleNotSupported
-    def getBoilerCommonSupplyTemperature(self):
-        return self.service.getProperty("heating.boiler.sensors.temperature.commonSupply")["properties"]["value"]["value"]
 
     @handleNotSupported
     def getSupplyTemperature(self):

--- a/PyViCare/PyViCareHeatingDevice.py
+++ b/PyViCare/PyViCareHeatingDevice.py
@@ -522,6 +522,10 @@ class HeatingCircuit(HeatingDeviceWithComponent):
         return self.deactivateProgram("comfort")
 
     @handleNotSupported
+    def getBoilerCommonSupplyTemperature(self):
+        return self.service.getProperty("heating.boiler.sensors.temperature.commonSupply")["properties"]["value"]["value"]
+
+    @handleNotSupported
     def getSupplyTemperature(self):
         return \
             self.service.getProperty(f"heating.circuits.{self.circuit}.sensors.temperature.supply")["properties"][


### PR DESCRIPTION
Exposes `heating.boiler.sensors.temperature.CommonSupply` for all heating devices.

fixes https://github.com/home-assistant/core/issues/142214