### PR TITLE
chore: Expose oauth constants

### DIFF
--- a/PyViCare/PyViCareAbstractOAuthManager.py
+++ b/PyViCare/PyViCareAbstractOAuthManager.py
@@ -15,6 +15,9 @@ logger = logging.getLogger('ViCare')
 logger.addHandler(logging.NullHandler())
 
 API_BASE_URL = 'https://api.viessmann-climatesolutions.com/iot/v2'
+AUTHORIZE_URL = 'https://iam.viessmann-climatesolutions.com/idp/v3/authorize'
+TOKEN_URL = 'https://iam.viessmann-climatesolutions.com/idp/v3/token'
+VIESSMANN_SCOPE = ["IoT User", "offline_access"]
 
 
 class AbstractViCareOAuthManager:

--- a/PyViCare/PyViCareAbstractOAuthManager.py
+++ b/PyViCare/PyViCareAbstractOAuthManager.py
@@ -17,7 +17,11 @@ logger.addHandler(logging.NullHandler())
 API_BASE_URL = 'https://api.viessmann-climatesolutions.com/iot/v2'
 AUTHORIZE_URL = 'https://iam.viessmann-climatesolutions.com/idp/v3/authorize'
 TOKEN_URL = 'https://iam.viessmann-climatesolutions.com/idp/v3/token'
-VIESSMANN_SCOPE = ["IoT User", "offline_access"]
+
+SCOPE_IOT = "IoT"
+SCOPE_USER = "User"
+SCOPE_OFFLINE_ACCESS = "offline_access"
+SCOPE_INTERNAL = "internal"
 
 
 class AbstractViCareOAuthManager:

--- a/PyViCare/PyViCareBrowserOAuthManager.py
+++ b/PyViCare/PyViCareBrowserOAuthManager.py
@@ -7,17 +7,19 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from authlib.common.security import generate_token
 from authlib.integrations.requests_client import OAuth2Session
 
-from PyViCare.PyViCareAbstractOAuthManager import AbstractViCareOAuthManager
+from PyViCare.PyViCareAbstractOAuthManager import (
+    AUTHORIZE_URL,
+    TOKEN_URL,
+    VIESSMANN_SCOPE,
+    AbstractViCareOAuthManager,
+)
 from PyViCare.PyViCareUtils import (PyViCareBrowserOAuthTimeoutReachedError,
                                     PyViCareInvalidCredentialsError)
 
 logger = logging.getLogger('ViCare')
 logger.addHandler(logging.NullHandler())
 
-AUTHORIZE_URL = 'https://iam.viessmann-climatesolutions.com/idp/v3/authorize'
-TOKEN_URL = 'https://iam.viessmann-climatesolutions.com/idp/v3/token'
 REDIRECT_PORT = 51125
-VIESSMANN_SCOPE = ["IoT User", "offline_access"]
 AUTH_TIMEOUT = 60 * 3
 
 

--- a/PyViCare/PyViCareBrowserOAuthManager.py
+++ b/PyViCare/PyViCareBrowserOAuthManager.py
@@ -9,8 +9,10 @@ from authlib.integrations.requests_client import OAuth2Session
 
 from PyViCare.PyViCareAbstractOAuthManager import (
     AUTHORIZE_URL,
+    SCOPE_IOT,
+    SCOPE_OFFLINE_ACCESS,
+    SCOPE_USER,
     TOKEN_URL,
-    VIESSMANN_SCOPE,
     AbstractViCareOAuthManager,
 )
 from PyViCare.PyViCareUtils import (PyViCareBrowserOAuthTimeoutReachedError,
@@ -52,7 +54,7 @@ class ViCareBrowserOAuthManager(AbstractViCareOAuthManager):
     def __execute_browser_authentication(self):
         redirect_uri = f"http://localhost:{REDIRECT_PORT}"
         oauth_session = OAuth2Session(
-            self.client_id, redirect_uri=redirect_uri, scope=VIESSMANN_SCOPE, code_challenge_method='S256')
+            self.client_id, redirect_uri=redirect_uri, scope=[SCOPE_IOT, SCOPE_USER, SCOPE_OFFLINE_ACCESS], code_challenge_method='S256')
         code_verifier = generate_token(48)
         authorization_url, _ = oauth_session.create_authorization_url(AUTHORIZE_URL, code_verifier=code_verifier)
 

