### PR TITLE
fix: catch all exceptions during Zigbee device enrichment

### DIFF
--- a/PyViCare/PyViCare.py
+++ b/PyViCare/PyViCare.py
@@ -8,7 +8,7 @@ from PyViCare.PyViCareDeviceConfig import PyViCareDeviceConfig
 from PyViCare.PyViCareOAuthManager import ViCareOAuthManager
 from PyViCare.PyViCareRoomControl import RoomControl
 from PyViCare.PyViCareService import ViCareDeviceAccessor, ViCareService
-from PyViCare.PyViCareUtils import PyViCareInvalidDataError, PyViCareNotSupportedFeatureError
+from PyViCare.PyViCareUtils import PyViCareInvalidDataError
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -86,7 +86,7 @@ class PyViCare:
             room_control = RoomControl(device_config.service)
             try:
                 actor_map = room_control.buildActorRoomMap()
-            except (KeyError, IndexError, PyViCareNotSupportedFeatureError):
+            except Exception:
                 logger.debug("Could not build actor map for %s", device_config.getModel(), exc_info=True)
                 continue
 

--- a/PyViCare/PyViCare.py
+++ b/PyViCare/PyViCare.py
@@ -86,7 +86,7 @@ class PyViCare:
             room_control = RoomControl(device_config.service)
             try:
                 actor_map = room_control.buildActorRoomMap()
-            except Exception:
+            except Exception:  # pylint: disable=broad-exception-caught
                 logger.debug("Could not build actor map for %s", device_config.getModel(), exc_info=True)
                 continue
 


### PR DESCRIPTION
## Summary
- Broaden exception handling in `__enrichZigbeeDevices()` from specific exceptions to `Exception`
- Fixes crash when a RoomControl device is offline (`PyViCareDeviceCommunicationError: GATEWAY_OFFLINE`)

## Motivation
#743 added Zigbee device enrichment from RoomControl. The enrichment runs during `__loadInstallations()`, so any unhandled exception crashes the entire client initialization. The original `except` only caught `KeyError`, `IndexError`, and `PyViCareNotSupportedFeatureError`, but offline devices throw `PyViCareDeviceCommunicationError`.

Since enrichment is best-effort (errors are logged with traceback, the device is skipped, and initialization continues), catching `Exception` is appropriate here.

## Test plan
- All 733 existing tests pass
- Reported by @CFenner on his setup with an offline RoomControl device