### PR TITLE
feat: add ventilation level volume flow getters

### DIFF
--- a/PyViCare/PyViCareVentilationDevice.py
+++ b/PyViCare/PyViCareVentilationDevice.py
@@ -289,3 +289,19 @@ class VentilationDevice(Device):
     @handleNotSupported
     def getExhaustVolumeFlow(self) -> int:
         return int(self.getProperty("ventilation.volumeFlow.current.output")["properties"]["value"]["value"])
+
+    @handleNotSupported
+    def getLevelOneVolumeFlow(self) -> int:
+        return int(self.getProperty("ventilation.levels.levelOne")["properties"]["volumeFlow"]["value"])
+
+    @handleNotSupported
+    def getLevelTwoVolumeFlow(self) -> int:
+        return int(self.getProperty("ventilation.levels.levelTwo")["properties"]["volumeFlow"]["value"])
+
+    @handleNotSupported
+    def getLevelThreeVolumeFlow(self) -> int:
+        return int(self.getProperty("ventilation.levels.levelThree")["properties"]["volumeFlow"]["value"])
+
+    @handleNotSupported
+    def getLevelFourVolumeFlow(self) -> int:
+        return int(self.getProperty("ventilation.levels.levelFour")["properties"]["volumeFlow"]["value"])

--- a/PyViCare/PyViCareVentilationDevice.py
+++ b/PyViCare/PyViCareVentilationDevice.py
@@ -291,17 +291,17 @@ class VentilationDevice(Device):
         return int(self.getProperty("ventilation.volumeFlow.current.output")["properties"]["value"]["value"])
 
     @handleNotSupported
-    def getLevelOneVolumeFlow(self) -> int:
+    def getConfiguredLevelOneVolumeFlow(self) -> int:
         return int(self.getProperty("ventilation.levels.levelOne")["properties"]["volumeFlow"]["value"])
 
     @handleNotSupported
-    def getLevelTwoVolumeFlow(self) -> int:
+    def getConfiguredLevelTwoVolumeFlow(self) -> int:
         return int(self.getProperty("ventilation.levels.levelTwo")["properties"]["volumeFlow"]["value"])
 
     @handleNotSupported
-    def getLevelThreeVolumeFlow(self) -> int:
+    def getConfiguredLevelThreeVolumeFlow(self) -> int:
         return int(self.getProperty("ventilation.levels.levelThree")["properties"]["volumeFlow"]["value"])
 
     @handleNotSupported
-    def getLevelFourVolumeFlow(self) -> int:
+    def getConfiguredLevelFourVolumeFlow(self) -> int:
         return int(self.getProperty("ventilation.levels.levelFour")["properties"]["volumeFlow"]["value"])

--- a/tests/test_VitoairFs300E.py
+++ b/tests/test_VitoairFs300E.py
@@ -55,3 +55,15 @@ class VitoairFs300(unittest.TestCase):
             "forcedLevelFour",
             "silent",
         ])
+
+    def test_getLevelOneVolumeFlow(self):
+        self.assertEqual(self.device.getLevelOneVolumeFlow(), 55)
+
+    def test_getLevelTwoVolumeFlow(self):
+        self.assertEqual(self.device.getLevelTwoVolumeFlow(), 129)
+
+    def test_getLevelThreeVolumeFlow(self):
+        self.assertEqual(self.device.getLevelThreeVolumeFlow(), 185)
+
+    def test_getLevelFourVolumeFlow(self):
+        self.assertEqual(self.device.getLevelFourVolumeFlow(), 240)

--- a/tests/test_VitoairFs300E.py
+++ b/tests/test_VitoairFs300E.py
@@ -56,14 +56,14 @@ class VitoairFs300(unittest.TestCase):
             "silent",
         ])
 
-    def test_getLevelOneVolumeFlow(self):
-        self.assertEqual(self.device.getLevelOneVolumeFlow(), 55)
+    def test_getConfiguredLevelOneVolumeFlow(self):
+        self.assertEqual(self.device.getConfiguredLevelOneVolumeFlow(), 55)
 
-    def test_getLevelTwoVolumeFlow(self):
-        self.assertEqual(self.device.getLevelTwoVolumeFlow(), 129)
+    def test_getConfiguredLevelTwoVolumeFlow(self):
+        self.assertEqual(self.device.getConfiguredLevelTwoVolumeFlow(), 129)
 
-    def test_getLevelThreeVolumeFlow(self):
-        self.assertEqual(self.device.getLevelThreeVolumeFlow(), 185)
+    def test_getConfiguredLevelThreeVolumeFlow(self):
+        self.assertEqual(self.device.getConfiguredLevelThreeVolumeFlow(), 185)
 
-    def test_getLevelFourVolumeFlow(self):
-        self.assertEqual(self.device.getLevelFourVolumeFlow(), 240)
+    def test_getConfiguredLevelFourVolumeFlow(self):
+        self.assertEqual(self.device.getConfiguredLevelFourVolumeFlow(), 240)


### PR DESCRIPTION
## Summary

Adds methods to retrieve the configured volume flow (m³/h) for each ventilation level:
- `getLevelOneVolumeFlow()`
- `getLevelTwoVolumeFlow()`
- `getLevelThreeVolumeFlow()`
- `getLevelFourVolumeFlow()`

These values are exposed in `ventilation.levels.levelOne` through `levelFour` and represent the airflow configuration for each level.

Fixes #630

## Test plan

- [x] Added 4 tests using existing VitoairFs300E test data
- [x] All 17 ventilation tests pass