### PR TITLE
fix(heat pump): fix naming of component functions

### DIFF
--- a/PyViCare/PyViCareHeatPump.py
+++ b/PyViCare/PyViCareHeatPump.py
@@ -396,7 +396,7 @@ class Compressor(HeatingDeviceWithComponent):
     @handleNotSupported
     @deprecated(reason="renamed, use getOutletPressureUnit", version="2.55.1")
     def getCompressorOutletPressureUnit(self) -> str:
-        return self.getOutletPressureUnit()
+        return str(self.getOutletPressureUnit())
 
     @handleNotSupported
     def getOutletPressureUnit(self) -> str:
@@ -407,7 +407,7 @@ class Compressor(HeatingDeviceWithComponent):
     @handleNotSupported
     @deprecated(reason="renamed, use getOutletPressure", version="2.55.1")
     def getCompressorOutletPressure(self) -> float:
-        return self.getOutletPressure()
+        return float(self.getOutletPressure())
 
     @handleNotSupported
     def getOutletPressure(self) -> float:
@@ -418,7 +418,7 @@ class Compressor(HeatingDeviceWithComponent):
     @handleNotSupported
     @deprecated(reason="renamed, use getInletPressureUnit", version="2.55.1")
     def getCompressorInletPressureUnit(self) -> str:
-        return self.getInletPressureUnit()
+        return str(self.getInletPressureUnit())
 
     @handleNotSupported
     def getInletPressureUnit(self) -> str:
@@ -429,7 +429,7 @@ class Compressor(HeatingDeviceWithComponent):
     @handleNotSupported
     @deprecated(reason="renamed, use getInletPressure", version="2.55.1")
     def getCompressorInletPressure(self) -> float:
-        return self.getInletPressure()
+        return float(self.getInletPressure())
 
     @handleNotSupported
     def getInletPressure(self) -> float:
@@ -440,7 +440,7 @@ class Compressor(HeatingDeviceWithComponent):
     @handleNotSupported
     @deprecated(reason="renamed, use getOutletTemperatureUnit", version="2.55.1")
     def getCompressorOutletTemperatureUnit(self) -> str:
-        return self.getOutletTemperatureUnit()
+        return str(self.getOutletTemperatureUnit())
 
     @handleNotSupported
     def getOutletTemperatureUnit(self) -> str:
@@ -451,7 +451,7 @@ class Compressor(HeatingDeviceWithComponent):
     @handleNotSupported
     @deprecated(reason="renamed, use getOutletTemperature", version="2.55.1")
     def getCompressorOutletTemperature(self) -> float:
-        return self.getOutletTemperature()
+        return float(self.getOutletTemperature())
 
     @handleNotSupported
     def getOutletTemperature(self) -> float:
@@ -462,7 +462,7 @@ class Compressor(HeatingDeviceWithComponent):
     @handleNotSupported
     @deprecated(reason="renamed, use getInletTemperatureUnit", version="2.55.1")
     def getCompressorInletTemperatureUnit(self) -> str:
-        return self.getInletTemperatureUnit()
+        return str(self.getInletTemperatureUnit())
 
     @handleNotSupported
     def getInletTemperatureUnit(self) -> str:
@@ -473,7 +473,7 @@ class Compressor(HeatingDeviceWithComponent):
     @handleNotSupported
     @deprecated(reason="renamed, use getInletTemperature", version="2.55.1")
     def getCompressorInletTemperature(self) -> float:
-        return self.getInletTemperature()
+        return float(self.getInletTemperature())
 
     @handleNotSupported
     def getInletTemperature(self) -> float:
@@ -491,7 +491,7 @@ class Evaporator(HeatingDeviceWithComponent):
     @handleNotSupported
     @deprecated(reason="renamed, use getLiquidTemperatureUnit", version="2.55.1")
     def getEvaporatorLiquidTemperatureUnit(self) -> str:
