### PR TITLE
feat(ess): add access methode for ess.transfer.charge.cumulated

### DIFF
--- a/PyViCare/PyViCareElectricalEnergySystem.py
+++ b/PyViCare/PyViCareElectricalEnergySystem.py
@@ -89,6 +89,42 @@ class ElectricalEnergySystem(Device):
         ]["unit"]
 
     @handleNotSupported
+    def getElectricalEnergySystemTransferChargeCumulatedUnit(self):
+        return self.service.getProperty("ess.transfer.charge.cumulated")[
+            "properties"
+        ]["currentDay"]["unit"]
+
+    @handleNotSupported
+    def getElectricalEnergySystemTransferChargeCumulatedCurrentDay(self):
+        return self.service.getProperty("ess.transfer.charge.cumulated")[
+            "properties"
+        ]["currentDay"]["value"]
+
+    @handleNotSupported
+    def getElectricalEnergySystemTransferChargeCumulatedCurrentWeek(self):
+        return self.service.getProperty("ess.transfer.charge.cumulated")[
+            "properties"
+        ]["currentWeek"]["value"]
+
+    @handleNotSupported
+    def getElectricalEnergySystemTransferChargeCumulatedCurrentMonth(self):
+        return self.service.getProperty("ess.transfer.charge.cumulated")[
+            "properties"
+        ]["currentMonth"]["value"]
+
+    @handleNotSupported
+    def getElectricalEnergySystemTransferChargeCumulatedCurrentYear(self):
+        return self.service.getProperty("ess.transfer.charge.cumulated")[
+            "properties"
+        ]["currentYear"]["value"]
+
+    @handleNotSupported
+    def getElectricalEnergySystemTransferChargeCumulatedLifeCycle(self):
+        return self.service.getProperty("ess.transfer.charge.cumulated")[
+            "properties"
+        ]["lifeCycle"]["value"]
+
+    @handleNotSupported
     def getElectricalEnergySystemTransferDischargeCumulatedUnit(self):
         return self.service.getProperty("ess.transfer.discharge.cumulated")[
             "properties"

--- a/tests/response/VitochargeVX3.json
+++ b/tests/response/VitochargeVX3.json
@@ -71,6 +71,44 @@
       "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/ess.stateOfCharge"
     },
     {
+      "feature": "ess.transfer.charge.cumulated",
+      "gatewayId": "################",
+      "deviceId": "0",
+      "timestamp": "2025-09-24T16:25:08.243Z",
+      "isEnabled": true,
+      "isReady": true,
+      "apiVersion": 1,
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ess.transfer.charge.cumulated",
+      "properties": {
+        "currentDay": {
+          "type": "number",
+          "value": 3004,
+          "unit": "wattHour"
+        },
+        "currentWeek": {
+          "type": "number",
+          "value": 6519,
+          "unit": "wattHour"
+        },
+        "currentMonth": {
+          "type": "number",
+          "value": 122090,
+          "unit": "wattHour"
+        },
+        "currentYear": {
+          "type": "number",
+          "value": 1230050,
+          "unit": "wattHour"
+        },
+        "lifeCycle": {
+          "type": "number",
+          "value": 1858108,
+          "unit": "wattHour"
+        }
+      },
+      "commands": {}
+    },
+    {
       "apiVersion": 1,
       "commands": {},
       "deviceId": "0",

--- a/tests/response/VitochargeVX3.json
+++ b/tests/response/VitochargeVX3.json
@@ -3,7 +3,150 @@
     {
       "apiVersion": 1,
       "commands": {},
-      "deviceId": "0",
+      "deviceId": "################",
+      "feature": "device.etn",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "value": {
+          "type": "string",
+          "value": "################"
+        }
+      },
+      "timestamp": "2025-09-29T13:59:30.725Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/device.etn"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "################",
+      "feature": "device.messages.info.raw",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "entries": {
+          "type": "array",
+          "value": []
+        }
+      },
+      "timestamp": "2025-09-29T13:59:30.725Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/device.messages.info.raw"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "################",
+      "feature": "device.messages.service.raw",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "entries": {
+          "type": "array",
+          "value": []
+        }
+      },
+      "timestamp": "2025-09-29T13:59:30.725Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/device.messages.service.raw"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "################",
+      "feature": "device.messages.status.raw",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "entries": {
+          "type": "array",
+          "value": []
+        }
+      },
+      "timestamp": "2025-09-29T13:59:30.725Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/device.messages.status.raw"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "################",
+      "feature": "device.parameterIdentification.version",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "value": {
+          "type": "string",
+          "value": "0024.0503.2239.0001"
+        }
+      },
+      "timestamp": "2025-09-29T13:59:30.725Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/device.parameterIdentification.version"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "################",
+      "feature": "device.productIdentification",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "product": {
+          "type": "object",
+          "value": {
+            "busAddress": 71,
+            "busType": "CanExternal",
+            "productFamily": "B_00012_VCH200",
+            "viessmannIdentificationNumber": "################"
+          }
+        }
+      },
+      "timestamp": "2025-09-29T13:59:30.725Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/device.productIdentification"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "################",
+      "feature": "device.productMatrix",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "product": {
+          "type": "array",
+          "value": [
+            {
+              "busAddress": 71,
+              "busType": "CanExternal",
+              "productFamily": "B_00012_VCH200",
+              "viessmannIdentificationNumber": "################"
+            }
+          ]
+        }
+      },
+      "timestamp": "2025-09-29T13:59:30.725Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/device.productMatrix"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "################",
+      "feature": "device.remoteReset",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2025-09-29T13:59:30.725Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/device.remoteReset"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "################",
       "feature": "device.serial",
       "gatewayId": "################",
       "isEnabled": true,
