### PR TITLE
chore: deprecate ventilation.operating.programs.* methods

### DIFF
--- a/PyViCare/PyViCareVentilationDevice.py
+++ b/PyViCare/PyViCareVentilationDevice.py
@@ -119,6 +119,13 @@ class VentilationDevice(Device):
         self.setProperty(f"ventilation.quickmodes.{quickmode}", "deactivate", {})
 
     @handleNotSupported
+    @deprecated(
+        reason=(
+            "ventilation.operating.programs.* was deprecated by Viessmann on 2024-09-15. "
+            "Use getVentilationModes() instead."
+        ),
+        version="2.61.0",
+    )
     def getVentilationPrograms(self):
         available_programs = []
         for program in ['basic', 'intensive', 'reduced', 'standard', 'standby', 'holidayAtHome', 'permanent']:
@@ -133,6 +140,14 @@ class VentilationDevice(Device):
         return self.getVentilationPrograms()
 
     @handleNotSupported
+    @deprecated(
+        reason=(
+            "ventilation.operating.programs.* was deprecated by Viessmann on 2024-09-15. "
+            "Use getVentilationLevel() to read the current fan level "
+            "(from ventilation.operating.state) instead."
+        ),
+        version="2.61.0",
+    )
     def getActiveVentilationProgram(self):
         return self.getProperty("ventilation.operating.programs.active")["properties"]["value"]["value"]
 
@@ -141,6 +156,13 @@ class VentilationDevice(Device):
     def getActiveProgram(self):
         return self.getActiveVentilationProgram()
 
+    @deprecated(
+        reason=(
+            "ventilation.operating.programs.* was deprecated by Viessmann on 2024-09-15. "
+            "Use activateVentilationMode() and setVentilationLevel() instead."
+        ),
+        version="2.61.0",
+    )
     def activateVentilationProgram(self, program):
         """ Activate a program
             NOTE
@@ -172,6 +194,13 @@ class VentilationDevice(Device):
         """
         return self.activateVentilationProgram(program)
 
+    @deprecated(
+        reason=(
+            "ventilation.operating.programs.* was deprecated by Viessmann on 2024-09-15. "
+            "Use activateVentilationMode() with a different mode instead."
+        ),
+        version="2.61.0",
+    )
     def deactivateVentilationProgram(self, program):
         """ Deactivate a program
         Parameters

--- a/tests/deprecated_features.json
+++ b/tests/deprecated_features.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "description": "Known deprecated Viessmann API features, merged from test data and device dumps.",
-    "updated": "2026-04-28",
+    "updated": "2026-06-10",
     "feature_count": 107
   },
   "features": {
@@ -225,7 +225,8 @@
         "Vitocal222S.json",
         "Vitocal250A.json",
         "Vitopure350.json",
-        "Vitocal252A.json"
+        "Vitocal252A.json",
+        "VitosetAqua.json"
       ]
     },
     "heating.dhw.comfort": {

--- a/tests/test_VitoairFs300E.py
+++ b/tests/test_VitoairFs300E.py
@@ -22,7 +22,8 @@ class VitoairFs300(unittest.TestCase):
         self.assertEqual(self.device.getActiveVentilationMode(), "sensorOverride")
 
     def test_getActiveVentilationProgram(self):
-        self.assertEqual(self.device.getActiveVentilationProgram(), "levelTwo")
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(self.device.getActiveVentilationProgram(), "levelTwo")
 
     def test_getVentilationModes(self):
         expected_modes = ['permanent', 'ventilation', 'sensorOverride', 'sensorDriven']
@@ -30,7 +31,8 @@ class VitoairFs300(unittest.TestCase):
 
     def test_getVentilationPrograms(self):
         expected_programs = []
-        self.assertListEqual(self.device.getVentilationPrograms(), expected_programs)
+        with self.assertWarns(DeprecationWarning):
+            self.assertListEqual(self.device.getVentilationPrograms(), expected_programs)
 
     def test_getVentilationLevels(self):
         expected_levels = ['levelOne', 'levelTwo', 'levelThree', 'levelFour']

--- a/tests/test_Vitopure350.py
+++ b/tests/test_Vitopure350.py
@@ -17,11 +17,13 @@ class Vitopure350(unittest.TestCase):
         self.assertListEqual(expected_modes, self.device.getVentilationModes())
 
     def test_getActiveVentilationProgram(self):
-        self.assertEqual("levelTwo", self.device.getActiveVentilationProgram())
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual("levelTwo", self.device.getActiveVentilationProgram())
 
     def test_getVentilationPrograms(self):
         expected_programs = []
-        self.assertListEqual(expected_programs, self.device.getVentilationPrograms())
+        with self.assertWarns(DeprecationWarning):
+            self.assertListEqual(expected_programs, self.device.getVentilationPrograms())
 
     def test_getVentilationLevels(self):
         expected_levels = ['levelOne', 'levelTwo', 'levelThree', 'levelFour']


### PR DESCRIPTION
## What

Marks the four `ventilation.operating.programs.*` methods on `VentilationDevice` as `@deprecated`:

- `getVentilationPrograms()`
- `getActiveVentilationProgram()`
- `activateVentilationProgram(program)`
- `deactivateVentilationProgram(program)`

Each deprecation message names the recommended replacement so library users get a clear migration path through the warning text.

## Why

Viessmann marked all `ventilation.operating.programs.*` features as deprecated on 2024-09-15 (see #708). The replacement API (`ventilation.operating.modes.*` + `setVentilationLevel`) has been in PyViCare since 2.40.0.

A recent debug capture from a Vitovent 200-W on a Vitocal 200-S gateway (IoT scope, HA Core 2026.6.2) confirms the deprecated path is dead on that device family: `ventilation.operating.modes.permanent` and `setLevel` are not exposed, `ventilation.levels.level*` features are present but `isEnabled: false` with no commands, and only `ventilation.operating.programs.active` survives as a read-only value. The `modes.*` API is fully wired up. See https://github.com/openviess/PyViCare/issues/708#issuecomment-4673362735 for the analysis and the attached log. Continuing to wrap the deprecated endpoints in public methods misleads downstream users about which API to write against.

This PR does not yet remove the methods. Removal should follow at least one release cycle so downstream projects can react to the warning.

## Tests

- Existing tests for `getActiveVentilationProgram` / `getVentilationPrograms` on `Vitopure350` and `VitoairFs300E` now wrap the call in `assertWarns(DeprecationWarning)`, so the deprecation is locked in by the suite.
- Full suite: 729 passed, 30 skipped, ruff clean.

Fixes #708