### PR TITLE
fix: Handle PACKAGE_NOT_PAID_FOR API error gracefully

### DIFF
--- a/PyViCare/PyViCareAbstractOAuthManager.py
+++ b/PyViCare/PyViCareAbstractOAuthManager.py
@@ -9,6 +9,7 @@ from PyViCare import Feature
 from PyViCare.PyViCareUtils import (PyViCareCommandError,
                                     PyViCareDeviceCommunicationError,
                                     PyViCareInternalServerError,
+                                    PyViCareNotPaidForError,
                                     PyViCareRateLimitError)
 
 logger = logging.getLogger('ViCare')
@@ -48,6 +49,7 @@ class AbstractViCareOAuthManager:
             self.__handle_expired_token(response)
             self.__handle_rate_limit(response)
             self.__handle_device_communication_error(response)
+            self.__handle_not_paid_for(response)
             self.__handle_server_error(response)
             return response
         except TokenExpiredError:
@@ -71,6 +73,10 @@ class AbstractViCareOAuthManager:
     def __handle_device_communication_error(self, response):
         if ("errorType" in response and response["errorType"] == "DEVICE_COMMUNICATION_ERROR"):
             raise PyViCareDeviceCommunicationError(response)
+
+    def __handle_not_paid_for(self, response):
+        if ("errorType" in response and response["errorType"] == "PACKAGE_NOT_PAID_FOR"):
+            raise PyViCareNotPaidForError(response)
 
     def __handle_server_error(self, response):
         if ("statusCode" in response and response["statusCode"] >= 500):

--- a/PyViCare/PyViCareCachedService.py
+++ b/PyViCare/PyViCareCachedService.py
@@ -8,6 +8,8 @@ from PyViCare.PyViCareService import (ViCareDeviceAccessor, ViCareService,
 from PyViCare.PyViCareUtils import (PyViCareDeviceCommunicationError,
                                     PyViCareInvalidDataError,
                                     PyViCareInternalServerError,
+                                    PyViCareNotPaidForError,
+                                    PyViCareNotSupportedFeatureError,
                                     ViCareTimer)
 
 logger = logging.getLogger('ViCare')
@@ -44,6 +46,11 @@ class ViCareCachedService(ViCareService):
 
                 try:
                     data = self.fetch_all_features()
+                except PyViCareNotPaidForError as e:
+                    logger.error("Viessmann API denied access (PACKAGE_NOT_PAID_FOR). Features unavailable: %s", e)
+                    if self.__cache is not None:
+                        return self.__cache
+                    raise PyViCareNotSupportedFeatureError("PACKAGE_NOT_PAID_FOR")
                 except (PyViCareDeviceCommunicationError, PyViCareInternalServerError) as e:
                     if self.__cache is not None:
                         logger.warning("API error, returning stale cache: %s", e)

--- a/PyViCare/PyViCareUtils.py
+++ b/PyViCare/PyViCareUtils.py
@@ -105,6 +105,17 @@ class PyViCareInvalidDataError(Exception):
     pass
 
 
+class PyViCareNotPaidForError(Exception):
+    def __init__(self, response):
+        extended_payload = response.get("extendedPayload", {})
+        monetization = extended_payload.get("monetization", "Unknown")
+
+        msg = f"Feature not available: {monetization}"
+
+        super().__init__(self, msg)
+        self.message = msg
+
+
 class PyViCareDeviceCommunicationError(Exception):
     def __init__(self, response):
         extended_payload = response.get("extendedPayload", {})


### PR DESCRIPTION
Since late March 2026, Viessmann's API returns `PACKAGE_NOT_PAID_FOR` (HTTP 402) for some users when fetching device features. This affects new installations across multiple countries (Germany, Poland, Ireland — see home-assistant/core#167367 and [Viessmann community thread](https://community.viessmann.de/t5/The-Viessmann-API/homeassistant-keine-Entitaeten/td-p/613353)).

Previously, this response lacked a `"data"` key and triggered `PyViCareInvalidDataError`, crashing the entire integration setup in Home Assistant.

**Approach:**

- New `PyViCareNotPaidForError` exception, raised when the API returns `errorType: PACKAGE_NOT_PAID_FOR`
- In `ViCareCachedService`, this is caught separately from other API errors:
  - If a stale cache exists (existing users experiencing a transient block), return the cached data
  - If no cache exists (new users), re-raise as `PyViCareNotSupportedFeatureError`

The re-raise as `PyViCareNotSupportedFeatureError` is a deliberate choice: HA already catches this exception in ~10 places to skip unsupported features. This means **no HA-side changes are needed** — the integration will set up cleanly but with zero entities for affected users, rather than crashing during platform setup.

I considered keeping `PyViCareNotPaidForError` all the way through, but that would require changes in every `is_supported()` call path in HA. The distinct exception still exists at the library level for anyone who needs to distinguish "not paid" from "not supported" in their own code.