@@ -14,13 +157,192 @@
           "value": "################"
         }
       },
-      "timestamp": "2023-05-25T14:43:26.622Z",
-      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/device.serial"
+      "timestamp": "2025-09-29T13:59:30.725Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/device.serial"
     },
     {
       "apiVersion": 1,
       "commands": {},
-      "deviceId": "0",
+      "deviceId": "################",
+      "feature": "device.serial.internalComponents",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "vinList": {
+          "type": "array",
+          "value": [
+            "################",
+            "################"
+          ]
+        }
+      },
+      "timestamp": "2025-09-29T13:59:30.725Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/device.serial.internalComponents"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {
+        "activate": {
+          "isExecutable": true,
+          "name": "activate",
+          "params": {
+            "begin": {
+              "constraints": {
+                "regEx": "^[\\d]{2}-[\\d]{2}$"
+              },
+              "required": true,
+              "type": "string"
+            },
+            "end": {
+              "constraints": {
+                "regEx": "^[\\d]{2}-[\\d]{2}$"
+              },
+              "required": true,
+              "type": "string"
+            }
+          },
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/device.time.daylightSaving/commands/activate"
+        },
+        "deactivate": {
+          "isExecutable": true,
+          "name": "deactivate",
+          "params": {},
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/device.time.daylightSaving/commands/deactivate"
+        }
+      },
+      "deviceId": "################",
+      "feature": "device.time.daylightSaving",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "active": {
+          "type": "boolean",
+          "value": true
+        },
+        "begin": {
+          "type": "string",
+          "value": "25-03"
+        },
+        "end": {
+          "type": "string",
+          "value": "25-10"
+        }
+      },
+      "timestamp": "2025-09-29T13:59:30.725Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/device.time.daylightSaving"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "################",
+      "feature": "ess.battery.usedAverage",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "averageUsableSystemEnergy": {
+          "type": "number",
+          "unit": "wattHour",
+          "value": 5000
+        },
+        "usableEnergyModuleFive": {
+          "type": "number",
+          "unit": "wattHour",
+          "value": 0
+        },
+        "usableEnergyModuleFour": {
+          "type": "number",
+          "unit": "wattHour",
+          "value": 0
+        },
+        "usableEnergyModuleOne": {
+          "type": "number",
+          "unit": "wattHour",
+          "value": 2934
+        },
+        "usableEnergyModuleSix": {
+          "type": "number",
+          "unit": "wattHour",
+          "value": 0
+        },
+        "usableEnergyModuleThree": {
+          "type": "number",
+          "unit": "wattHour",
+          "value": 0
+        },
+        "usableEnergyModuleTwo": {
+          "type": "number",
+          "unit": "wattHour",
+          "value": 2930
+        }
+      },
+      "timestamp": "2025-09-29T16:35:50.613Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/ess.battery.usedAverage"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "################",
+      "feature": "ess.configuration.backupBox",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "value": {
+          "type": "number",
+          "unit": "percent",
+          "value": 25
+        }
+      },
+      "timestamp": "2025-09-29T13:59:30.725Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/ess.configuration.backupBox"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "################",
+      "feature": "ess.configuration.systemType",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "value": {
+          "type": "string",
+          "value": "hybrid"
+        }
+      },
+      "timestamp": "2025-09-29T13:59:30.725Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/ess.configuration.systemType"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "################",
+      "feature": "ess.inverter.ac.power",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "activePower": {
+          "type": "number",
+          "unit": "watt",
+          "value": 521
+        },
+        "reactivePower": {
+          "type": "number",
+          "unit": "watt",
+          "value": 0
+        }
+      },
+      "timestamp": "2025-09-29T18:29:06.060Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/ess.inverter.ac.power"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "################",
       "feature": "ess.operationState",
       "gatewayId": "################",
       "isEnabled": true,