-        return self.getLiquidTemperatureUnit()
+        return str(self.getLiquidTemperatureUnit())
 
     @handleNotSupported
     def getLiquidTemperatureUnit(self) -> str:
@@ -502,7 +502,7 @@ class Evaporator(HeatingDeviceWithComponent):
     @handleNotSupported
     @deprecated(reason="renamed, use getLiquidTemperature", version="2.55.1")
     def getEvaporatorLiquidTemperature(self) -> float:
-        return self.getLiquidTemperature()
+        return float(self.getLiquidTemperature())
 
     @handleNotSupported
     def getLiquidTemperature(self) -> float:
@@ -513,7 +513,7 @@ class Evaporator(HeatingDeviceWithComponent):
     @handleNotSupported
     @deprecated(reason="renamed, use getOverheatTemperatureUnit", version="2.55.1")
     def getEvaporatorOverheatTemperatureUnit(self) -> str:
-        return self.getOverheatTemperatureUnit()
+        return str(self.getOverheatTemperatureUnit())
 
     @handleNotSupported
     def getOverheatTemperatureUnit(self) -> str:
@@ -524,7 +524,7 @@ class Evaporator(HeatingDeviceWithComponent):
     @handleNotSupported
     @deprecated(reason="renamed, use getOverheatTemperature", version="2.55.1")
     def getEvaporatorOverheatTemperature(self) -> float:
-        return self.getOverheatTemperature()
+        return float(self.getOverheatTemperature())
 
     @handleNotSupported
     def getOverheatTemperature(self) -> float:
@@ -542,7 +542,7 @@ class Condensor(HeatingDeviceWithComponent):
     @handleNotSupported
     @deprecated(reason="renamed, use getSubcoolingTemperatureUnit", version="2.55.1")
     def getCondensorSubcoolingTemperatureUnit(self) -> str:
-        return self.getSubcoolingTemperatureUnit()
+        return str(self.getSubcoolingTemperatureUnit())
 
     @handleNotSupported
     def getSubcoolingTemperatureUnit(self) -> str:
@@ -553,7 +553,7 @@ class Condensor(HeatingDeviceWithComponent):
     @handleNotSupported
     @deprecated(reason="renamed, use getSubcoolingTemperature", version="2.55.1")
     def getCondensorSubcoolingTemperature(self) -> float:
-        return self.getSubcoolingTemperature()
+        return float(self.getSubcoolingTemperature())
 
     @handleNotSupported
     def getSubcoolingTemperature(self) -> float:
@@ -564,7 +564,7 @@ class Condensor(HeatingDeviceWithComponent):
     @handleNotSupported
     @deprecated(reason="renamed, use getLiquidTemperatureUnit", version="2.55.1")
     def getCondensorLiquidTemperatureUnit(self) -> str:
-        return self.getLiquidTemperatureUnit()
+        return str(self.getLiquidTemperatureUnit())
 
     @handleNotSupported
     def getLiquidTemperatureUnit(self) -> str:
@@ -575,7 +575,7 @@ class Condensor(HeatingDeviceWithComponent):
     @handleNotSupported
     @deprecated(reason="renamed, use getLiquidTemperature", version="2.55.1")
     def getCondensorLiquidTemperature(self) -> float:
-        return self.getLiquidTemperature()
+        return float(self.getLiquidTemperature())
 
     @handleNotSupported
     def getLiquidTemperature(self) -> float:

--- a/PyViCare/PyViCareHeatPump.py
+++ b/PyViCare/PyViCareHeatPump.py
@@ -392,43 +392,91 @@ class Compressor(HeatingDeviceWithComponent):
     def getPowerConsumptionTotalUnit(self) -> str:
         return str(self.getProperty(f"heating.compressors.{self.compressor}.power.consumption.total")["properties"]["year"]["unit"])
 
+    #TODO: remove deprecated method in 03.2026 release
     @handleNotSupported
