### PR TITLE
fix: catch PyViCareNotPaidForError in auto-detection and diagnostics

### DIFF
--- a/PyViCare/PyViCareDeviceConfig.py
+++ b/PyViCare/PyViCareDeviceConfig.py
@@ -16,6 +16,7 @@ from PyViCare.PyViCareRoomSensor import RoomSensor
 from PyViCare.PyViCareRepeater import Repeater
 from PyViCare.PyViCareElectricalEnergySystem import ElectricalEnergySystem
 from PyViCare.PyViCareGateway import Gateway
+from PyViCare.PyViCareUtils import PyViCareNotPaidForError
 from PyViCare.PyViCareVentilationDevice import VentilationDevice
 
 logger = logging.getLogger(__name__)
@@ -148,6 +149,14 @@ class PyViCareDeviceConfig:
             has_burners = any(f.startswith("heating.burners") for f in feature_names)
             has_compressors = any(f.startswith("heating.compressors") for f in feature_names)
             return has_burners and has_compressors
+        except PyViCareNotPaidForError:
+            # Account lacks the paid feature package, so feature listing is
+            # unavailable. Treat as non-hybrid and let downstream feature
+            # access fall back to PyViCareNotSupportedFeatureError via the
+            # cached service. Without this, auto-detection crashes the
+            # integration setup before any device is created.
+            logger.debug("PACKAGE_NOT_PAID_FOR while detecting hybrid for %s, treating as non-hybrid", self.device_model)
+            return False
         except (KeyError, TypeError, AttributeError, OSError):
             logger.debug("Could not fetch features for hybrid detection of %s", self.device_model)
             return False
@@ -156,7 +165,6 @@ class PyViCareDeviceConfig:
         return self.service.fetch_all_features()
 
     def dump_secure(self, flat=False):
-        raw_data = self.get_raw_json()
         device_info = {
             "id": self.device_id,
             "modelId": self.device_model,
@@ -164,9 +172,20 @@ class PyViCareDeviceConfig:
             "status": self.status,
             "roles": self.roles
         }
+        try:
+            raw_data = self.get_raw_json()
+            data = raw_data['data']
+        except PyViCareNotPaidForError:
+            # Feature listing requires a paid package the account does not
+            # have. Emit a placeholder so diagnostics still produce a usable
+            # dump (device metadata plus an unavailable-reason marker)
+            # rather than crashing the diagnostics endpoint.
+            logger.debug("PACKAGE_NOT_PAID_FOR while dumping features for %s", self.device_model)
+            data = []
+            device_info["dataUnavailableReason"] = "PACKAGE_NOT_PAID_FOR"
         output = {
             "device": device_info,
-            "data": raw_data['data']
+            "data": data
         }
 
         if flat:

--- a/tests/test_PyViCareDeviceConfig.py
+++ b/tests/test_PyViCareDeviceConfig.py
@@ -1,8 +1,10 @@
+import json
 import unittest
 from unittest.mock import Mock
 
 from PyViCare.PyViCareDeviceConfig import PyViCareDeviceConfig
 from PyViCare.PyViCareService import hasRoles
+from PyViCare.PyViCareUtils import PyViCareNotPaidForError
 
 
 def has_roles(roles):
@@ -235,6 +237,29 @@ class PyViCareDeviceConfigTest(unittest.TestCase):
             self.service, "0", "CU401B_S", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("HeatPump", type(device_type).__name__)
+
+    def test_autoDetect_NotPaidFor_keeps_original(self):
+        self.service.hasRoles = has_roles(["type:heatpump"])
+        self.service.fetch_all_features = Mock(
+            side_effect=PyViCareNotPaidForError({"errorType": "PACKAGE_NOT_PAID_FOR"}))
+        c = PyViCareDeviceConfig(
+            self.service, "0", "CU401B_S", "Online")
+        device_type = c.asAutoDetectDevice()
+        # Without the fix, asAutoDetectDevice would propagate the exception
+        # and crash integration setup. With the fix, hybrid detection falls
+        # back to non-hybrid and the device is created as HeatPump.
+        self.assertEqual("HeatPump", type(device_type).__name__)
+
+    def test_dump_secure_NotPaidFor_emits_placeholder(self):
+        self.service.fetch_all_features = Mock(
+            side_effect=PyViCareNotPaidForError({"errorType": "PACKAGE_NOT_PAID_FOR"}))
+        c = PyViCareDeviceConfig(
+            self.service, "0", "CU401B_S", "Online")
+        dump = json.loads(c.dump_secure())
+        # Diagnostics should produce a usable dump rather than crashing
+        # when the account lacks the paid feature package.
+        self.assertEqual(dump["device"]["dataUnavailableReason"], "PACKAGE_NOT_PAID_FOR")
+        self.assertEqual(dump["data"], [])
 
     def test_getDeviceType_heating(self):
         c = PyViCareDeviceConfig(self.service, "0", "Vitocal", "Online", "heating")


### PR DESCRIPTION
Closes the integration-setup crash reported in home-assistant/core#167367.

## Problem

PR #737 introduced `PyViCareNotPaidForError` and made the cached service handle it gracefully, but two paths still propagate the exception unhandled:

1. **`_isHybridByFeatures()`** calls `fetch_all_features()` and catches only `KeyError/TypeError/AttributeError/OSError`. For GazBoiler and HeatPump devices the hybrid detection runs during `asAutoDetectDevice()`, so the exception crashes integration setup before any device is created. This matches the stacktrace reported by @drveni on home-assistant/core#167367 ending at `__handle_not_paid_for`.
2. **`dump_secure()` / `get_raw_json()`** have no exception handling at all, so the diagnostics endpoint crashes for the same users.

## Fix

- `_isHybridByFeatures()`: catch `PyViCareNotPaidForError` and fall back to non-hybrid. Downstream feature access still surfaces paid-only features as `PyViCareNotSupportedFeatureError` through the cached service.
- `dump_secure()`: catch `PyViCareNotPaidForError` and emit a placeholder dump with `device.dataUnavailableReason = "PACKAGE_NOT_PAID_FOR"` so diagnostics produce a usable file instead of crashing.

## Tests

- `test_autoDetect_NotPaidFor_keeps_original`: Vitocal auto-detects as `HeatPump` despite the API raising `PyViCareNotPaidForError`.
- `test_dump_secure_NotPaidFor_emits_placeholder`: diagnostics dump contains the `dataUnavailableReason` marker and an empty `data` list.

All 727 tests pass.