@@ -31,13 +353,13 @@
           "value": "discharge"
         }
       },
-      "timestamp": "2023-05-26T18:33:10.937Z",
-      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/ess.operationState"
+      "timestamp": "2025-09-29T16:47:33.784Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/ess.operationState"
     },
     {
       "apiVersion": 1,
       "commands": {},
-      "deviceId": "0",
+      "deviceId": "################",
       "feature": "ess.power",
       "gatewayId": "################",
       "isEnabled": true,
@@ -46,16 +368,38 @@
         "value": {
           "type": "number",
           "unit": "watt",
-          "value": 700
+          "value": 522
         }
       },
-      "timestamp": "2023-05-26T20:21:12.542Z",
-      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/ess.power"
+      "timestamp": "2025-09-29T18:28:55.580Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/ess.power"
     },
     {
       "apiVersion": 1,
       "commands": {},
-      "deviceId": "0",
+      "deviceId": "################",
+      "feature": "ess.sensors.temperature.ambient",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "status": {
+          "type": "string",
+          "value": "connected"
+        },
+        "value": {
+          "type": "number",
+          "unit": "celsius",
+          "value": 24.1
+        }
+      },
+      "timestamp": "2025-09-29T18:28:23.208Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/ess.sensors.temperature.ambient"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "################",
       "feature": "ess.stateOfCharge",
       "gatewayId": "################",
       "isEnabled": true,
@@ -64,54 +408,54 @@
         "value": {
           "type": "number",
           "unit": "percent",
-          "value": 91
+          "value": 84
         }
       },
-      "timestamp": "2023-05-26T20:20:30.651Z",
-      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/ess.stateOfCharge"
-    },
-    {
-      "feature": "ess.transfer.charge.cumulated",
-      "gatewayId": "################",
-      "deviceId": "0",
-      "timestamp": "2025-09-24T16:25:08.243Z",
-      "isEnabled": true,
-      "isReady": true,
-      "apiVersion": 1,
-      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/features/installations/#######/gateways/################/devices/0/features/ess.transfer.charge.cumulated",
-      "properties": {
-        "currentDay": {
-          "type": "number",
-          "value": 3004,
-          "unit": "wattHour"
-        },
-        "currentWeek": {
-          "type": "number",
-          "value": 6519,
-          "unit": "wattHour"
-        },
-        "currentMonth": {
-          "type": "number",
-          "value": 122090,
-          "unit": "wattHour"
-        },
-        "currentYear": {
-          "type": "number",
-          "value": 1230050,
-          "unit": "wattHour"
-        },
-        "lifeCycle": {
-          "type": "number",
-          "value": 1858108,
-          "unit": "wattHour"
-        }
-      },
-      "commands": {}
+      "timestamp": "2025-09-29T18:26:55.956Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/ess.stateOfCharge"
     },
     {
       "apiVersion": 1,
       "commands": {},
-      "deviceId": "0",
+      "deviceId": "################",
+      "feature": "ess.transfer.charge.cumulated",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "currentDay": {
+          "type": "number",
+          "unit": "wattHour",
+          "value": 5449
+        },
+        "currentMonth": {
+          "type": "number",
+          "unit": "wattHour",
+          "value": 143145
+        },
+        "currentWeek": {
+          "type": "number",
+          "unit": "wattHour",
+          "value": 5449
+        },
+        "currentYear": {
+          "type": "number",
+          "unit": "wattHour",
+          "value": 1251105
+        },
+        "lifeCycle": {
+          "type": "number",
+          "unit": "wattHour",
+          "value": 1879163
+        }
+      },
+      "timestamp": "2025-09-29T16:45:15.994Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/ess.transfer.charge.cumulated"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "################",
       "feature": "ess.transfer.discharge.cumulated",
       "gatewayId": "################",
       "isEnabled": true,
@@ -120,36 +464,69 @@
         "currentDay": {
           "type": "number",
           "unit": "wattHour",
-          "value": 4751
+          "value": 3197
         },
         "currentMonth": {
           "type": "number",
           "unit": "wattHour",
-          "value": 66926
+          "value": 136292
         },
         "currentWeek": {
           "type": "number",
           "unit": "wattHour",
-          "value": 29820
+          "value": 3197
         },
         "currentYear": {
           "type": "number",
           "unit": "wattHour",
-          "value": 66926
+          "value": 1197530
         },
         "lifeCycle": {
           "type": "number",
           "unit": "wattHour",
-          "value": 66926
+          "value": 1801122
         }
       },
