### PR TITLE
feat: expose device_type on PyViCareDeviceConfig

### DIFF
--- a/PyViCare/PyViCare.py
+++ b/PyViCare/PyViCare.py
@@ -61,7 +61,7 @@ class PyViCare:
 
                     logger.info("Device found: %s", device.modelId)
 
-                    yield PyViCareDeviceConfig(service, device.id, device.modelId, device.status)
+                    yield PyViCareDeviceConfig(service, device.id, device.modelId, device.status, device.deviceType)
 
 
 class DictWrap(object):

--- a/PyViCare/PyViCareDeviceConfig.py
+++ b/PyViCare/PyViCareDeviceConfig.py
@@ -91,7 +91,7 @@ class PyViCareDeviceConfig:
         return self.device_type
 
     def isGateway(self):
-        return self.device_type == "vitoconnect"
+        return self.device_type in ["vitoconnect", "tcu"]
 
     # see: https://vitodata300.viessmann.com/vd300/ApplicationHelp/VD300/1031_de_DE/Ger%C3%A4teliste.html
     def asAutoDetectDevice(self):

--- a/PyViCare/PyViCareDeviceConfig.py
+++ b/PyViCare/PyViCareDeviceConfig.py
@@ -22,11 +22,12 @@ logger.addHandler(logging.NullHandler())
 
 
 class PyViCareDeviceConfig:
-    def __init__(self, service, device_id, device_model, status):
+    def __init__(self, service, device_id, device_model, status, device_type=None):
         self.service = service
         self.device_id = device_id
         self.device_model = device_model
         self.status = status
+        self.device_type = device_type
 
     def asGeneric(self):
         return HeatingDevice(self.service)
@@ -84,6 +85,12 @@ class PyViCareDeviceConfig:
 
     def isOnline(self):
         return self.status == "Online"
+
+    def getDeviceType(self):
+        return self.device_type
+
+    def isGateway(self):
+        return self.device_type == "vitoconnect"
 
     # see: https://vitodata300.viessmann.com/vd300/ApplicationHelp/VD300/1031_de_DE/Ger%C3%A4teliste.html
     def asAutoDetectDevice(self):

--- a/PyViCare/PyViCareDeviceConfig.py
+++ b/PyViCare/PyViCareDeviceConfig.py
@@ -22,6 +22,7 @@ logger.addHandler(logging.NullHandler())
 
 
 class PyViCareDeviceConfig:
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
     def __init__(self, service, device_id, device_model, status, device_type=None):
         self.service = service
         self.device_id = device_id

--- a/PyViCare/PyViCareDeviceConfig.py
+++ b/PyViCare/PyViCareDeviceConfig.py
@@ -91,7 +91,7 @@ class PyViCareDeviceConfig:
         return self.device_type
 
     def isGateway(self):
-        return self.device_type in ["vitoconnect", "tcu"]
+        return self.service._isGateway()  # pylint: disable=protected-access
 
     # see: https://vitodata300.viessmann.com/vd300/ApplicationHelp/VD300/1031_de_DE/Ger%C3%A4teliste.html
     def asAutoDetectDevice(self):

--- a/tests/test_PyViCareDeviceConfig.py
+++ b/tests/test_PyViCareDeviceConfig.py
@@ -188,11 +188,11 @@ class PyViCareDeviceConfigTest(unittest.TestCase):
         self.assertIsNone(c.getDeviceType())
 
     def test_isGateway_true_for_gateway_role(self):
-        self.service._isGateway = Mock(return_value=True)
+        self.service._isGateway = Mock(return_value=True)  # pylint: disable=protected-access
         c = PyViCareDeviceConfig(self.service, "0", "Heatbox1", "Online", "vitoconnect")
         self.assertTrue(c.isGateway())
 
     def test_isGateway_false_for_non_gateway_role(self):
-        self.service._isGateway = Mock(return_value=False)
+        self.service._isGateway = Mock(return_value=False)  # pylint: disable=protected-access
         c = PyViCareDeviceConfig(self.service, "0", "Vitocal", "Online", "heating")
         self.assertFalse(c.isGateway())

--- a/tests/test_PyViCareDeviceConfig.py
+++ b/tests/test_PyViCareDeviceConfig.py
@@ -187,10 +187,12 @@ class PyViCareDeviceConfigTest(unittest.TestCase):
         c = PyViCareDeviceConfig(self.service, "0", "Vitocal", "Online")
         self.assertIsNone(c.getDeviceType())
 
-    def test_isGateway_true_for_vitoconnect(self):
+    def test_isGateway_true_for_gateway_role(self):
+        self.service._isGateway = Mock(return_value=True)
         c = PyViCareDeviceConfig(self.service, "0", "Heatbox1", "Online", "vitoconnect")
         self.assertTrue(c.isGateway())
 
-    def test_isGateway_false_for_heating(self):
+    def test_isGateway_false_for_non_gateway_role(self):
+        self.service._isGateway = Mock(return_value=False)
         c = PyViCareDeviceConfig(self.service, "0", "Vitocal", "Online", "heating")
         self.assertFalse(c.isGateway())

--- a/tests/test_PyViCareDeviceConfig.py
+++ b/tests/test_PyViCareDeviceConfig.py
@@ -174,3 +174,23 @@ class PyViCareDeviceConfigTest(unittest.TestCase):
         device = c.asAutoDetectDevice()
         self.assertEqual(device.isLegacyDevice(), False)
         self.assertEqual(device.isE3Device(), True)
+
+    def test_getDeviceType_heating(self):
+        c = PyViCareDeviceConfig(self.service, "0", "Vitocal", "Online", "heating")
+        self.assertEqual(c.getDeviceType(), "heating")
+
+    def test_getDeviceType_vitoconnect(self):
+        c = PyViCareDeviceConfig(self.service, "0", "Heatbox1", "Online", "vitoconnect")
+        self.assertEqual(c.getDeviceType(), "vitoconnect")
+
+    def test_getDeviceType_none_when_not_provided(self):
+        c = PyViCareDeviceConfig(self.service, "0", "Vitocal", "Online")
+        self.assertIsNone(c.getDeviceType())
+
+    def test_isGateway_true_for_vitoconnect(self):
+        c = PyViCareDeviceConfig(self.service, "0", "Heatbox1", "Online", "vitoconnect")
+        self.assertTrue(c.isGateway())
+
+    def test_isGateway_false_for_heating(self):
+        c = PyViCareDeviceConfig(self.service, "0", "Vitocal", "Online", "heating")
+        self.assertFalse(c.isGateway())


### PR DESCRIPTION
## Summary
- Pass `deviceType` from API response through to `PyViCareDeviceConfig`
- Add `getDeviceType()` method and `device_type` property
- Add `isGateway()` convenience method

## Motivation
Fixes #565 - The Viessmann API may return devices in unpredictable order. Users with multiple devices (e.g., gateway + heating) using `devices[0]` may get unexpected results when the gateway appears first.

With this change, users can filter devices by type:
```python
heating_devices = [d for d in vicare.devices if not d.isGateway()]
# or
heating_devices = [d for d in vicare.devices if d.getDeviceType() == "heating"]
```

## Test plan
- Added 5 unit tests for `getDeviceType()` and `isGateway()`
- All 516 tests pass