### PR TITLE
feat: add DHW operating mode getters

### DIFF
--- a/PyViCare/PyViCareHeatingDevice.py
+++ b/PyViCare/PyViCareHeatingDevice.py
@@ -198,6 +198,16 @@ class HeatingDevice(Device):
         return self.setProperty("heating.dhw.temperature.temp2", "setTargetTemperature",
                                         {"temperature": int(temperature)})
 
+    @handleNotSupported
+    def getDomesticHotWaterOperatingModes(self):
+        return self.getProperty("heating.dhw.operating.modes.active")[
+            "commands"]["setMode"]["params"]["mode"]["constraints"]["enum"]
+
+    @handleNotSupported
+    def getDomesticHotWaterActiveOperatingMode(self):
+        return self.getProperty("heating.dhw.operating.modes.active")[
+            "properties"]["value"]["value"]
+
     @handleAPICommandErrors
     def setDomesticHotWaterOperatingMode(self, mode):
         return self.setProperty("heating.dhw.operating.modes.active", "setMode",

--- a/tests/test_Vitocal222S.py
+++ b/tests/test_Vitocal222S.py
@@ -23,3 +23,12 @@ class Vitocal222S(unittest.TestCase):
 
     def test_compressor_getSpeed(self):
         self.assertEqual(self.device.getCompressor(0).getSpeed(), 20)
+
+    def test_getDomesticHotWaterOperatingModes(self):
+        self.assertListEqual(
+            self.device.getDomesticHotWaterOperatingModes(),
+            ['efficientWithMinComfort', 'efficient', 'off'])
+
+    def test_getDomesticHotWaterActiveOperatingMode(self):
+        self.assertEqual(
+            self.device.getDomesticHotWaterActiveOperatingMode(), 'efficient')

--- a/tests/test_Vitocal250A.py
+++ b/tests/test_Vitocal250A.py
@@ -242,5 +242,14 @@ class Vitocal250A(unittest.TestCase):
     def test_inverter_getTemperature(self):
         self.assertEqual(self.device.inverters[0].getTemperature(), 26.3)
 
+    def test_getDomesticHotWaterOperatingModes(self):
+        self.assertListEqual(
+            self.device.getDomesticHotWaterOperatingModes(),
+            ['efficientWithMinComfort', 'efficient', 'off'])
+
+    def test_getDomesticHotWaterActiveOperatingMode(self):
+        self.assertEqual(
+            self.device.getDomesticHotWaterActiveOperatingMode(), 'efficient')
+
     def test_getWifiSignalStrength(self):
         self.assertEqual(self.device.getWifiSignalStrength(), -30)

--- a/tests/test_VitovalorPT2.py
+++ b/tests/test_VitovalorPT2.py
@@ -203,5 +203,14 @@ class VitovalorPT2(unittest.TestCase):
         self.assertEqual(self.device.getSupplyPressure(), 1.7)
         self.assertEqual(self.device.getSupplyPressureUnit(), "bar")
 
+    def test_getDomesticHotWaterOperatingModes(self):
+        self.assertListEqual(
+            self.device.getDomesticHotWaterOperatingModes(),
+            ['balanced', 'off'])
+
+    def test_getDomesticHotWaterActiveOperatingMode(self):
+        self.assertEqual(
+            self.device.getDomesticHotWaterActiveOperatingMode(), 'balanced')
+
     def test_getWifiSignalStrength(self):
         self.assertEqual(self.device.getWifiSignalStrength(), -47)


### PR DESCRIPTION
Add `getDomesticHotWaterOperatingModes()` and `getDomesticHotWaterActiveOperatingMode()` to `HeatingDevice`.

These complement the existing `setDomesticHotWaterOperatingMode()` setter (added in #319) by providing read access to:
- The list of available DHW operating modes (from the `setMode` command constraints)
- The currently active DHW operating mode

### Test coverage

Tests added for three devices with different mode sets:
| Device | Available modes | Active mode |
|--------|----------------|-------------|
| Vitocal 250A | efficientWithMinComfort, efficient, off | efficient |
| Vitocal 222S | efficientWithMinComfort, efficient, off | efficient |
| Vitovalor PT2 | balanced, off | balanced |

Needed for home-assistant/core#154414 (ViCare DHW operating mode select entity).