### PR TITLE
chore: add obtain_token_via_basic_auth_pkce migration helper

### DIFF
--- a/PyViCare/PyViCareOAuthManager.py
+++ b/PyViCare/PyViCareOAuthManager.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import pickle
+import warnings
 from contextlib import suppress
 from pickle import UnpicklingError
 
@@ -31,6 +32,12 @@ def obtain_token_via_basic_auth_pkce(
 ) -> dict[str, object]:
     """Obtain an OAuth2 token via PKCE auth-code flow with HTTP Basic auth.
 
+    .. deprecated::
+        One-shot migration helper for Home Assistant's password-to-OAuth2
+        migration (see home-assistant/core#165621). Scheduled for removal
+        once the migration window has closed. New code should use the
+        standard OAuth2 auth-code flow.
+
     Viessmann's authorization endpoint accepts HTTP Basic auth and returns
     the auth code in the redirect Location header (no browser involved).
     Useful for one-shot migration from stored username/password to OAuth2,
@@ -45,6 +52,13 @@ def obtain_token_via_basic_auth_pkce(
     credentials rejected, token exchange failed). Failures are logged at
     WARNING level.
     """
+    warnings.warn(
+        "obtain_token_via_basic_auth_pkce is a one-shot migration helper "
+        "for Home Assistant's password-to-OAuth2 migration and is scheduled "
+        "for removal. New code should use the standard OAuth2 auth-code flow.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     oauth = OAuth2Session(
         client_id,
         redirect_uri=REDIRECT_URI,

--- a/PyViCare/PyViCareOAuthManager.py
+++ b/PyViCare/PyViCareOAuthManager.py
@@ -6,11 +6,13 @@ from pickle import UnpicklingError
 
 import requests
 from authlib.common.security import generate_token
+from authlib.integrations.base_client.errors import OAuthError
 from authlib.integrations.requests_client import OAuth2Session
 
 from PyViCare.PyViCareAbstractOAuthManager import (
     AUTHORIZE_URL,
     SCOPE_IOT,
+    SCOPE_OFFLINE_ACCESS,
     SCOPE_USER,
     TOKEN_URL,
     AbstractViCareOAuthManager,
@@ -22,6 +24,66 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 REDIRECT_URI = "vicare://oauth-callback/everest"
+
+
+def obtain_token_via_basic_auth_pkce(
+    client_id: str, username: str, password: str
+) -> dict[str, object]:
+    """Obtain an OAuth2 token via PKCE auth-code flow with HTTP Basic auth.
+
+    Viessmann's authorization endpoint accepts HTTP Basic auth and returns
+    the auth code in the redirect Location header (no browser involved).
+    Useful for one-shot migration from stored username/password to OAuth2,
+    so users don't need to re-authenticate interactively.
+
+    Requests scopes ``IoT`` and ``offline_access`` (sufficient for all
+    PyViCare API endpoints; ``offline_access`` is required to receive a
+    refresh token).
+
+    Returns the token dict (access_token, refresh_token, expires_at, etc.)
+    on success, or an empty dict on any failure (auth server unreachable,
+    credentials rejected, token exchange failed). Failures are logged at
+    WARNING level.
+    """
+    oauth = OAuth2Session(
+        client_id,
+        redirect_uri=REDIRECT_URI,
+        scope=[SCOPE_IOT, SCOPE_OFFLINE_ACCESS],
+        code_challenge_method="S256",
+    )
+    code_verifier = generate_token(48)
+    auth_url, _ = oauth.create_authorization_url(
+        AUTHORIZE_URL, code_verifier=code_verifier
+    )
+
+    try:
+        response = requests.post(
+            auth_url,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            auth=(username, password),
+            allow_redirects=False,
+            timeout=15,
+        )
+    except requests.RequestException:
+        logger.warning("Failed to reach Viessmann auth server")
+        return {}
+
+    if response.status_code != 302 or "Location" not in response.headers:
+        logger.warning("Basic-auth authorization failed")
+        return {}
+
+    try:
+        oauth.fetch_token(
+            TOKEN_URL,
+            authorization_response=response.headers["Location"],
+            code_verifier=code_verifier,
+            timeout=15,
+        )
+    except (requests.RequestException, OAuthError, KeyError, ValueError):
+        logger.warning("Token exchange failed")
+        return {}
+
+    return dict(oauth.token)
 
 
 class ViCareOAuthManager(AbstractViCareOAuthManager):

--- a/tests/test_ViCareOAuthManager.py
+++ b/tests/test_ViCareOAuthManager.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import Mock, patch
 
+import pytest
 import requests
 from authlib.integrations.base_client.errors import OAuthError
 
@@ -151,6 +152,9 @@ class PyViCareServiceTest(unittest.TestCase):
         self.oauth_mock.renewToken.assert_called_once()
 
 
+@pytest.mark.filterwarnings(
+    "ignore:obtain_token_via_basic_auth_pkce:DeprecationWarning"
+)
 class ObtainTokenViaBasicAuthPkceTest(unittest.TestCase):
 
     @patch('PyViCare.PyViCareOAuthManager.OAuth2Session')

--- a/tests/test_ViCareOAuthManager.py
+++ b/tests/test_ViCareOAuthManager.py
@@ -1,7 +1,11 @@
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
-from PyViCare.PyViCareOAuthManager import AbstractViCareOAuthManager
+import requests
+from authlib.integrations.base_client.errors import OAuthError
+
+from PyViCare.PyViCareOAuthManager import (AbstractViCareOAuthManager,
+                                           obtain_token_via_basic_auth_pkce)
 from PyViCare.PyViCareUtils import (PyViCareCommandError,
                                     PyViCareDeviceCommunicationError,
                                     PyViCareInternalServerError,
@@ -145,3 +149,68 @@ class PyViCareServiceTest(unittest.TestCase):
         ]
         self.manager.post("/", "some")
         self.oauth_mock.renewToken.assert_called_once()
+
+
+class ObtainTokenViaBasicAuthPkceTest(unittest.TestCase):
+
+    @patch('PyViCare.PyViCareOAuthManager.OAuth2Session')
+    @patch('PyViCare.PyViCareOAuthManager.requests.post')
+    def test_returns_token_on_success(self, mock_post, mock_oauth_cls):
+        mock_oauth = Mock()
+        mock_oauth.create_authorization_url.return_value = ('http://auth', 'state')
+        mock_oauth.token = {'access_token': 'a', 'refresh_token': 'r'}
+        mock_oauth_cls.return_value = mock_oauth
+
+        mock_post.return_value = Mock(
+            status_code=302,
+            headers={'Location': 'vicare://oauth-callback/everest?code=xyz'},
+        )
+
+        token = obtain_token_via_basic_auth_pkce('client', 'user', 'pass')
+        self.assertEqual(token, {'access_token': 'a', 'refresh_token': 'r'})
+        mock_oauth.fetch_token.assert_called_once()
+
+    @patch('PyViCare.PyViCareOAuthManager.requests.post')
+    def test_returns_empty_on_request_exception(self, mock_post):
+        mock_post.side_effect = requests.RequestException("network down")
+        self.assertEqual(
+            obtain_token_via_basic_auth_pkce('client', 'user', 'pass'), {})
+
+    @patch('PyViCare.PyViCareOAuthManager.OAuth2Session')
+    @patch('PyViCare.PyViCareOAuthManager.requests.post')
+    def test_returns_empty_on_non_redirect_response(self, mock_post, mock_oauth_cls):
+        mock_oauth_cls.return_value.create_authorization_url.return_value = (
+            'http://auth', 'state')
+        mock_post.return_value = Mock(status_code=401, headers={})
+        self.assertEqual(
+            obtain_token_via_basic_auth_pkce('client', 'user', 'pass'), {})
+
+    @patch('PyViCare.PyViCareOAuthManager.OAuth2Session')
+    @patch('PyViCare.PyViCareOAuthManager.requests.post')
+    def test_returns_empty_on_token_exchange_failure(self, mock_post, mock_oauth_cls):
+        mock_oauth = Mock()
+        mock_oauth.create_authorization_url.return_value = ('http://auth', 'state')
+        mock_oauth.fetch_token.side_effect = requests.RequestException("fail")
+        mock_oauth_cls.return_value = mock_oauth
+
+        mock_post.return_value = Mock(
+            status_code=302,
+            headers={'Location': 'vicare://oauth-callback/everest?code=xyz'},
+        )
+        self.assertEqual(
+            obtain_token_via_basic_auth_pkce('client', 'user', 'pass'), {})
+
+    @patch('PyViCare.PyViCareOAuthManager.OAuth2Session')
+    @patch('PyViCare.PyViCareOAuthManager.requests.post')
+    def test_returns_empty_on_authlib_oauth_error(self, mock_post, mock_oauth_cls):
+        mock_oauth = Mock()
+        mock_oauth.create_authorization_url.return_value = ('http://auth', 'state')
+        mock_oauth.fetch_token.side_effect = OAuthError("invalid_grant")
+        mock_oauth_cls.return_value = mock_oauth
+
+        mock_post.return_value = Mock(
+            status_code=302,
+            headers={'Location': 'vicare://oauth-callback/everest?code=xyz'},
+        )
+        self.assertEqual(
+            obtain_token_via_basic_auth_pkce('client', 'user', 'pass'), {})


### PR DESCRIPTION
Adds a public helper that exchanges stored username/password credentials for an OAuth2 token via Viessmann's PKCE auth-code flow with HTTP Basic auth. The authorization endpoint accepts Basic auth and returns the auth code in the redirect `Location` header, so no browser is involved.

## Motivation

The HA Core ViCare integration is migrating from username/password to OAuth2 with Application Credentials (home-assistant/core#165621). To avoid forcing every existing user to re-authenticate manually, a one-shot helper exchanges their stored credentials for a refresh token in the background.

Reviewer @joostlek pointed out that this is API code (Viessmann-specific protocol logic) and belongs in PyViCare, not in the integration. Moving it here.

## API

```python
from PyViCare.PyViCareOAuthManager import obtain_token_via_basic_auth_pkce

token = obtain_token_via_basic_auth_pkce(client_id, username, password)
# {} on any failure, otherwise dict with access_token, refresh_token, expires_at, ...
```

Failures (auth server unreachable, credentials rejected, token exchange failed) are logged at WARNING and return `{}`. Caller can detect the migration failure and prompt for reauth.

## Tests

Four new tests cover: success path, network failure during authorization, non-redirect response (bad credentials), and token exchange failure. All 737 PyViCare tests pass.

## Followup

Once this is merged and released, home-assistant/core#165621 will bump the PyViCare dependency and replace the integration-local copy with an import.