+    @deprecated(reason="renamed, use getOutletPressureUnit", version="2.55.1")
     def getCompressorOutletPressureUnit(self) -> str:
+        return self.getOutletPressureUnit()
+
+    @handleNotSupported
+    def getOutletPressureUnit(self) -> str:
         # Shows the unit of measurement of the outlet pressure.
         return str(self.getProperty(f"heating.compressors.{self.compressor}.sensors.pressure.outlet")["properties"]["value"]["unit"])
 
+    #TODO: remove deprecated method in 03.2026 release
     @handleNotSupported
+    @deprecated(reason="renamed, use getOutletPressure", version="2.55.1")
     def getCompressorOutletPressure(self) -> float:
+        return self.getOutletPressure()
+
+    @handleNotSupported
+    def getOutletPressure(self) -> float:
         # Shows the outlet pressure of the compressor.
         return float(self.getProperty(f"heating.compressors.{self.compressor}.sensors.pressure.outlet")["properties"]["value"]["value"])
 
+    #TODO: remove deprecated method in 03.2026 release
     @handleNotSupported
+    @deprecated(reason="renamed, use getInletPressureUnit", version="2.55.1")
     def getCompressorInletPressureUnit(self) -> str:
+        return self.getInletPressureUnit()
+
+    @handleNotSupported
+    def getInletPressureUnit(self) -> str:
         # Shows the unit of measurement of the inlet pressure.
         return str(self.getProperty(f"heating.compressors.{self.compressor}.sensors.pressure.inlet")["properties"]["value"]["unit"])
 
+    #TODO: remove deprecated method in 03.2026 release
     @handleNotSupported
+    @deprecated(reason="renamed, use getInletPressure", version="2.55.1")
     def getCompressorInletPressure(self) -> float:
+        return self.getInletPressure()
+
+    @handleNotSupported
+    def getInletPressure(self) -> float:
         # Shows the inlet pressure of the compressor.
         return float(self.getProperty(f"heating.compressors.{self.compressor}.sensors.pressure.inlet")["properties"]["value"]["value"])
 
+    #TODO: remove deprecated method in 03.2026 release
     @handleNotSupported
+    @deprecated(reason="renamed, use getOutletTemperatureUnit", version="2.55.1")
     def getCompressorOutletTemperatureUnit(self) -> str:
+        return self.getOutletTemperatureUnit()
+
+    @handleNotSupported
+    def getOutletTemperatureUnit(self) -> str:
         # Shows the unit of measurement of the outlet temperature.
         return str(self.getProperty(f"heating.compressors.{self.compressor}.sensors.temperature.outlet")["properties"]["value"]["unit"])
 
+    #TODO: remove deprecated method in 03.2026 release
     @handleNotSupported
+    @deprecated(reason="renamed, use getOutletTemperature", version="2.55.1")
     def getCompressorOutletTemperature(self) -> float:
+        return self.getOutletTemperature()
+
+    @handleNotSupported
+    def getOutletTemperature(self) -> float:
         # Shows the outlet temperature of the compressor.
         return float(self.getProperty(f"heating.compressors.{self.compressor}.sensors.temperature.outlet")["properties"]["value"]["value"])
 
+    #TODO: remove deprecated method in 03.2026 release
     @handleNotSupported
+    @deprecated(reason="renamed, use getInletTemperatureUnit", version="2.55.1")
     def getCompressorInletTemperatureUnit(self) -> str:
+        return self.getInletTemperatureUnit()
+
+    @handleNotSupported
+    def getInletTemperatureUnit(self) -> str:
         # Shows the unit of measurement of the inlet temperature.
         return str(self.getProperty(f"heating.compressors.{self.compressor}.sensors.temperature.inlet")["properties"]["value"]["unit"])
 
+    #TODO: remove deprecated method in 03.2026 release
     @handleNotSupported