-      "timestamp": "2023-05-26T20:21:05.602Z",
-      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/ess.transfer.discharge.cumulated"
+      "timestamp": "2025-09-29T18:28:59.827Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/ess.transfer.discharge.cumulated"
     },
     {
       "apiVersion": 1,
       "commands": {},
-      "deviceId": "0",
+      "deviceId": "################",
+      "feature": "ess.version.hardware",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "assemblyVariant": {
+          "type": "number",
+          "unit": "",
+          "value": 1
+        },
+        "family": {
+          "type": "number",
+          "unit": "",
+          "value": 24
+        },
+        "revision": {
+          "type": "number",
+          "unit": "",
+          "value": 101
+        },
+        "version": {
+          "type": "number",
+          "unit": "",
+          "value": 603
+        }
+      },
+      "timestamp": "2025-09-29T13:59:30.725Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/ess.version.hardware"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "################",
       "feature": "heating.boiler.serial",
       "gatewayId": "################",
       "isEnabled": true,
@@ -160,13 +537,164 @@
           "value": "################"
         }
       },
-      "timestamp": "2023-05-25T14:43:26.623Z",
-      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/heating.boiler.serial"
+      "timestamp": "2025-09-29T13:59:30.725Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/heating.boiler.serial"
     },
     {
       "apiVersion": 1,
       "commands": {},
-      "deviceId": "0",
+      "deviceId": "################",
+      "feature": "heating.device.mainECU",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "runtime": {
+          "type": "number",
+          "unit": "seconds",
+          "value": 38383200
+        }
+      },
+      "timestamp": "2025-09-29T13:59:55.128Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/heating.device.mainECU"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {
+        "setTime": {
+          "isExecutable": true,
+          "name": "setTime",
+          "params": {
+            "value": {
+              "constraints": {
+                "regEx": "^[0-9]{4}-((0[13578]|1[02])-(0[1-9]|[12][0-9]|3[01])|(0[469]|11)-(0[1-9]|[12][0-9]|30)|(02)-(0[1-9]|[12][0-9]))T(0[0-9]|1[0-9]|2[0-3]):(0[0-9]|[1-5][0-9]):(0[0-9]|[1-5][0-9])$"
+              },
+              "required": true,
+              "type": "string"
+            }
+          },
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/heating.device.time/commands/setTime"
+        }
+      },
+      "deviceId": "################",
+      "feature": "heating.device.time",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {},
+      "timestamp": "2025-09-29T18:28:09.781Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/heating.device.time"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "################",
+      "feature": "pcc.ac.active.current",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "phaseOne": {
+          "type": "number",
+          "unit": "ampere",
+          "value": 1
+        },
+        "phaseThree": {
+          "type": "number",
+          "unit": "ampere",
+          "value": 1
+        },
+        "phaseTwo": {
+          "type": "number",
+          "unit": "ampere",
+          "value": 2
+        },
+        "total": {
+          "type": "number",
+          "unit": "ampere",
+          "value": 4
+        }
+      },
+      "timestamp": "2025-09-29T18:28:47.828Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/pcc.ac.active.current"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "################",
+      "feature": "pcc.ac.active.power",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "phaseOne": {
+          "type": "number",
+          "unit": "watt",
+          "value": 161
+        },
+        "phaseThree": {
+          "type": "number",
+          "unit": "watt",
+          "value": -95
+        },
+        "phaseTwo": {
+          "type": "number",
+          "unit": "watt",
+          "value": -37
+        }
+      },
+      "timestamp": "2025-09-29T18:28:59.827Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/pcc.ac.active.power"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "################",
+      "feature": "pcc.ac.reactive.power",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "phaseOne": {
+          "type": "number",
+          "unit": "watt",
+          "value": 25
+        },
+        "phaseThree": {
+          "type": "number",
+          "unit": "watt",
+          "value": -98
+        },
+        "phaseTwo": {
+          "type": "number",
+          "unit": "watt",
+          "value": -401
+        }
+      },
+      "timestamp": "2025-09-29T18:28:59.827Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/pcc.ac.reactive.power"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "################",
+      "feature": "pcc.state.gridCode",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "value": {
+          "type": "string",
+          "value": "normOne"
+        }
+      },
+      "timestamp": "2025-09-29T13:59:30.725Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/pcc.state.gridCode"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "################",
       "feature": "pcc.transfer.consumption.total",
       "gatewayId": "################",
       "isEnabled": true,
