### PR TITLE
chore: Change logger name to 'PyViCare...'

### DIFF
--- a/PyViCare/PyViCare.py
+++ b/PyViCare/PyViCare.py
@@ -9,7 +9,7 @@ from PyViCare.PyViCareOAuthManager import ViCareOAuthManager
 from PyViCare.PyViCareService import ViCareDeviceAccessor, ViCareService
 from PyViCare.PyViCareUtils import PyViCareInvalidDataError
 
-logger = logging.getLogger('ViCare')
+logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 

--- a/PyViCare/PyViCareAbstractOAuthManager.py
+++ b/PyViCare/PyViCareAbstractOAuthManager.py
@@ -11,7 +11,7 @@ from PyViCare.PyViCareUtils import (PyViCareCommandError,
                                     PyViCareInternalServerError,
                                     PyViCareRateLimitError)
 
-logger = logging.getLogger('ViCare')
+logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 API_BASE_URL = 'https://api.viessmann-climatesolutions.com/iot/v2'

--- a/PyViCare/PyViCareBrowserOAuthManager.py
+++ b/PyViCare/PyViCareBrowserOAuthManager.py
@@ -18,7 +18,7 @@ from PyViCare.PyViCareAbstractOAuthManager import (
 from PyViCare.PyViCareUtils import (PyViCareBrowserOAuthTimeoutReachedError,
                                     PyViCareInvalidCredentialsError)
 
-logger = logging.getLogger('ViCare')
+logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 REDIRECT_PORT = 51125

--- a/PyViCare/PyViCareCachedService.py
+++ b/PyViCare/PyViCareCachedService.py
@@ -10,7 +10,7 @@ from PyViCare.PyViCareUtils import (PyViCareDeviceCommunicationError,
                                     PyViCareInternalServerError,
                                     ViCareTimer)
 
-logger = logging.getLogger('ViCare')
+logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 

--- a/PyViCare/PyViCareDeviceConfig.py
+++ b/PyViCare/PyViCareDeviceConfig.py
@@ -17,7 +17,7 @@ from PyViCare.PyViCareElectricalEnergySystem import ElectricalEnergySystem
 from PyViCare.PyViCareGateway import Gateway
 from PyViCare.PyViCareVentilationDevice import VentilationDevice
 
-logger = logging.getLogger('ViCare')
+logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 

--- a/PyViCare/PyViCareOAuthManager.py
+++ b/PyViCare/PyViCareOAuthManager.py
@@ -18,7 +18,7 @@ from PyViCare.PyViCareAbstractOAuthManager import (
 from PyViCare.PyViCareUtils import (PyViCareInvalidConfigurationError,
                                     PyViCareInvalidCredentialsError)
 
-logger = logging.getLogger('ViCare')
+logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 REDIRECT_URI = "vicare://oauth-callback/everest"

--- a/PyViCare/PyViCareService.py
+++ b/PyViCare/PyViCareService.py
@@ -5,7 +5,7 @@ from typing import Any, List
 from PyViCare.PyViCareAbstractOAuthManager import AbstractViCareOAuthManager
 from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
 
-logger = logging.getLogger('ViCare')
+logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 def readFeature(entities, property_name):


### PR DESCRIPTION
All 7 modules use `logging.getLogger('ViCare')`, but Home Assistant's vicare integration registers `"loggers": ["PyViCare"]` in its `manifest.json`. This mismatch means HA's logger configuration for the integration has no effect on the library's log output.

Renaming to `'PyViCare'` matches the package name (Python convention) and makes HA's logger settings work as expected.