+    @deprecated(reason="renamed, use getInletTemperature", version="2.55.1")
     def getCompressorInletTemperature(self) -> float:
+        return self.getInletTemperature()
+
+    @handleNotSupported
+    def getInletTemperature(self) -> float:
         # Shows the inlet temperature of the compressor.
         return float(self.getProperty(f"heating.compressors.{self.compressor}.sensors.temperature.inlet")["properties"]["value"]["value"])
 
@@ -439,23 +487,47 @@ class Evaporator(HeatingDeviceWithComponent):
     def evaporator(self) -> str:
         return self.component
 
+    #TODO: remove deprecated method in 03.2026 release
     @handleNotSupported
+    @deprecated(reason="renamed, use getLiquidTemperatureUnit", version="2.55.1")
     def getEvaporatorLiquidTemperatureUnit(self) -> str:
+        return self.getLiquidTemperatureUnit()
+
+    @handleNotSupported
+    def getLiquidTemperatureUnit(self) -> str:
         # Shows the unit of measurement of the liquid temperature of the evaporator.
         return str(self.getProperty(f"heating.evaporators.{self.evaporator}.sensors.temperature.liquid")["properties"]["value"]["unit"])
 
+    #TODO: remove deprecated method in 03.2026 release
     @handleNotSupported
+    @deprecated(reason="renamed, use getLiquidTemperature", version="2.55.1")
     def getEvaporatorLiquidTemperature(self) -> float:
+        return self.getLiquidTemperature()
+
+    @handleNotSupported
+    def getLiquidTemperature(self) -> float:
         # Shows the liquid temperature of the evaporator.
         return float(self.getProperty(f"heating.evaporators.{self.evaporator}.sensors.temperature.liquid")["properties"]["value"]["value"])
 
+    #TODO: remove deprecated method in 03.2026 release
     @handleNotSupported
+    @deprecated(reason="renamed, use getOverheatTemperatureUnit", version="2.55.1")
     def getEvaporatorOverheatTemperatureUnit(self) -> str:
+        return self.getOverheatTemperatureUnit()
+
+    @handleNotSupported
+    def getOverheatTemperatureUnit(self) -> str:
         # Shows the unit of measurement of the overheat temperature of the evaporator.
         return str(self.getProperty(f"heating.evaporators.{self.evaporator}.sensors.temperature.overheat")["properties"]["value"]["unit"])
 
+    #TODO: remove deprecated method in 03.2026 release
     @handleNotSupported
+    @deprecated(reason="renamed, use getOverheatTemperature", version="2.55.1")
     def getEvaporatorOverheatTemperature(self) -> float:
+        return self.getOverheatTemperature()
+
+    @handleNotSupported
+    def getOverheatTemperature(self) -> float:
         # Shows the overheat temperature of the evaporator.
         return float(self.getProperty(f"heating.evaporators.{self.evaporator}.sensors.temperature.overheat")["properties"]["value"]["value"])
 
@@ -466,22 +538,46 @@ class Condensor(HeatingDeviceWithComponent):
     def condensor(self) -> str:
         return self.component
 
+    #TODO: remove deprecated method in 03.2026 release
     @handleNotSupported
+    @deprecated(reason="renamed, use getSubcoolingTemperatureUnit", version="2.55.1")
     def getCondensorSubcoolingTemperatureUnit(self) -> str:
+        return self.getSubcoolingTemperatureUnit()
+
+    @handleNotSupported
+    def getSubcoolingTemperatureUnit(self) -> str:
         # Shows the unit of measurement of the subcooling temperature of the condensor.
         return str(self.getProperty(f"heating.condensors.{self.condensor}.sensors.temperature.subcooling")["properties"]["value"]["unit"])
 
+    #TODO: remove deprecated method in 03.2026 release
     @handleNotSupported
+    @deprecated(reason="renamed, use getSubcoolingTemperature", version="2.55.1")
     def getCondensorSubcoolingTemperature(self) -> float:
+        return self.getSubcoolingTemperature()
+
+    @handleNotSupported
+    def getSubcoolingTemperature(self) -> float:
         # Shows the subcooling temperature of the condensor.
         return float(self.getProperty(f"heating.condensors.{self.condensor}.sensors.temperature.subcooling")["properties"]["value"]["value"])
 
+    #TODO: remove deprecated method in 03.2026 release
     @handleNotSupported
+    @deprecated(reason="renamed, use getLiquidTemperatureUnit", version="2.55.1")
     def getCondensorLiquidTemperatureUnit(self) -> str:
+        return self.getLiquidTemperatureUnit()
+
+    @handleNotSupported
+    def getLiquidTemperatureUnit(self) -> str:
         # Shows the unit of measurement of the liquid temperature of the condensor.
         return str(self.getProperty(f"heating.condensors.{self.condensor}.sensors.temperature.liquid")["properties"]["value"]["unit"])
 
+    #TODO: remove deprecated method in 03.2026 release
     @handleNotSupported
+    @deprecated(reason="renamed, use getLiquidTemperature", version="2.55.1")
     def getCondensorLiquidTemperature(self) -> float:
+        return self.getLiquidTemperature()
+
+    @handleNotSupported
+    def getLiquidTemperature(self) -> float:
         # Shows the liquid temperature of the condensor.
         return float(self.getProperty(f"heating.condensors.{self.condensor}.sensors.temperature.liquid")["properties"]["value"]["value"])

--- a/PyViCare/PyViCareHeatPump.py
+++ b/PyViCare/PyViCareHeatPump.py
@@ -546,7 +546,7 @@ class Condensor(HeatingDeviceWithComponent):
 
     @handleNotSupported
     def getSubcoolingTemperatureUnit(self) -> str:
-        # Shows the unit of measurement of the subcooling temperature of the condensor.
+        # Shows the unit of measurement of the subcooling temperature of the condenser.
         return str(self.getProperty(f"heating.condensors.{self.condensor}.sensors.temperature.subcooling")["properties"]["value"]["unit"])
 
     #TODO: remove deprecated method in 03.2026 release
@@ -557,7 +557,7 @@ class Condensor(HeatingDeviceWithComponent):
 
     @handleNotSupported
     def getSubcoolingTemperature(self) -> float:
-        # Shows the subcooling temperature of the condensor.
+        # Shows the subcooling temperature of the condenser.
         return float(self.getProperty(f"heating.condensors.{self.condensor}.sensors.temperature.subcooling")["properties"]["value"]["value"])
 
     #TODO: remove deprecated method in 03.2026 release
@@ -568,7 +568,7 @@ class Condensor(HeatingDeviceWithComponent):
 
     @handleNotSupported
     def getLiquidTemperatureUnit(self) -> str:
-        # Shows the unit of measurement of the liquid temperature of the condensor.
+        # Shows the unit of measurement of the liquid temperature of the condenser.
         return str(self.getProperty(f"heating.condensors.{self.condensor}.sensors.temperature.liquid")["properties"]["value"]["unit"])
 
     #TODO: remove deprecated method in 03.2026 release
@@ -579,5 +579,5 @@ class Condensor(HeatingDeviceWithComponent):
 
     @handleNotSupported
     def getLiquidTemperature(self) -> float:
-        # Shows the liquid temperature of the condensor.
+        # Shows the liquid temperature of the condenser.
         return float(self.getProperty(f"heating.condensors.{self.condensor}.sensors.temperature.liquid")["properties"]["value"]["value"])

--- a/tests/test_Vitocal200.py
+++ b/tests/test_Vitocal200.py
@@ -11,41 +11,41 @@ class Vitocal200(unittest.TestCase):
         self.service = ViCareServiceMock('response/Vitocal200.json')
         self.device = HeatPump(self.service)
 