--- a/PyViCare/PyViCareOAuthManager.py
+++ b/PyViCare/PyViCareOAuthManager.py
@@ -59,7 +59,7 @@ class ViCareOAuthManager(AbstractViCareOAuthManager):
             oauth sessions object
         """
         oauth_session = OAuth2Session(
-            self.client_id, redirect_uri=REDIRECT_URI, scope=[SCOPE_IOT, SCOPE_USER, SCOPE_OFFLINE_ACCESS], code_challenge_method='S256')
+            self.client_id, redirect_uri=REDIRECT_URI, scope=[SCOPE_IOT, SCOPE_USER], code_challenge_method='S256')
         code_verifier = generate_token(48)
         authorization_url, _ = oauth_session.create_authorization_url(AUTHORIZE_URL, code_verifier=code_verifier)
         logger.debug("Auth URL is: %s", authorization_url)

--- a/PyViCare/PyViCareOAuthManager.py
+++ b/PyViCare/PyViCareOAuthManager.py
@@ -11,7 +11,6 @@ from authlib.integrations.requests_client import OAuth2Session
 from PyViCare.PyViCareAbstractOAuthManager import (
     AUTHORIZE_URL,
     SCOPE_IOT,
-    SCOPE_OFFLINE_ACCESS,
     SCOPE_USER,
     TOKEN_URL,
     AbstractViCareOAuthManager,

--- a/PyViCare/PyViCareOAuthManager.py
+++ b/PyViCare/PyViCareOAuthManager.py
@@ -10,8 +10,10 @@ from authlib.integrations.requests_client import OAuth2Session
 
 from PyViCare.PyViCareAbstractOAuthManager import (
     AUTHORIZE_URL,
+    SCOPE_IOT,
+    SCOPE_OFFLINE_ACCESS,
+    SCOPE_USER,
     TOKEN_URL,
-    VIESSMANN_SCOPE,
     AbstractViCareOAuthManager,
 )
 from PyViCare.PyViCareUtils import (PyViCareInvalidConfigurationError,
@@ -57,7 +59,7 @@ class ViCareOAuthManager(AbstractViCareOAuthManager):
             oauth sessions object
         """
         oauth_session = OAuth2Session(
-            self.client_id, redirect_uri=REDIRECT_URI, scope=VIESSMANN_SCOPE, code_challenge_method='S256')
+            self.client_id, redirect_uri=REDIRECT_URI, scope=[SCOPE_IOT, SCOPE_USER, SCOPE_OFFLINE_ACCESS], code_challenge_method='S256')
         code_verifier = generate_token(48)
         authorization_url, _ = oauth_session.create_authorization_url(AUTHORIZE_URL, code_verifier=code_verifier)
         logger.debug("Auth URL is: %s", authorization_url)

--- a/PyViCare/PyViCareOAuthManager.py
+++ b/PyViCare/PyViCareOAuthManager.py
@@ -8,17 +8,19 @@ import requests
 from authlib.common.security import generate_token
 from authlib.integrations.requests_client import OAuth2Session
 
-from PyViCare.PyViCareAbstractOAuthManager import AbstractViCareOAuthManager
+from PyViCare.PyViCareAbstractOAuthManager import (
+    AUTHORIZE_URL,
+    TOKEN_URL,
+    VIESSMANN_SCOPE,
+    AbstractViCareOAuthManager,
+)
 from PyViCare.PyViCareUtils import (PyViCareInvalidConfigurationError,
                                     PyViCareInvalidCredentialsError)
 
 logger = logging.getLogger('ViCare')
 logger.addHandler(logging.NullHandler())
 
-AUTHORIZE_URL = 'https://iam.viessmann-climatesolutions.com/idp/v3/authorize'
-TOKEN_URL = 'https://iam.viessmann-climatesolutions.com/idp/v3/token'
 REDIRECT_URI = "vicare://oauth-callback/everest"
-VIESSMANN_SCOPE = ["IoT User"]
 
 
 class ViCareOAuthManager(AbstractViCareOAuthManager):


### PR DESCRIPTION
Move `AUTHORIZE_URL`, `TOKEN_URL`, and `VIESSMANN_SCOPE` to `PyViCareAbstractOAuthManager` as the single source of truth. Both `PyViCareOAuthManager` and `PyViCareBrowserOAuthManager` now import from there.

This aligns the scope to `["IoT User", "offline_access"]` for both managers. Previously, the password-grant manager used only `["IoT User"]`, which meant tokens had no refresh capability — they expired after 1h with no way to renew without re-authenticating with username/password.

Adding `offline_access` to the password-grant flow gives it a refresh token too, improving reliability for long-running sessions.

Related: openviess/PyViCare#724, home-assistant/core#165621