### PR TITLE
feat: Add heating schedule setter for circuits

### DIFF
--- a/PyViCare/PyViCareHeatingDevice.py
+++ b/PyViCare/PyViCareHeatingDevice.py
@@ -699,6 +699,16 @@ class HeatingCircuit(HeatingDeviceWithComponent):
             "sun": properties["entries"]["value"]["sun"]
         }
 
+    @handleAPICommandErrors
+    def setHeatingSchedule(self, schedule: dict) -> None:
+        self.service.setProperty(f"heating.circuits.{self.circuit}.heating.schedule",
+                                 "setSchedule", {'newSchedule': schedule})
+
+    @handleNotSupported
+    def getHeatingScheduleModes(self) -> list:  # type: ignore[type-arg]
+        return list(self.getProperty(f"heating.circuits.{self.circuit}.heating.schedule"
+            )["commands"]["setSchedule"]["params"]["newSchedule"]["constraints"]["modes"])
+
     # Calculates target supply temperature based on data from Viessmann
     # See: https://www.viessmann-community.com/t5/Gas/Mathematische-Formel-fuer-Vorlauftemperatur-aus-den-vier/m-p/68890#M27556
     def getTargetSupplyTemperature(self) -> Optional[float]:

--- a/tests/test_Vitocal300G.py
+++ b/tests/test_Vitocal300G.py
@@ -262,3 +262,8 @@ class Vitocal300G(unittest.TestCase):
     def test_coolingCircuit_getReverseActive(self):
         self.assertEqual(
             self.device.coolingCircuits[0].getReverseActive(), False)
+
+    def test_getHeatingScheduleModes(self):
+        expected_modes = {'reduced', 'normal', 'fixed'}
+        self.assertSetEqual(
+            set(self.device.circuits[0].getHeatingScheduleModes()), expected_modes)

--- a/tests/test_Vitocal300G.py
+++ b/tests/test_Vitocal300G.py
@@ -267,3 +267,23 @@ class Vitocal300G(unittest.TestCase):
         expected_modes = {'reduced', 'normal', 'fixed'}
         self.assertSetEqual(
             set(self.device.circuits[0].getHeatingScheduleModes()), expected_modes)
+
+    def test_setHeatingSchedule(self):
+        schedule = {
+            "mon": [{"start": "06:00", "end": "22:00", "mode": "normal", "position": 0}],
+            "tue": [],
+            "wed": [],
+            "thu": [],
+            "fri": [],
+            "sat": [],
+            "sun": [],
+        }
+        self.device.circuits[0].setHeatingSchedule(schedule)
+        self.assertEqual(len(self.service.setPropertyData), 1)
+        self.assertEqual(
+            self.service.setPropertyData[0]['property_name'],
+            f'heating.circuits.{self.device.circuits[0].circuit}.heating.schedule')
+        self.assertEqual(
+            self.service.setPropertyData[0]['action'], 'setSchedule')
+        self.assertEqual(
+            self.service.setPropertyData[0]['data'], {'newSchedule': schedule})


### PR DESCRIPTION
## Summary

Adds methods to set heating circuit schedules:
- `setHeatingSchedule(schedule)` - set the heating schedule for a circuit
- `getHeatingScheduleModes()` - get available schedule modes (e.g., reduced, normal, fixed)

This complements the existing `getHeatingSchedule()` method and follows the same pattern as `setDomesticHotWaterCirculationSchedule()`.

Fixes #539

## Test plan

- [x] Added test for `getHeatingScheduleModes()` using Vitocal300G test data
- [x] All tests pass