-    def test_getCompressorActive(self):
-        self.assertEqual(self.device.getCompressor(0).getActive(), False)
-
-    def test_getCompressorHours(self):
-        self.assertAlmostEqual(
-            self.device.getCompressor(0).getHours(), 13651.9)
-
     def test_getAvailableCompressors(self):
         self.assertEqual(self.device.getAvailableCompressors(), ['0'])
 
-    def test_getCompressorStarts(self):
+    def test_compressor_getActive(self):
+        self.assertEqual(self.device.getCompressor(0).getActive(), False)
+
+    def test_compressor_getHours(self):
+        self.assertAlmostEqual(
+            self.device.getCompressor(0).getHours(), 13651.9)
+
+    def test_compressor_getStarts(self):
         self.assertAlmostEqual(
             self.device.getCompressor(0).getStarts(), 6973)
 
-    def test_getCompressorHoursLoadClass1(self):
+    def test_compressor_getHoursLoadClass1(self):
         self.assertAlmostEqual(
             self.device.getCompressor(0).getHoursLoadClass1(), 366)
 
-    def test_getCompressorHoursLoadClass2(self):
+    def test_compressor_getHoursLoadClass2(self):
         self.assertAlmostEqual(
             self.device.getCompressor(0).getHoursLoadClass2(), 5579)
 
-    def test_getCompressorHoursLoadClass3(self):
+    def test_compressor_getHoursLoadClass3(self):
         self.assertAlmostEqual(
             self.device.getCompressor(0).getHoursLoadClass3(), 6024)
 
-    def test_getCompressorHoursLoadClass4(self):
+    def test_compressor_getHoursLoadClass4(self):
         self.assertAlmostEqual(
             self.device.getCompressor(0).getHoursLoadClass4(), 659)
 
-    def test_getCompressorHoursLoadClass5(self):
+    def test_compressor_getHoursLoadClass5(self):
         self.assertAlmostEqual(
             self.device.getCompressor(0).getHoursLoadClass5(), 715)
 
-    def test_getCompressorPhase(self):
+    def test_compressor_getPhase(self):
         self.assertEqual(
             self.device.getCompressor(0).getPhase(), "off")
 

--- a/tests/test_Vitocal222S.py
+++ b/tests/test_Vitocal222S.py
@@ -9,14 +9,14 @@ class Vitocal222S(unittest.TestCase):
         self.service = ViCareServiceMock('response/Vitocal222S.json')
         self.device = HeatPump(self.service)
 
-    def test_getCondensorsLiquidTemperature(self):
-        self.assertEqual(self.device.getCondensor(0).getCondensorLiquidTemperature(), 26.1)
-        self.assertEqual(self.device.getCondensor(0).getCondensorLiquidTemperatureUnit(), "celsius")
+    def test_condensers_getLiquidTemperature(self):
+        self.assertEqual(self.device.getCondensor(0).getLiquidTemperature(), 26.1)
+        self.assertEqual(self.device.getCondensor(0).getLiquidTemperatureUnit(), "celsius")
 
-    def test_getCompressorInletTemperature(self):
-        self.assertEqual(self.device.getCompressor(0).getCompressorInletTemperature(), 0.0)
-        self.assertEqual(self.device.getCompressor(0).getCompressorInletTemperatureUnit(), "celsius")
+    def test_compressor_getInletTemperature(self):
+        self.assertEqual(self.device.getCompressor(0).getInletTemperature(), 0.0)
+        self.assertEqual(self.device.getCompressor(0).getInletTemperatureUnit(), "celsius")
 
-    def test_getCompressorOutletTemperature(self):
-        self.assertEqual(self.device.getCompressor(0).getCompressorOutletTemperature(), 32.8)
-        self.assertEqual(self.device.getCompressor(0).getCompressorOutletTemperatureUnit(), "celsius")
+    def test_compressor_getOutletTemperature(self):
+        self.assertEqual(self.device.getCompressor(0).getOutletTemperature(), 32.8)
+        self.assertEqual(self.device.getCompressor(0).getOutletTemperatureUnit(), "celsius")

