### PR TITLE
fix: auto-detect hybrid devices using API features

### DIFF
--- a/PyViCare/PyViCareDeviceConfig.py
+++ b/PyViCare/PyViCareDeviceConfig.py
@@ -143,7 +143,7 @@ class PyViCareDeviceConfig:
             has_burners = any(f.startswith("heating.burners") for f in feature_names)
             has_compressors = any(f.startswith("heating.compressors") for f in feature_names)
             return has_burners and has_compressors
-        except Exception:
+        except (KeyError, TypeError, AttributeError, OSError):
             logger.debug("Could not fetch features for hybrid detection of %s", self.device_model)
             return False
 

--- a/PyViCare/PyViCareDeviceConfig.py
+++ b/PyViCare/PyViCareDeviceConfig.py
@@ -125,10 +125,27 @@ class PyViCareDeviceConfig:
         for (creator_method, type_name, roles) in device_types:
             if re.search(type_name, self.device_model) or self.service.hasRoles(roles):
                 logger.info("detected %s %s", self.device_model, creator_method.__name__)
-                return creator_method()
+                device = creator_method()
+                if isinstance(device, (GazBoiler, HeatPump)) and not isinstance(device, Hybrid):
+                    if self._isHybridByFeatures():
+                        logger.info("upgrading %s to Hybrid based on API features", self.device_model)
+                        return self.asHybridDevice()
+                return device
 
         logger.info("Could not auto detect %s. Use generic device.", self.device_model)
         return self.asGeneric()
+
+    def _isHybridByFeatures(self):
+        """Check API features to detect hybrid devices (both burners and compressors)."""
+        try:
+            features = self.service.fetch_all_features()
+            feature_names = [f["feature"] for f in features.get("data", [])]
+            has_burners = any(f.startswith("heating.burners") for f in feature_names)
+            has_compressors = any(f.startswith("heating.compressors") for f in feature_names)
+            return has_burners and has_compressors
+        except Exception:
+            logger.debug("Could not fetch features for hybrid detection of %s", self.device_model)
+            return False
 
     def get_raw_json(self):
         return self.service.fetch_all_features()

--- a/tests/test_PyViCareDeviceConfig.py
+++ b/tests/test_PyViCareDeviceConfig.py
@@ -175,6 +175,51 @@ class PyViCareDeviceConfigTest(unittest.TestCase):
         self.assertEqual(device.isLegacyDevice(), False)
         self.assertEqual(device.isE3Device(), True)
 
+    def test_autoDetect_CU401B_S_with_burners_and_compressors_asHybrid(self):
+        self.service.hasRoles = has_roles(["type:heatpump"])
+        self.service.fetch_all_features = Mock(return_value={"data": [
+            {"feature": "heating.burners"},
+            {"feature": "heating.burners.0"},
+            {"feature": "heating.compressors"},
+            {"feature": "heating.compressors.0"},
+        ]})
+        c = PyViCareDeviceConfig(
+            self.service, "0", "CU401B_S", "Online")
+        device_type = c.asAutoDetectDevice()
+        self.assertEqual("Hybrid", type(device_type).__name__)
+
+    def test_autoDetect_HeatPump_without_burners_stays_HeatPump(self):
+        self.service.hasRoles = has_roles(["type:heatpump"])
+        self.service.fetch_all_features = Mock(return_value={"data": [
+            {"feature": "heating.compressors"},
+            {"feature": "heating.compressors.0"},
+        ]})
+        c = PyViCareDeviceConfig(
+            self.service, "0", "Vitocal300", "Online")
+        device_type = c.asAutoDetectDevice()
+        self.assertEqual("HeatPump", type(device_type).__name__)
+
+    def test_autoDetect_GazBoiler_with_compressors_asHybrid(self):
+        self.service.hasRoles = has_roles(["type:boiler"])
+        self.service.fetch_all_features = Mock(return_value={"data": [
+            {"feature": "heating.burners"},
+            {"feature": "heating.burners.0"},
+            {"feature": "heating.compressors"},
+            {"feature": "heating.compressors.0"},
+        ]})
+        c = PyViCareDeviceConfig(
+            self.service, "0", "Vitodens200", "Online")
+        device_type = c.asAutoDetectDevice()
+        self.assertEqual("Hybrid", type(device_type).__name__)
+
+    def test_autoDetect_feature_fetch_failure_keeps_original(self):
+        self.service.hasRoles = has_roles(["type:heatpump"])
+        self.service.fetch_all_features = Mock(side_effect=Exception("API error"))
+        c = PyViCareDeviceConfig(
+            self.service, "0", "CU401B_S", "Online")
+        device_type = c.asAutoDetectDevice()
+        self.assertEqual("HeatPump", type(device_type).__name__)
+
     def test_getDeviceType_heating(self):
         c = PyViCareDeviceConfig(self.service, "0", "Vitocal", "Online", "heating")
         self.assertEqual(c.getDeviceType(), "heating")

--- a/tests/test_PyViCareDeviceConfig.py
+++ b/tests/test_PyViCareDeviceConfig.py
@@ -214,7 +214,7 @@ class PyViCareDeviceConfigTest(unittest.TestCase):
 
     def test_autoDetect_feature_fetch_failure_keeps_original(self):
         self.service.hasRoles = has_roles(["type:heatpump"])
-        self.service.fetch_all_features = Mock(side_effect=Exception("API error"))
+        self.service.fetch_all_features = Mock(side_effect=OSError("API error"))
         c = PyViCareDeviceConfig(
             self.service, "0", "CU401B_S", "Online")
         device_type = c.asAutoDetectDevice()


### PR DESCRIPTION
## Problem

Hybrid devices like the Vitocaldens 222-F (controller `CU401B_S`) are detected as `HeatPump` because `CU401B` matches the heat pump regex pattern. The `Hybrid` class was never in the auto-detect list — it was only reachable via the manual `heating_type: hybrid` config option in Home Assistant, which was removed in home-assistant/core#165649.

This causes all burner entities to disappear, since `HeatPump` doesn't expose `heating.burners.*` features — only `Hybrid` (which inherits from both `GazBoiler` and `HeatPump`) does.

## Solution

After regex/role matching picks `GazBoiler` or `HeatPump`, the device's API features are fetched and checked. If both `heating.burners` and `heating.compressors` features exist, the device is upgraded to `Hybrid`.

This is a fallback — the existing regex matching is unchanged. If the feature fetch fails, the original detection is silently kept.

## Why not full feature-based detection?

Non-heating device types (ventilation, radiator actuators, room sensors, gateways) don't have obvious feature-prefix signatures, so they still need regex/role matching. This approach is the smallest change that catches all hybrid devices — current and future — without maintaining a model name list.

Fixes home-assistant/core#168288