### PR TITLE
feat: add all_devices property with unfiltered device list

### DIFF
--- a/PyViCare/PyViCare.py
+++ b/PyViCare/PyViCare.py
@@ -46,20 +46,24 @@ class PyViCare:
 
         data = installations['data']
         self.installations = Wrap(data)
-        self.devices = list(self.__extract_devices())
+        self.all_devices = list(self.__extract_all_devices())
+        self.devices = [d for d in self.all_devices
+                        if d.device_type in self.SUPPORTED_DEVICE_TYPES]
 
-    def __extract_devices(self):
+    SUPPORTED_DEVICE_TYPES = [
+        "heating", "zigbee", "vitoconnect", "electricityStorage",
+        "tcu", "ventilation",
+    ]
+
+    def __extract_all_devices(self):
         for installation in self.installations:
             for gateway in installation.gateways:
                 for device in gateway.devices:
-                    if device.deviceType not in ["heating", "zigbee", "vitoconnect", "electricityStorage", "tcu", "ventilation"]:
-                        continue  # we are only interested in heating, photovoltaic, electricityStorage, and ventilation devices
-
                     accessor = ViCareDeviceAccessor(
                         installation.id, gateway.serial, device.id)
                     service = self.__buildService(accessor, device.roles)
 
-                    logger.info("Device found: %s", device.modelId)
+                    logger.info("Device found: %s (type=%s)", device.modelId, device.deviceType)
 
                     yield PyViCareDeviceConfig(service, device.id, device.modelId, device.status, device.deviceType, device.roles)
 


### PR DESCRIPTION
## Summary
- Add `all_devices` property that includes every device from the installation, regardless of `deviceType`
- Keep `devices` filtered to `SUPPORTED_DEVICE_TYPES` (no behavior change for existing consumers)
- Extract supported types as `SUPPORTED_DEVICE_TYPES` class constant

## Motivation
Devices with unknown `deviceType` (e.g. Vitoset Aqua with type `domesticHotWater`) are currently dropped by the filter in `__extract_devices()`. This means they don't appear in HA diagnostics, making it harder to debug and add support for new device types.

With `all_devices`, HA diagnostics can switch to showing all devices while entity setup continues using the safe filtered `devices` list.

## Follow-up
HA Core vicare integration needs a one-line change in diagnostics to use `all_devices` instead of `devices`. That PR will depend on a PyViCare release containing this change.

## Test plan
- All existing tests pass (no behavior change for `devices`)
- `all_devices` is a superset of `devices`