@@ -175,16 +703,16 @@
         "value": {
           "type": "number",
           "unit": "wattHour",
-          "value": 7700
+          "value": 2844400
         }
       },
-      "timestamp": "2023-05-25T16:55:44.150Z",
-      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/pcc.transfer.consumption.total"
+      "timestamp": "2025-09-29T13:59:30.725Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/pcc.transfer.consumption.total"
     },
     {
       "apiVersion": 1,
       "commands": {},
-      "deviceId": "0",
+      "deviceId": "################",
       "feature": "pcc.transfer.feedIn.total",
       "gatewayId": "################",
       "isEnabled": true,
@@ -193,16 +721,16 @@
         "value": {
           "type": "number",
           "unit": "wattHour",
-          "value": 298900
+          "value": 10433300
         }
       },
-      "timestamp": "2023-05-26T18:19:16.330Z",
-      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/pcc.transfer.feedIn.total"
+      "timestamp": "2025-09-29T16:33:09.012Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/pcc.transfer.feedIn.total"
     },
     {
       "apiVersion": 1,
       "commands": {},
-      "deviceId": "0",
+      "deviceId": "################",
       "feature": "pcc.transfer.power.exchange",
       "gatewayId": "################",
       "isEnabled": true,
@@ -211,16 +739,34 @@
         "value": {
           "type": "number",
           "unit": "watt",
-          "value": 0
+          "value": 4
         }
       },
-      "timestamp": "2023-05-26T20:21:05.602Z",
-      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/pcc.transfer.power.exchange"
+      "timestamp": "2025-09-29T18:28:59.827Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/pcc.transfer.power.exchange"
     },
     {
       "apiVersion": 1,
       "commands": {},
-      "deviceId": "0",
+      "deviceId": "################",
+      "feature": "photovoltaic.installedPeakPower",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "value": {
+          "type": "number",
+          "unit": "kilowattpeak",
+          "value": 10.3
+        }
+      },
+      "timestamp": "2025-09-29T13:59:30.725Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/photovoltaic.installedPeakPower"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "################",
       "feature": "photovoltaic.production.cumulated",
       "gatewayId": "################",
       "isEnabled": true,
@@ -229,36 +775,36 @@
         "currentDay": {
           "type": "number",
           "unit": "wattHour",
-          "value": 47440
+          "value": 30077
         },
         "currentMonth": {
           "type": "number",
           "unit": "wattHour",
-          "value": 487670
+          "value": 927873
         },
         "currentWeek": {
           "type": "number",
           "unit": "wattHour",
-          "value": 208436
+          "value": 30077
         },
         "currentYear": {
           "type": "number",
           "unit": "wattHour",
-          "value": 487670
+          "value": 10732404
         },
         "lifeCycle": {
           "type": "number",
           "unit": "wattHour",
-          "value": 487670
+          "value": 15510008
         }
       },
-      "timestamp": "2023-05-26T19:22:09.055Z",
-      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/photovoltaic.production.cumulated"
+      "timestamp": "2025-09-29T17:16:02.355Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/photovoltaic.production.cumulated"
     },
     {
       "apiVersion": 1,
       "commands": {},
-      "deviceId": "0",
+      "deviceId": "################",
       "feature": "photovoltaic.production.current",
       "gatewayId": "################",
       "isEnabled": true,
@@ -270,13 +816,13 @@
           "value": 0
         }
       },
-      "timestamp": "2023-05-26T19:19:13.292Z",
-      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/photovoltaic.production.current"
+      "timestamp": "2025-09-29T17:09:38.793Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/photovoltaic.production.current"
     },
     {
       "apiVersion": 1,
       "commands": {},
-      "deviceId": "0",
+      "deviceId": "################",
       "feature": "photovoltaic.status",
       "gatewayId": "################",
       "isEnabled": true,
@@ -287,8 +833,64 @@
           "value": "ready"
         }
       },
