### PR TITLE
chore(testdata): Add device section to Vitocal300G_CU401B

### DIFF
--- a/tests/response/Vitocal300G_CU401B.json
+++ b/tests/response/Vitocal300G_CU401B.json
@@ -3931,5 +3931,25 @@
       "timestamp": "2026-01-22T00:00:00.000Z",
       "uri": "https://api.viessmann-platform.io/iot/v1/equipment/installations/######/gateways/################/devices/0/features/ventilation.volumeFlow.current.output"
     }
-  ]
+  ],
+  "device": {
+    "id": "0",
+    "modelId": "CU401B_G",
+    "roles": [
+      "capability:consumptionReport;electric",
+      "capability:monetization;AdvancedReport",
+      "capability:productionReport;electric",
+      "capability:productionReport;thermal",
+      "capability:service;AdvancedReport",
+      "type:brand;Viessmann",
+      "type:cooling;integrated",
+      "type:dhw;integrated",
+      "type:heating;integrated",
+      "type:heatpump",
+      "type:legacy",
+      "type:product;CU401B"
+    ],
+    "status": "Online",
+    "type": "heating"
+  }
 }


### PR DESCRIPTION
Add the `device` metadata section (from `dump_secure()`) to the Vitocal 300-G test data. This includes `modelId`, `type`, `status`, and `roles` fields that enable device classification testing.

No data changes — only the `device` section is added to the existing response file.