### PR TITLE
feat: add support for using client id extracted from android app

### DIFF
--- a/PyViCare/PyViCareBrowserOAuthManager.py
+++ b/PyViCare/PyViCareBrowserOAuthManager.py
@@ -52,7 +52,7 @@ class ViCareBrowserOAuthManager(AbstractViCareOAuthManager):
         oauth_session = OAuth2Session(
             self.client_id, redirect_uri=redirect_uri, scope=VIESSMANN_SCOPE, code_challenge_method='S256')
         code_verifier = generate_token(48)
-        authorization_url, _ = oauth_session.create_authorization_url(AUTHORIZE_URL, code_verifier=code_verifier)
+        authorization_url, _ = oauth_session.create_authorization_url(AUTHORIZE_URL, code_verifier=code_verifier, scope="Internal openid offline_access")
 
         webbrowser.open(authorization_url)
 

--- a/PyViCare/PyViCareOAuthManager.py
+++ b/PyViCare/PyViCareOAuthManager.py
@@ -57,7 +57,7 @@ class ViCareOAuthManager(AbstractViCareOAuthManager):
         oauth_session = OAuth2Session(
             self.client_id, redirect_uri=REDIRECT_URI, scope=VIESSMANN_SCOPE, code_challenge_method='S256')
         code_verifier = generate_token(48)
-        authorization_url, _ = oauth_session.create_authorization_url(AUTHORIZE_URL, code_verifier=code_verifier)
+        authorization_url, _ = oauth_session.create_authorization_url(AUTHORIZE_URL, code_verifier=code_verifier, scope="Internal openid offline_access")
         logger.debug("Auth URL is: %s", authorization_url)
 
         header = {'Content-Type': 'application/x-www-form-urlencoded'}


### PR DESCRIPTION
By setting this scope I'm able to use the clientId I've been able to extract from the android app.

This should hopefully allow to use this integration without ratelimits..
I can provide the clientId I've been able to extract on request.