--- a/tests/test_Vitocal250A.py
+++ b/tests/test_Vitocal250A.py
@@ -10,26 +10,26 @@ class Vitocal250A(unittest.TestCase):
         self.service = ViCareServiceMock('response/Vitocal250A.json')
         self.device = HeatPump(self.service)
 
-    def test_getCompressorActive(self):
+    def test_compressor_getActive(self):
         self.assertFalse(self.device.compressors[0].getActive())
 
-    def test_getCompressorHours(self):
+    def test_compressor_getHours(self):
         self.assertEqual(
             self.device.compressors[0].getHours(), 8118)
 
-    def test_getCompressorStarts(self):
+    def test_compressor_getStarts(self):
         self.assertEqual(
             self.device.compressors[0].getStarts(), 1502)
 
-    # def test_getCompressorHeatProduction(self):
+    # def test_compressor_getHeatProduction(self):
     #     self.assertEqual(self.device.compressors[0].getHeatProductionCurrent(), 13.317)
     #     self.assertEqual(self.device.compressors[0].getHeatProductionCurrentUnit(), "watt")
 
-    # def test_getCompressorPowerConsumptionCurrent(self):
+    # def test_compressor_getPowerConsumptionCurrent(self):
     #     self.assertEqual(self.device.compressors[0].getPowerConsumptionCurrent(), 3.107)
     #     self.assertEqual(self.device.compressors[0].getPowerConsumptionCurrentUnit(), "kilowatt")
 
-    def test_getCompressorPowerConsumptionThisYear(self):
+    def test_compressor_getPowerConsumptionThisYear(self):
         # self.assertEqual(self.device.compressors[0].getPowerConsumptionDHWThisYear(), 143.0)
         # self.assertEqual(self.device.compressors[0].getPowerConsumptionHeatingThisYear(), 55.2)
         self.assertRaises(PyViCareNotSupportedFeatureError, self.device.compressors[0].getPowerConsumptionCoolingThisYear)
@@ -140,7 +140,7 @@ class Vitocal250A(unittest.TestCase):
         self.assertEqual(
             self.device.getPowerSummaryConsumptionDomesticHotWaterLastYear(), 1536.8)
 
-    def test_getCompressorPhase(self):
+    def test_compressor_getPhase(self):
         self.assertEqual(
             self.device.getCompressor(0).getPhase(), "ready")
 

--- a/tests/test_Vitocal300G.py
+++ b/tests/test_Vitocal300G.py
@@ -9,34 +9,34 @@ class Vitocal300G(unittest.TestCase):
         self.service = ViCareServiceMock('response/Vitocal300G.json')
         self.device = HeatPump(self.service)
 
-    def test_getCompressorActive(self):
+    def test_compressor_getActive(self):
         self.assertEqual(self.device.compressors[0].getActive(), False)
 
-    def test_getCompressorHours(self):
+    def test_compressor_getHours(self):
         self.assertAlmostEqual(
             self.device.compressors[0].getHours(), 1762.41)
 
-    def test_getCompressorStarts(self):
+    def test_compressor_getStarts(self):
         self.assertAlmostEqual(
             self.device.compressors[0].getStarts(), 3012)
 
-    def test_getCompressorHoursLoadClass1(self):
+    def test_compressor_getHoursLoadClass1(self):
         self.assertAlmostEqual(
             self.device.compressors[0].getHoursLoadClass1(), 30)
 
-    def test_getCompressorHoursLoadClass2(self):
+    def test_compressor_getHoursLoadClass2(self):
         self.assertAlmostEqual(
             self.device.compressors[0].getHoursLoadClass2(), 703)
 
