### PR TITLE
feat: add CoolingCircuit support for heat pumps

### DIFF
--- a/tests/test_TestForMissingProperties.py
+++ b/tests/test_TestForMissingProperties.py
@@ -201,8 +201,6 @@ class TestForMissingProperties(unittest.TestCase):
             'heating.configuration.dhwHeater',
             'heating.configuration.flow.temperature.max',
             'heating.configuration.flow.temperature.min',
-            'heating.coolingCircuits.0.reverse',
-            'heating.coolingCircuits.0.type',
             'heating.cop.cooling',
             'heating.cop.dhw',
             'heating.cop.green',
@@ -359,7 +357,7 @@ class TestForMissingProperties(unittest.TestCase):
                 continue
 
             for match in re.findall(r'getProperty\(\s*?f?"(.*)"\s*?\)', all_python_files[python]):
-                feature_name = re.sub(r'{self.(circuit|burner|compressor|condensor|evaporator|inverter)}', '0', match)
+                feature_name = re.sub(r'{(self\.)?(circuit|burner|compressor|condensor|evaporator|inverter)}', '0', match)
                 feature_name = re.sub(r'{burner}', '0', feature_name)
                 feature_name = re.sub(r'\.{(quickmode|mode|program|active_program)}', '', feature_name)
                 used_features.append(feature_name)

--- a/tests/test_Vitocal300G.py
+++ b/tests/test_Vitocal300G.py
@@ -80,3 +80,16 @@ class Vitocal300G(unittest.TestCase):
     def test_getDomesticHotWaterCirculationPumpActive(self):
         self.assertEqual(
             self.device.getDomesticHotWaterCirculationPumpActive(), False)
+
+    # Cooling circuit tests
+    def test_getAvailableCoolingCircuits(self):
+        self.assertEqual(
+            self.device.getAvailableCoolingCircuits(), ['0'])
+
+    def test_coolingCircuit_getType(self):
+        self.assertEqual(
+            self.device.coolingCircuits[0].getType(), "VC 3xx-G Emerson")
+
+    def test_coolingCircuit_getReverseActive(self):
+        self.assertEqual(
+            self.device.coolingCircuits[0].getReverseActive(), False)


### PR DESCRIPTION
Add detection and accessors for cooling circuits on heat pumps with cooling capability.

Split out from #689 per review feedback to keep PRs focused.

**Changes:**
- `CoolingCircuit` class with `getType()` and `getReverseActive()`
- Auto-detection of available cooling circuits (0-3) via `getAvailableCoolingCircuits()`
- `coolingCircuits` property on `HeatPump`
- Tests for Vitocal 300G CU401B

**Tested devices** (feature present in test data):
- Vitocal 300G CU401B
- Vitocal 333G with Vitovent 300F
- Vitocal 200S AWB-M-E-AC-201.D10

**Deprecation check:** Verified all cooling circuit features (`heating.coolingCircuits.*.type`, `heating.coolingCircuits.*.reverse`) against the API's `deprecated` field in recent device dumps — none are flagged as deprecated.

Addresses part of #363 (natural cooling).