-      "timestamp": "2023-05-26T19:10:36.637Z",
-      "uri": "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations/#######/gateways/################/devices/0/features/photovoltaic.status"
+      "timestamp": "2025-09-29T17:05:21.936Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/photovoltaic.status"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "################",
+      "feature": "photovoltaic.string.current",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "stringOne": {
+          "type": "number",
+          "unit": "ampere",
+          "value": 0
+        },
+        "stringThree": {
+          "type": "number",
+          "unit": "ampere",
+          "value": 0
+        },
+        "stringTwo": {
+          "type": "number",
+          "unit": "ampere",
+          "value": 0
+        }
+      },
+      "timestamp": "2025-09-29T16:38:23.020Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/photovoltaic.string.current"
+    },
+    {
+      "apiVersion": 1,
+      "commands": {},
+      "deviceId": "################",
+      "feature": "photovoltaic.string.voltage",
+      "gatewayId": "################",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "stringOne": {
+          "type": "number",
+          "unit": "volt",
+          "value": 0
+        },
+        "stringThree": {
+          "type": "number",
+          "unit": "volt",
+          "value": 182
+        },
+        "stringTwo": {
+          "type": "number",
+          "unit": "volt",
+          "value": 143
+        }
+      },
+      "timestamp": "2025-09-29T18:27:39.817Z",
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/#######/gateways/################/devices/################/features/photovoltaic.string.voltage"
     }
   ]
 }