-    def test_getCompressorHoursLoadClass3(self):
+    def test_compressor_getHoursLoadClass3(self):
         self.assertAlmostEqual(
             self.device.compressors[0].getHoursLoadClass3(), 878)
 
-    def test_getCompressorHoursLoadClass4(self):
+    def test_compressor_getHoursLoadClass4(self):
         self.assertAlmostEqual(
             self.device.compressors[0].getHoursLoadClass4(), 117)
 
-    def test_getCompressorHoursLoadClass5(self):
+    def test_compressor_getHoursLoadClass5(self):
         self.assertAlmostEqual(
             self.device.compressors[0].getHoursLoadClass5(), 20)
 

--- a/tests/test_Vitocal333G_with_Vitovent300F.py
+++ b/tests/test_Vitocal333G_with_Vitovent300F.py
@@ -16,18 +16,18 @@ class Vitocal333G_with_Vitovent300F(unittest.TestCase):
         self.assertEqual(self.device.getSupplyVolumeFlow(), 257)
         self.assertEqual(self.device.getExhaustVolumeFlow(), 257)
 
-    def test_getCondensorSubcoolingTemperature(self):
-        self.assertEqual(self.device.getCondensor("0").getCondensorSubcoolingTemperature(), -2.8)
-        self.assertEqual(self.device.getCondensor("0").getCondensorSubcoolingTemperatureUnit(), "celsius")
+    def test_condenser_getSubcoolingTemperature(self):
+        self.assertEqual(self.device.getCondensor("0").getSubcoolingTemperature(), -2.8)
+        self.assertEqual(self.device.getCondensor("0").getSubcoolingTemperatureUnit(), "celsius")
 
-    def test_getEvaporatorOverheatTemperature(self):
-        self.assertEqual(self.device.getEvaporator("0").getEvaporatorOverheatTemperature(), 0.0)
-        self.assertEqual(self.device.getEvaporator("0").getEvaporatorOverheatTemperatureUnit(), "celsius")
+    def test_evaporator_getOverheatTemperature(self):
+        self.assertEqual(self.device.getEvaporator("0").getOverheatTemperature(), 0.0)
+        self.assertEqual(self.device.getEvaporator("0").getOverheatTemperatureUnit(), "celsius")
 
-    def test_getEvaporatorLiquidTemperature(self):
-        self.assertEqual(self.device.getEvaporator("0").getEvaporatorLiquidTemperature(), 18.2)
-        self.assertEqual(self.device.getEvaporator("0").getEvaporatorLiquidTemperatureUnit(), "celsius")
+    def test_evaporator_getLiquidTemperature(self):
+        self.assertEqual(self.device.getEvaporator("0").getLiquidTemperature(), 18.2)
+        self.assertEqual(self.device.getEvaporator("0").getLiquidTemperatureUnit(), "celsius")
 
-    def test_getCompressorInletPressure(self):
-        self.assertEqual(self.device.getCompressor("0").getCompressorInletPressure(), 12.9)
-        self.assertEqual(self.device.getCompressor("0").getCompressorInletPressureUnit(), "bar")
+    def test_compressor_getInletPressure(self):
+        self.assertEqual(self.device.getCompressor("0").getInletPressure(), 12.9)
+        self.assertEqual(self.device.getCompressor("0").getInletPressureUnit(), "bar")

--- a/tests/test_Vitocaldens222F.py
+++ b/tests/test_Vitocaldens222F.py
@@ -49,7 +49,7 @@ class Vitocaldens222F(unittest.TestCase):
     def test_getBurnerModulation(self):
         self.assertEqual(self.device.getBurner(0).getModulation(), 0)
 
-    def test_getCompressorHours(self):
+    def test_compressor_getHours(self):
         self.assertEqual(self.device.getCompressor(0).getHours(), 1.4)
 
     def test_getPrograms(self):


### PR DESCRIPTION
Trim prefix of `condenser`, `compressor`, `evaporator` functions.