--- a/tests/response/VitochargeVX3.json
+++ b/tests/response/VitochargeVX3.json
@@ -436,7 +436,7 @@
         "currentWeek": {
           "type": "number",
           "unit": "wattHour",
-          "value": 5449
+          "value": 5450
         },
         "currentYear": {
           "type": "number",
@@ -474,7 +474,7 @@
         "currentWeek": {
           "type": "number",
           "unit": "wattHour",
-          "value": 3197
+          "value": 3198
         },
         "currentYear": {
           "type": "number",
@@ -785,7 +785,7 @@
         "currentWeek": {
           "type": "number",
           "unit": "wattHour",
-          "value": 30077
+          "value": 30078
         },
         "currentYear": {
           "type": "number",

--- a/tests/test_TestForMissingProperties.py
+++ b/tests/test_TestForMissingProperties.py
@@ -18,6 +18,13 @@ class TestForMissingProperties(unittest.TestCase):
         # are added to the response files
 
         ignore = [
+            # general - not yet used
+            'device.messages.info.raw',
+            'device.messages.service.raw',
+            'device.messages.status.raw',
+            'device.parameterIdentification.version',
+
+            # heating ignored for now
             'heating.operating.programs.holidayAtHome',
             'heating.operating.programs.holiday',
             'heating.device.time.offset',
@@ -99,6 +106,24 @@ class TestForMissingProperties(unittest.TestCase):
             'heating.scop.heating', # deprecated
             'heating.scop.total', # deprecated
             'heating.dhw.comfort', # deprecated
+
+            # energy system - not yet used
+            'device.etn',
+            'device.serial.internalComponents',
+            'ess.battery.usedAverage',
+            'ess.configuration.backupBox',
+            'ess.configuration.systemType',
+            'ess.inverter.ac.power',
+            'ess.sensors.temperature.ambient',
+            'ess.version.hardware',
+            'heating.device.mainECU',
+            'pcc.ac.active.current',
+            'pcc.ac.active.power',
+            'pcc.ac.reactive.power',
+            'pcc.state.gridCode',
+            'photovoltaic.installedPeakPower',
+            'photovoltaic.string.current',
+            'photovoltaic.string.voltage',
         ]
 
         all_features = self.read_all_features()

--- a/tests/test_VitochargeVX3.py
+++ b/tests/test_VitochargeVX3.py
@@ -63,6 +63,24 @@ class VitochargeVX3(unittest.TestCase):
     def test_getPointOfCommonCouplingTransferFeedInTotalUnit(self):
         self.assertEqual(self.device.getPointOfCommonCouplingTransferFeedInTotalUnit(), "wattHour")
 
+    def test_getElectricalEnergySystemTransferChargeCumulatedUnit(self):
+        self.assertEqual(self.device.getElectricalEnergySystemTransferChargeCumulatedUnit(), "wattHour")
+
+    def test_getElectricalEnergySystemTransferChargeCumulatedCurrentDay(self):
+        self.assertEqual(self.device.getElectricalEnergySystemTransferChargeCumulatedCurrentDay(), 3004)
+
+    def test_getElectricalEnergySystemTransferChargeCumulatedCurrentWeek(self):
+        self.assertEqual(self.device.getElectricalEnergySystemTransferChargeCumulatedCurrentWeek(), 6519)
+
+    def test_getElectricalEnergySystemTransferChargeCumulatedCurrentMonth(self):
+        self.assertEqual(self.device.getElectricalEnergySystemTransferChargeCumulatedCurrentMonth(), 122090)
+
+    def test_getElectricalEnergySystemTransferChargeCumulatedCurrentYear(self):
+        self.assertEqual(self.device.getElectricalEnergySystemTransferChargeCumulatedCurrentYear(), 1230050)
+
+    def test_getElectricalEnergySystemTransferChargeCumulatedLifeCycle(self):
+        self.assertEqual(self.device.getElectricalEnergySystemTransferChargeCumulatedLifeCycle(), 1858108)
+
     def test_getElectricalEnergySystemTransferDischargeCumulatedUnit(self):
         self.assertEqual(self.device.getElectricalEnergySystemTransferDischargeCumulatedUnit(), "wattHour")
 

--- a/tests/test_VitochargeVX3.py
+++ b/tests/test_VitochargeVX3.py
@@ -22,25 +22,25 @@ class VitochargeVX3(unittest.TestCase):
         self.assertEqual(self.device.getSerial(), '################')
 
     def test_getPointOfCommonCouplingTransferPowerExchange(self):
-        self.assertEqual(self.device.getPointOfCommonCouplingTransferPowerExchange(), 0)
+        self.assertEqual(self.device.getPointOfCommonCouplingTransferPowerExchange(), 4)
 
     def test_getPhotovoltaicProductionCumulatedUnit(self):
         self.assertEqual(self.device.getPhotovoltaicProductionCumulatedUnit(), "wattHour")
 
     def test_getPhotovoltaicProductionCumulatedCurrentDay(self):
-        self.assertEqual(self.device.getPhotovoltaicProductionCumulatedCurrentDay(), 47440)
+        self.assertEqual(self.device.getPhotovoltaicProductionCumulatedCurrentDay(), 30077)
 
     def test_getPhotovoltaicProductionCumulatedCurrentWeek(self):
-        self.assertEqual(self.device.getPhotovoltaicProductionCumulatedCurrentWeek(), 208436)
+        self.assertEqual(self.device.getPhotovoltaicProductionCumulatedCurrentWeek(), 30078)
 
     def test_getPhotovoltaicProductionCumulatedCurrentMonth(self):
-        self.assertEqual(self.device.getPhotovoltaicProductionCumulatedCurrentMonth(), 487670)
+        self.assertEqual(self.device.getPhotovoltaicProductionCumulatedCurrentMonth(), 927873)
 
     def test_getPhotovoltaicProductionCumulatedCurrentYear(self):
-        self.assertEqual(self.device.getPhotovoltaicProductionCumulatedCurrentYear(), 487670)
+        self.assertEqual(self.device.getPhotovoltaicProductionCumulatedCurrentYear(), 10732404)
 
     def test_getPhotovoltaicProductionCumulatedLifeCycle(self):
-        self.assertEqual(self.device.getPhotovoltaicProductionCumulatedLifeCycle(), 487670)
+        self.assertEqual(self.device.getPhotovoltaicProductionCumulatedLifeCycle(), 15510008)
 
     def test_getPhotovoltaicStatus(self):
         self.assertEqual(self.device.getPhotovoltaicStatus(), "ready")
@@ -52,13 +52,13 @@ class VitochargeVX3(unittest.TestCase):
         self.assertEqual(self.device.getPhotovoltaicProductionCurrentUnit(), "kilowatt")
 
     def test_getPointOfCommonCouplingTransferConsumptionTotal(self):
-        self.assertEqual(self.device.getPointOfCommonCouplingTransferConsumptionTotal(), 7700)
+        self.assertEqual(self.device.getPointOfCommonCouplingTransferConsumptionTotal(), 2844400)
 
     def test_getPointOfCommonCouplingTransferConsumptionTotalUnit(self):
         self.assertEqual(self.device.getPointOfCommonCouplingTransferConsumptionTotalUnit(), "wattHour")
 
     def test_getPointOfCommonCouplingTransferFeedInTotal(self):
-        self.assertEqual(self.device.getPointOfCommonCouplingTransferFeedInTotal(), 298900)
+        self.assertEqual(self.device.getPointOfCommonCouplingTransferFeedInTotal(), 10433300)
 
     def test_getPointOfCommonCouplingTransferFeedInTotalUnit(self):
         self.assertEqual(self.device.getPointOfCommonCouplingTransferFeedInTotalUnit(), "wattHour")
@@ -67,46 +67,46 @@ class VitochargeVX3(unittest.TestCase):
         self.assertEqual(self.device.getElectricalEnergySystemTransferChargeCumulatedUnit(), "wattHour")
 
     def test_getElectricalEnergySystemTransferChargeCumulatedCurrentDay(self):
-        self.assertEqual(self.device.getElectricalEnergySystemTransferChargeCumulatedCurrentDay(), 3004)
+        self.assertEqual(self.device.getElectricalEnergySystemTransferChargeCumulatedCurrentDay(), 5449)
 
     def test_getElectricalEnergySystemTransferChargeCumulatedCurrentWeek(self):
-        self.assertEqual(self.device.getElectricalEnergySystemTransferChargeCumulatedCurrentWeek(), 6519)
+        self.assertEqual(self.device.getElectricalEnergySystemTransferChargeCumulatedCurrentWeek(), 5450)
 
     def test_getElectricalEnergySystemTransferChargeCumulatedCurrentMonth(self):
-        self.assertEqual(self.device.getElectricalEnergySystemTransferChargeCumulatedCurrentMonth(), 122090)
+        self.assertEqual(self.device.getElectricalEnergySystemTransferChargeCumulatedCurrentMonth(), 143145)
 
     def test_getElectricalEnergySystemTransferChargeCumulatedCurrentYear(self):
-        self.assertEqual(self.device.getElectricalEnergySystemTransferChargeCumulatedCurrentYear(), 1230050)
+        self.assertEqual(self.device.getElectricalEnergySystemTransferChargeCumulatedCurrentYear(), 1251105)
 
     def test_getElectricalEnergySystemTransferChargeCumulatedLifeCycle(self):
-        self.assertEqual(self.device.getElectricalEnergySystemTransferChargeCumulatedLifeCycle(), 1858108)
+        self.assertEqual(self.device.getElectricalEnergySystemTransferChargeCumulatedLifeCycle(), 1879163)
 
     def test_getElectricalEnergySystemTransferDischargeCumulatedUnit(self):
         self.assertEqual(self.device.getElectricalEnergySystemTransferDischargeCumulatedUnit(), "wattHour")
 
     def test_getElectricalEnergySystemTransferDischargeCumulatedCurrentDay(self):
-        self.assertEqual(self.device.getElectricalEnergySystemTransferDischargeCumulatedCurrentDay(), 4751)
+        self.assertEqual(self.device.getElectricalEnergySystemTransferDischargeCumulatedCurrentDay(), 3197)
 
     def test_getElectricalEnergySystemTransferDischargeCumulatedCurrentWeek(self):
-        self.assertEqual(self.device.getElectricalEnergySystemTransferDischargeCumulatedCurrentWeek(), 29820)
+        self.assertEqual(self.device.getElectricalEnergySystemTransferDischargeCumulatedCurrentWeek(), 3198)
 
     def test_getElectricalEnergySystemTransferDischargeCumulatedCurrentMonth(self):
-        self.assertEqual(self.device.getElectricalEnergySystemTransferDischargeCumulatedCurrentMonth(), 66926)
+        self.assertEqual(self.device.getElectricalEnergySystemTransferDischargeCumulatedCurrentMonth(), 136292)
 
     def test_getElectricalEnergySystemTransferDischargeCumulatedCurrentYear(self):
-        self.assertEqual(self.device.getElectricalEnergySystemTransferDischargeCumulatedCurrentYear(), 66926)
+        self.assertEqual(self.device.getElectricalEnergySystemTransferDischargeCumulatedCurrentYear(), 1197530)
 
     def test_getElectricalEnergySystemTransferDischargeCumulatedLifeCycle(self):
-        self.assertEqual(self.device.getElectricalEnergySystemTransferDischargeCumulatedLifeCycle(), 66926)
+        self.assertEqual(self.device.getElectricalEnergySystemTransferDischargeCumulatedLifeCycle(), 1801122)
 
     def test_getElectricalEnergySystemSOC(self):
-        self.assertEqual(self.device.getElectricalEnergySystemSOC(), 91)
+        self.assertEqual(self.device.getElectricalEnergySystemSOC(), 84)
 
     def test_getElectricalEnergySystemSOCUnit(self):
         self.assertEqual(self.device.getElectricalEnergySystemSOCUnit(), "percent")
 
     def test_getElectricalEnergySystemPower(self):
-        self.assertEqual(self.device.getElectricalEnergySystemPower(), 700)
+        self.assertEqual(self.device.getElectricalEnergySystemPower(), 522)
 
     def test_getElectricalEnergySystemPowerUnit(self):
         self.assertEqual(self.device.getElectricalEnergySystemPowerUnit(), "watt")


### PR DESCRIPTION
Add access method to charge statistics of the vx3 battery. The feature `ess.transfer.charge.cumulated` was finally added with the eu data act changes.

SEE: https://api.viessmann-climatesolutions.com/documentation/data-points