### PR TITLE
refactor: move accessor from service to device

### DIFF
--- a/PyViCare/PyViCare.py
+++ b/PyViCare/PyViCare.py
@@ -32,10 +32,10 @@ class PyViCare:
     def initWithBrowserOAuth(self, client_id: str, token_file: str) -> None:
         self.initWithExternalOAuth(ViCareBrowserOAuthManager(client_id, token_file))
 
-    def __buildService(self, accessor, roles):
+    def __buildService(self, roles):
         if self.cacheDuration > 0:
-            return ViCareCachedService(self.oauth_manager, accessor, roles, self.cacheDuration)
-        return ViCareService(self.oauth_manager, accessor, roles)
+            return ViCareCachedService(self.oauth_manager, roles, self.cacheDuration)
+        return ViCareService(self.oauth_manager, roles)
 
     def __loadInstallations(self):
         installations = self.oauth_manager.get(
@@ -61,11 +61,11 @@ class PyViCare:
                 for device in gateway.devices:
                     accessor = ViCareDeviceAccessor(
                         installation.id, gateway.serial, device.id)
-                    service = self.__buildService(accessor, device.roles)
+                    service = self.__buildService(device.roles)
 
                     logger.info("Device found: %s (type=%s)", device.modelId, device.deviceType)
 
-                    yield PyViCareDeviceConfig(service, device.id, device.modelId, device.status, device.deviceType, device.roles)
+                    yield PyViCareDeviceConfig(accessor, service, device.modelId, device.status, device.deviceType, device.roles)
 
 
 class DictWrap(object):

--- a/PyViCare/PyViCareCachedService.py
+++ b/PyViCare/PyViCareCachedService.py
@@ -1,6 +1,7 @@
 import logging
 import threading
-from typing import Any, List
+from datetime import datetime
+from typing import Any, List, Optional
 
 from PyViCare.PyViCareAbstractOAuthManager import AbstractViCareOAuthManager
 from PyViCare.PyViCareService import (ViCareDeviceAccessor, ViCareService,
@@ -18,24 +19,24 @@ logger.addHandler(logging.NullHandler())
 
 class ViCareCachedService(ViCareService):
 
-    def __init__(self, oauth_manager: AbstractViCareOAuthManager, accessor: ViCareDeviceAccessor, roles: List[str], cacheDuration: int) -> None:
-        ViCareService.__init__(self, oauth_manager, accessor, roles)
+    def __init__(self, oauth_manager: AbstractViCareOAuthManager, roles: List[str], cacheDuration: int) -> None:
+        ViCareService.__init__(self, oauth_manager, roles)
         self.__cacheDuration = cacheDuration
-        self.__cache = None
-        self.__cacheTime = None
+        self.__cache: Optional[dict] = None
+        self.__cacheTime: Optional[datetime] = None
         self.__lock = threading.Lock()
 
-    def getProperty(self, property_name: str) -> Any:
-        data = self.__get_or_update_cache()
+    def getProperty(self, accessor: ViCareDeviceAccessor, property_name: str) -> Any:
+        data = self.__get_or_update_cache(accessor)
         entities = data["data"]
         return readFeature(entities, property_name)
 
-    def setProperty(self, property_name, action, data):
-        response = super().setProperty(property_name, action, data)
+    def setProperty(self, accessor: ViCareDeviceAccessor, property_name: str, action: str, data: Any) -> Any:
+        response = super().setProperty(accessor, property_name, action, data)
         self.clear_cache()
         return response
 
-    def __get_or_update_cache(self):
+    def __get_or_update_cache(self, accessor: ViCareDeviceAccessor):
         with self.__lock:
             if self.is_cache_invalid():
                 # we always set the cache time before we fetch the data
@@ -45,7 +46,7 @@ class ViCareCachedService(ViCareService):
                 self.__cacheTime = ViCareTimer().now()
 
                 try:
-                    data = self.fetch_all_features()
+                    data = self.fetch_all_features(accessor)
                 except PyViCareNotPaidForError as e:
                     logger.error("Viessmann API denied access (PACKAGE_NOT_PAID_FOR). Features unavailable: %s", e)
                     if self.__cache is not None:

--- a/PyViCare/PyViCareDevice.py
+++ b/PyViCare/PyViCareDevice.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from PyViCare.PyViCareService import ViCareService
+from PyViCare.PyViCareService import ViCareDeviceAccessor, ViCareService
 from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError, handleAPICommandErrors, handleNotSupported
 
 
@@ -11,14 +11,15 @@ class Device:
     Note that currently, a new token is generated for each run.
     """
 
-    def __init__(self, service: ViCareService) -> None:
+    def __init__(self, accessor: ViCareDeviceAccessor, service: ViCareService) -> None:
+        self.accessor = accessor
         self.service = service
 
     def getProperty(self, property_name: str) -> Any:
-        return self.service.getProperty(property_name)
+        return self.service.getProperty(self.accessor, property_name)
 
     def setProperty(self, property_name: str, action: str, data: Any) -> Any:
-        return self.service.setProperty(property_name, action, data)
+        return self.service.setProperty(self.accessor, property_name, action, data)
 
     @handleNotSupported
     def getSerial(self):

--- a/PyViCare/PyViCareDeviceConfig.py
+++ b/PyViCare/PyViCareDeviceConfig.py
@@ -16,6 +16,7 @@ from PyViCare.PyViCareRoomSensor import RoomSensor
 from PyViCare.PyViCareRepeater import Repeater
 from PyViCare.PyViCareElectricalEnergySystem import ElectricalEnergySystem
 from PyViCare.PyViCareGateway import Gateway
+from PyViCare.PyViCareService import ViCareDeviceAccessor, ViCareService
 from PyViCare.PyViCareUtils import PyViCareNotPaidForError
 from PyViCare.PyViCareVentilationDevice import VentilationDevice
 
@@ -25,64 +26,65 @@ logger.addHandler(logging.NullHandler())
 
 class PyViCareDeviceConfig:
     # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-instance-attributes
-    def __init__(self, service, device_id, device_model, status, device_type=None, roles=None):
+    def __init__(self, accessor: ViCareDeviceAccessor, service: ViCareService, device_model, status, device_type=None, roles=None):
+        self.accessor = accessor
         self.service = service
-        self.device_id = device_id
+        self.device_id = accessor.device_id
         self.device_model = device_model
         self.status = status
         self.device_type = device_type
         self.roles = roles if roles is not None else []
 
     def asGeneric(self):
-        return HeatingDevice(self.service)
+        return HeatingDevice(self.accessor, self.service)
 
     def asGazBoiler(self):
-        return GazBoiler(self.service)
+        return GazBoiler(self.accessor, self.service)
 
     def asFuelCell(self):
-        return FuelCell(self.service)
+        return FuelCell(self.accessor, self.service)
 
     def asHeatPump(self):
-        return HeatPump(self.service)
+        return HeatPump(self.accessor, self.service)
 
     def asOilBoiler(self):
-        return OilBoiler(self.service)
+        return OilBoiler(self.accessor, self.service)
 
     def asPelletsBoiler(self):
-        return PelletsBoiler(self.service)
+        return PelletsBoiler(self.accessor, self.service)
 
     def asHybridDevice(self):
-        return Hybrid(self.service)
+        return Hybrid(self.accessor, self.service)
 
     def asRadiatorActuator(self):
-        return RadiatorActuator(self.service)
+        return RadiatorActuator(self.accessor, self.service)
 
     def asFloorHeating(self):
-        return FloorHeating(self.service)
+        return FloorHeating(self.accessor, self.service)
 
     def asFloorHeatingChannel(self):
-        return FloorHeatingChannel(self.service)
+        return FloorHeatingChannel(self.accessor, self.service)
 
     def asRoomSensor(self):
-        return RoomSensor(self.service)
+        return RoomSensor(self.accessor, self.service)
 
     def asRoomControl(self):
-        return RoomControl(self.service)
+        return RoomControl(self.accessor, self.service)
 
     def asRepeater(self):
-        return Repeater(self.service)
+        return Repeater(self.accessor, self.service)
 
     def asElectricalEnergySystem(self):
-        return ElectricalEnergySystem(self.service)
+        return ElectricalEnergySystem(self.accessor, self.service)
 
     def asGateway(self):
-        return Gateway(self.service)
+        return Gateway(self.accessor, self.service)
 
     def asVentilation(self):
-        return VentilationDevice(self.service)
+        return VentilationDevice(self.accessor, self.service)
 
     def getConfig(self):
-        return self.service.accessor
+        return self.accessor
 
     def getId(self):
         return self.device_id
@@ -144,7 +146,7 @@ class PyViCareDeviceConfig:
     def _isHybridByFeatures(self):
         """Check API features to detect hybrid devices (both burners and compressors)."""
         try:
-            features = self.service.fetch_all_features()
+            features = self.service.fetch_all_features(self.accessor)
             feature_names = [f["feature"] for f in features.get("data", [])]
             has_burners = any(f.startswith("heating.burners") for f in feature_names)
             has_compressors = any(f.startswith("heating.compressors") for f in feature_names)
@@ -162,7 +164,7 @@ class PyViCareDeviceConfig:
             return False
 
     def get_raw_json(self):
-        return self.service.fetch_all_features()
+        return self.service.fetch_all_features(self.accessor)
 
     def dump_secure(self, flat=False):
         device_info = {

--- a/PyViCare/PyViCareFuelCell.py
+++ b/PyViCare/PyViCareFuelCell.py
@@ -17,7 +17,7 @@ class FuelCell(HeatingDevice):
 
     @handleNotSupported
     def getAvailableBurners(self):
-        return get_available_burners(self.service)
+        return get_available_burners(self)
 
     @handleNotSupported
     def getReturnTemperature(self):

--- a/PyViCare/PyViCareGazBoiler.py
+++ b/PyViCare/PyViCareGazBoiler.py
@@ -17,7 +17,7 @@ class GazBoiler(HeatingDevice):
 
     @handleNotSupported
     def getAvailableBurners(self):
-        return get_available_burners(self.service)
+        return get_available_burners(self)
 
     @handleNotSupported
     def getGasConsumptionHeatingUnit(self):

--- a/PyViCare/PyViCareHeatingDevice.py
+++ b/PyViCare/PyViCareHeatingDevice.py
@@ -17,13 +17,13 @@ def all_set(_list: List[Any]) -> bool:
     return all(v is not None for v in _list)
 
 
-def get_available_burners(service):
+def get_available_burners(device):
     # workaround starting from 25.01.2022
     # see: https://github.com/somm15/PyViCare/issues/243
     available_burners = []
     for burner in ['0', '1', '2', '3', '4', '5']:
         with suppress(PyViCareNotSupportedFeatureError):
-            if service.getProperty(f"heating.burners.{burner}") is not None:
+            if device.getProperty(f"heating.burners.{burner}") is not None:
                 available_burners.append(burner)
 
     return available_burners
@@ -701,8 +701,8 @@ class HeatingCircuit(HeatingDeviceWithComponent):
 
     @handleAPICommandErrors
     def setHeatingSchedule(self, schedule: dict) -> None:
-        self.service.setProperty(f"heating.circuits.{self.circuit}.heating.schedule",
-                                 "setSchedule", {'newSchedule': schedule})
+        self.device.setProperty(f"heating.circuits.{self.circuit}.heating.schedule",
+                                "setSchedule", {'newSchedule': schedule})
 
     @handleNotSupported
     def getHeatingScheduleModes(self) -> list:  # type: ignore[type-arg]

--- a/PyViCare/PyViCareOilBoiler.py
+++ b/PyViCare/PyViCareOilBoiler.py
@@ -17,7 +17,7 @@ class OilBoiler(HeatingDevice):
 
     @handleNotSupported
     def getAvailableBurners(self):
-        return get_available_burners(self.service)
+        return get_available_burners(self)
 
     @handleNotSupported
     def getBoilerTemperature(self):

--- a/PyViCare/PyViCarePelletsBoiler.py
+++ b/PyViCare/PyViCarePelletsBoiler.py
@@ -16,7 +16,7 @@ class PelletsBoiler(HeatingDevice):
 
     @handleNotSupported
     def getAvailableBurners(self):
-        return get_available_burners(self.service)
+        return get_available_burners(self)
 
     @handleNotSupported
     def getBoilerTemperature(self):

--- a/PyViCare/PyViCareRoomControl.py
+++ b/PyViCare/PyViCareRoomControl.py
@@ -16,83 +16,83 @@ class RoomControl(Device):
 
     @handleNotSupported
     def getAvailableRooms(self) -> list[str]:
-        return cast(list[str], self.service.getProperty("rooms")["properties"]["enabled"]["value"])
+        return cast(list[str], self.getProperty("rooms")["properties"]["enabled"]["value"])
 
     def getRoomActorIds(self, room_id: str) -> list[str]:
         """Return list of actor device IDs for a room."""
         try:
-            actors = self.service.getProperty(f"rooms.{room_id}")["properties"]["actors"]["value"]
+            actors = self.getProperty(f"rooms.{room_id}")["properties"]["actors"]["value"]
             return [str(a["deviceId"]) for a in actors]
         except (PyViCareNotSupportedFeatureError, KeyError):
             return []
 
     def getRoomName(self, room_id: str) -> str | None:
         try:
-            return str(self.service.getProperty(f"rooms.{room_id}")["properties"]["name"]["value"])
+            return str(self.getProperty(f"rooms.{room_id}")["properties"]["name"]["value"])
         except (PyViCareNotSupportedFeatureError, KeyError):
             return None
 
     def getRoomType(self, room_id: str) -> str | None:
         try:
-            return str(self.service.getProperty(f"rooms.{room_id}")["properties"]["type"]["value"])
+            return str(self.getProperty(f"rooms.{room_id}")["properties"]["type"]["value"])
         except (PyViCareNotSupportedFeatureError, KeyError):
             return None
 
     # --- Sensors ---
 
     def getRoomTemperature(self, room_id: str) -> float:
-        return float(self.service.getProperty(f"rooms.{room_id}.sensors.temperature")["properties"]["value"]["value"])
+        return float(self.getProperty(f"rooms.{room_id}.sensors.temperature")["properties"]["value"]["value"])
 
     def getRoomHumidity(self, room_id: str) -> float:
-        return float(self.service.getProperty(f"rooms.{room_id}.sensors.humidity")["properties"]["value"]["value"])
+        return float(self.getProperty(f"rooms.{room_id}.sensors.humidity")["properties"]["value"]["value"])
 
     def getRoomCO2(self, room_id: str) -> int:
-        return int(self.service.getProperty(f"rooms.{room_id}.sensors.co2")["properties"]["value"]["value"])
+        return int(self.getProperty(f"rooms.{room_id}.sensors.co2")["properties"]["value"]["value"])
 
     def getRoomCondensationRisk(self, room_id: str) -> bool:
-        return bool(self.service.getProperty(f"rooms.{room_id}.condensationRisk")["properties"]["value"]["value"])
+        return bool(self.getProperty(f"rooms.{room_id}.condensationRisk")["properties"]["value"]["value"])
 
     # --- Operating state ---
 
     def getRoomOperatingStateLevel(self, room_id: str) -> str:
-        return str(self.service.getProperty(f"rooms.{room_id}.operating.state")["properties"]["level"]["value"])
+        return str(self.getProperty(f"rooms.{room_id}.operating.state")["properties"]["level"]["value"])
 
     def getRoomOperatingStateDemand(self, room_id: str) -> str:
-        return str(self.service.getProperty(f"rooms.{room_id}.operating.state")["properties"]["demand"]["value"])
+        return str(self.getProperty(f"rooms.{room_id}.operating.state")["properties"]["demand"]["value"])
 
     def getRoomOperatingStateReason(self, room_id: str) -> str:
-        return str(self.service.getProperty(f"rooms.{room_id}.operating.state")["properties"]["reason"]["value"])
+        return str(self.getProperty(f"rooms.{room_id}.operating.state")["properties"]["reason"]["value"])
 
     # --- Heating programs ---
 
     def getRoomNormalHeatingTemperature(self, room_id: str) -> float:
-        return float(self.service.getProperty(f"rooms.{room_id}.operating.programs.normalHeating")["properties"]["temperature"]["value"])
+        return float(self.getProperty(f"rooms.{room_id}.operating.programs.normalHeating")["properties"]["temperature"]["value"])
 
     @handleAPICommandErrors
     def setRoomNormalHeatingTemperature(self, room_id: str, temperature: float) -> None:
-        self.service.setProperty(f"rooms.{room_id}.operating.programs.normalHeating", "setTemperature",
+        self.setProperty(f"rooms.{room_id}.operating.programs.normalHeating", "setTemperature",
                                  {"targetTemperature": temperature})
 
     def getRoomReducedHeatingTemperature(self, room_id: str) -> float:
-        return float(self.service.getProperty(f"rooms.{room_id}.operating.programs.reducedHeating")["properties"]["temperature"]["value"])
+        return float(self.getProperty(f"rooms.{room_id}.operating.programs.reducedHeating")["properties"]["temperature"]["value"])
 
     @handleAPICommandErrors
     def setRoomReducedHeatingTemperature(self, room_id: str, temperature: float) -> None:
-        self.service.setProperty(f"rooms.{room_id}.operating.programs.reducedHeating", "setTemperature",
+        self.setProperty(f"rooms.{room_id}.operating.programs.reducedHeating", "setTemperature",
                                  {"targetTemperature": temperature})
 
     def getRoomComfortHeatingTemperature(self, room_id: str) -> float:
-        return float(self.service.getProperty(f"rooms.{room_id}.operating.programs.comfortHeating")["properties"]["temperature"]["value"])
+        return float(self.getProperty(f"rooms.{room_id}.operating.programs.comfortHeating")["properties"]["temperature"]["value"])
 
     @handleAPICommandErrors
     def setRoomComfortHeatingTemperature(self, room_id: str, temperature: float) -> None:
-        self.service.setProperty(f"rooms.{room_id}.operating.programs.comfortHeating", "setTemperature",
+        self.setProperty(f"rooms.{room_id}.operating.programs.comfortHeating", "setTemperature",
                                  {"targetTemperature": temperature})
 
     # --- Schedule ---
 
     def getRoomSchedule(self, room_id: str) -> dict[str, Any]:
-        props = self.service.getProperty(f"rooms.{room_id}.schedule")["properties"]
+        props = self.getProperty(f"rooms.{room_id}.schedule")["properties"]
         return {
             "active": props["active"]["value"],
             "mon": props["entries"]["value"]["mon"],
@@ -107,14 +107,14 @@ class RoomControl(Device):
     # --- Quick modes ---
 
     def getRoomManualTillNextScheduleActive(self, room_id: str) -> bool:
-        return bool(self.service.getProperty(
+        return bool(self.getProperty(
             f"rooms.{room_id}.quickmodes.manualTillNextSchedule")["properties"]["active"]["value"])
 
     @handleAPICommandErrors
     def activateRoomManualTillNextSchedule(self, room_id: str, temperature: float) -> None:
-        self.service.setProperty(f"rooms.{room_id}.quickmodes.manualTillNextSchedule", "activate",
+        self.setProperty(f"rooms.{room_id}.quickmodes.manualTillNextSchedule", "activate",
                                  {"temperature": temperature})
 
     @handleAPICommandErrors
     def deactivateRoomManualTillNextSchedule(self, room_id: str) -> None:
-        self.service.setProperty(f"rooms.{room_id}.quickmodes.manualTillNextSchedule", "deactivate", {})
+        self.setProperty(f"rooms.{room_id}.quickmodes.manualTillNextSchedule", "deactivate", {})

--- a/PyViCare/PyViCareService.py
+++ b/PyViCare/PyViCareService.py
@@ -30,19 +30,18 @@ class ViCareDeviceAccessor:
         self.device_id = device_id
 
 class ViCareService:
-    def __init__(self, oauth_manager: AbstractViCareOAuthManager, accessor: ViCareDeviceAccessor, roles: List[str]) -> None:
+    def __init__(self, oauth_manager: AbstractViCareOAuthManager, roles: List[str]) -> None:
         self.oauth_manager = oauth_manager
-        self.accessor = accessor
         self.roles = roles
 
-    def getProperty(self, property_name: str) -> Any:
-        url = self.buildGetPropertyUrl(property_name)
+    def getProperty(self, accessor: ViCareDeviceAccessor, property_name: str) -> Any:
+        url = self.buildGetPropertyUrl(accessor, property_name)
         return self.oauth_manager.get(url)
 
-    def buildGetPropertyUrl(self, property_name):
+    def buildGetPropertyUrl(self, accessor: ViCareDeviceAccessor, property_name):
         if self._isGateway():
-            return f'/features/installations/{self.accessor.id}/gateways/{self.accessor.serial}/features/{property_name}'
-        return f'/features/installations/{self.accessor.id}/gateways/{self.accessor.serial}/devices/{self.accessor.device_id}/features/{property_name}'
+            return f'/features/installations/{accessor.id}/gateways/{accessor.serial}/features/{property_name}'
+        return f'/features/installations/{accessor.id}/gateways/{accessor.serial}/devices/{accessor.device_id}/features/{property_name}'
 
     def hasRoles(self, requested_roles) -> bool:
         return hasRoles(requested_roles, self.roles)
@@ -50,20 +49,19 @@ class ViCareService:
     def _isGateway(self) -> bool:
         return self.hasRoles(["type:gateway;VitoconnectOpto1"]) or self.hasRoles(["type:gateway;VitoconnectOpto2/OT2"]) or self.hasRoles(["type:gateway;TCU100"]) or self.hasRoles(["type:gateway;TCU200"]) or self.hasRoles(["type:gateway;TCU300"])
 
-    def setProperty(self, property_name: str, action: str, data: Any) -> Any:
-        url = buildSetPropertyUrl(
-            self.accessor, property_name, action)
+    def setProperty(self, accessor: ViCareDeviceAccessor, property_name: str, action: str, data: Any) -> Any:
+        url = buildSetPropertyUrl(accessor, property_name, action)
 
         post_data = data if isinstance(data, str) else json.dumps(data)
         return self.oauth_manager.post(url, post_data)
 
-    def fetch_all_features(self) -> Any:
-        url = f'/features/installations/{self.accessor.id}/gateways/{self.accessor.serial}/devices/{self.accessor.device_id}/features/'
+    def fetch_all_features(self, accessor: ViCareDeviceAccessor) -> Any:
+        url = f'/features/installations/{accessor.id}/gateways/{accessor.serial}/devices/{accessor.device_id}/features/'
         if self._isGateway():
-            url = f'/features/installations/{self.accessor.id}/gateways/{self.accessor.serial}/features/'
+            url = f'/features/installations/{accessor.id}/gateways/{accessor.serial}/features/'
         return self.oauth_manager.get(url)
 
-    def reboot_gateway(self) -> Any:
-        url = f'/equipment/installations/{self.accessor.id}/gateways/{self.accessor.serial}/reboot'
+    def reboot_gateway(self, accessor: ViCareDeviceAccessor) -> Any:
+        url = f'/equipment/installations/{accessor.id}/gateways/{accessor.serial}/reboot'
         data = "{}"
         return self.oauth_manager.post(url, data)

--- a/tests/ViCareServiceMock.py
+++ b/tests/ViCareServiceMock.py
@@ -23,18 +23,25 @@ class ViCareServiceMock:
         else:
             self.testData = rawInput
 
-        self.accessor = ViCareDeviceAccessor(
-            '[id]', '[serial]', '[deviceid]')
         self.setPropertyData = []
 
-    def getProperty(self, property_name):
+    def getProperty(self, accessor: ViCareDeviceAccessor, property_name):
         entities = self.testData["data"]
         return readFeature(entities, property_name)
 
-    def setProperty(self, property_name, action, data):
+    def setProperty(self, accessor: ViCareDeviceAccessor, property_name, action, data):
         self.setPropertyData.append({
-            "url": buildSetPropertyUrl(self.accessor, property_name, action),
+            "url": buildSetPropertyUrl(accessor, property_name, action),
             "property_name": property_name,
             "action": action,
             "data": data
         })
+
+    def fetch_all_features(self, accessor: ViCareDeviceAccessor):
+        return self.testData
+
+    def hasRoles(self, requested_roles):
+        return False
+
+    def _isGateway(self):
+        return False

--- a/tests/ViCareServiceMock.py
+++ b/tests/ViCareServiceMock.py
@@ -25,7 +25,7 @@ class ViCareServiceMock:
 
         self.setPropertyData = []
 
-    def getProperty(self, accessor: ViCareDeviceAccessor, property_name):
+    def getProperty(self, _accessor: ViCareDeviceAccessor, property_name):
         entities = self.testData["data"]
         return readFeature(entities, property_name)
 
@@ -37,10 +37,10 @@ class ViCareServiceMock:
             "data": data
         })
 
-    def fetch_all_features(self, accessor: ViCareDeviceAccessor):
+    def fetch_all_features(self, _accessor: ViCareDeviceAccessor):
         return self.testData
 
-    def hasRoles(self, requested_roles):
+    def hasRoles(self, _requested_roles):
         return False
 
     def _isGateway(self):

--- a/tests/test_E3_TCU300_ethernet.py
+++ b/tests/test_E3_TCU300_ethernet.py
@@ -1,5 +1,6 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareGateway import Gateway
 from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
 from tests.ViCareServiceMock import ViCareServiceMock
@@ -7,8 +8,9 @@ from tests.ViCareServiceMock import ViCareServiceMock
 
 class TCU300_ethernet(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/TCU300_ethernet.json')
-        self.device = Gateway(self.service)
+        self.device = Gateway(self.accessor, self.service)
 
     def test_getSerial(self):
         self.assertEqual(

--- a/tests/test_Ecotronic.py
+++ b/tests/test_Ecotronic.py
@@ -1,5 +1,6 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCarePelletsBoiler import PelletsBoiler
 from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
 from tests.ViCareServiceMock import ViCareServiceMock
@@ -7,8 +8,9 @@ from tests.ViCareServiceMock import ViCareServiceMock
 
 class Ecotronic(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/Ecotronic.json')
-        self.device = PelletsBoiler(self.service)
+        self.device = PelletsBoiler(self.accessor, self.service)
 
     def test_isDomesticHotWaterDevice(self):
         self.assertEqual(self.device.isDomesticHotWaterDevice(), False)

--- a/tests/test_GenericDevice.py
+++ b/tests/test_GenericDevice.py
@@ -1,14 +1,16 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareHeatingDevice import HeatingDevice
 from tests.ViCareServiceMock import MockCircuitsData, ViCareServiceMock
 
 
 class GenericDeviceTest(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock(
             None, {'data': [MockCircuitsData([0])]})
-        self.device = HeatingDevice(self.service)
+        self.device = HeatingDevice(self.accessor, self.service)
 
     def test_activateComfort(self):
         self.device.circuits[0].activateComfort()

--- a/tests/test_PyViCareCachedService.py
+++ b/tests/test_PyViCareCachedService.py
@@ -17,35 +17,35 @@ class PyViCareCachedServiceTest(unittest.TestCase):
     def setUp(self):
         self.oauth_mock = Mock()
         self.oauth_mock.get.return_value = {'data': [{"feature": "someprop"}]}
-        accessor = ViCareDeviceAccessor("[id]", "[serial]", "[device]")
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "[device]")
         self.service = ViCareCachedService(
-            self.oauth_mock, accessor, [], self.CACHE_DURATION)
+            self.oauth_mock, [], self.CACHE_DURATION)
 
     def test_getProperty_existing(self):
-        self.service.getProperty("someprop")
+        self.service.getProperty(self.accessor, "someprop")
         self.oauth_mock.get.assert_called_once_with(
             '/features/installations/[id]/gateways/[serial]/devices/[device]/features/')
 
     def test_getProperty_nonexisting_raises_exception(self):
 
         def func():
-            return self.service.getProperty("some-non-prop")
+            return self.service.getProperty(self.accessor, "some-non-prop")
         self.assertRaises(PyViCareNotSupportedFeatureError, func)
 
     def test_setProperty_works(self):
-        self.service.setProperty("someotherprop", "doaction", {'name': 'abc'})
+        self.service.setProperty(self.accessor, "someotherprop", "doaction", {'name': 'abc'})
         self.oauth_mock.post.assert_called_once_with(
             '/features/installations/[id]/gateways/[serial]/devices/[device]/features/someotherprop/commands/doaction', '{"name": "abc"}')
 
     def test_getProperty_existing_cached(self):
         # time+0 seconds
         with now_is('2000-01-01 00:00:00'):
-            self.service.getProperty("someprop")
-            self.service.getProperty("someprop")
+            self.service.getProperty(self.accessor, "someprop")
+            self.service.getProperty(self.accessor, "someprop")
 
         # time+30 seconds
         with now_is('2000-01-01 00:00:30'):
-            self.service.getProperty("someprop")
+            self.service.getProperty(self.accessor, "someprop")
 
         self.assertEqual(self.oauth_mock.get.call_count, 1)
         self.oauth_mock.get.assert_called_once_with(
@@ -53,7 +53,7 @@ class PyViCareCachedServiceTest(unittest.TestCase):
 
         # time+70 seconds (must be more than CACHE_DURATION)
         with now_is('2000-01-01 00:01:10'):
-            self.service.getProperty("someprop")
+            self.service.getProperty(self.accessor, "someprop")
 
         self.assertEqual(self.oauth_mock.get.call_count, 2)
 
@@ -61,20 +61,20 @@ class PyViCareCachedServiceTest(unittest.TestCase):
         # freeze time
         with now_is('2000-01-01 00:00:00'):
             self.assertEqual(self.service.is_cache_invalid(), True)
-            self.service.getProperty("someprop")
+            self.service.getProperty(self.accessor, "someprop")
             self.assertEqual(self.service.is_cache_invalid(), False)
 
-            self.service.setProperty(
+            self.service.setProperty(self.accessor,
                 "someotherprop", "doaction", {'name': 'abc'})
             self.assertEqual(self.service.is_cache_invalid(), True)
 
-            self.service.getProperty("someprop")
+            self.service.getProperty(self.accessor, "someprop")
             self.assertEqual(self.oauth_mock.get.call_count, 2)
 
     def test_device_communication_error_returns_stale_cache(self):
         """When device goes offline after successful fetch, return stale cache."""
         with now_is('2000-01-01 00:00:00'):
-            self.service.getProperty("someprop")
+            self.service.getProperty(self.accessor, "someprop")
 
         # Device goes offline after cache expires
         self.oauth_mock.get.side_effect = PyViCareDeviceCommunicationError(
@@ -82,21 +82,21 @@ class PyViCareCachedServiceTest(unittest.TestCase):
              "extendedPayload": {"reason": "GATEWAY_OFFLINE"}})
 
         with now_is('2000-01-01 00:01:10'):
-            result = self.service.getProperty("someprop")
+            result = self.service.getProperty(self.accessor, "someprop")
 
         self.assertIsNotNone(result)
 
     def test_server_error_returns_stale_cache(self):
         """When server returns 500 after successful fetch, return stale cache."""
         with now_is('2000-01-01 00:00:00'):
-            self.service.getProperty("someprop")
+            self.service.getProperty(self.accessor, "someprop")
 
         self.oauth_mock.get.side_effect = PyViCareInternalServerError(
             {"statusCode": 500, "message": "Internal server error",
              "viErrorId": "test"})
 
         with now_is('2000-01-01 00:01:10'):
-            result = self.service.getProperty("someprop")
+            result = self.service.getProperty(self.accessor, "someprop")
 
         self.assertIsNotNone(result)
 
@@ -109,7 +109,7 @@ class PyViCareCachedServiceTest(unittest.TestCase):
         with now_is('2000-01-01 00:00:00'):
             self.assertRaises(
                 PyViCareDeviceCommunicationError,
-                self.service.getProperty, "someprop")
+                self.service.getProperty, self.accessor, "someprop")
 
     def test_server_error_raises_without_cache(self):
         """When server errors on first fetch (no cache), must raise."""
@@ -120,12 +120,12 @@ class PyViCareCachedServiceTest(unittest.TestCase):
         with now_is('2000-01-01 00:00:00'):
             self.assertRaises(
                 PyViCareInternalServerError,
-                self.service.getProperty, "someprop")
+                self.service.getProperty, self.accessor, "someprop")
 
     def test_invalid_data_still_raises_with_cache(self):
         """PyViCareInvalidDataError (genuine bad data) must still raise even with cache."""
         with now_is('2000-01-01 00:00:00'):
-            self.service.getProperty("someprop")
+            self.service.getProperty(self.accessor, "someprop")
 
         self.oauth_mock.get.side_effect = None
         self.oauth_mock.get.return_value = {"unexpected": "response"}
@@ -133,4 +133,4 @@ class PyViCareCachedServiceTest(unittest.TestCase):
         with now_is('2000-01-01 00:01:10'):
             self.assertRaises(
                 PyViCareInvalidDataError,
-                self.service.getProperty, "someprop")
+                self.service.getProperty, self.accessor, "someprop")

--- a/tests/test_PyViCareDeviceConfig.py
+++ b/tests/test_PyViCareDeviceConfig.py
@@ -3,7 +3,7 @@ import unittest
 from unittest.mock import Mock
 
 from PyViCare.PyViCareDeviceConfig import PyViCareDeviceConfig
-from PyViCare.PyViCareService import hasRoles
+from PyViCare.PyViCareService import ViCareDeviceAccessor, hasRoles
 from PyViCare.PyViCareUtils import PyViCareNotPaidForError
 
 
@@ -16,179 +16,210 @@ class PyViCareDeviceConfigTest(unittest.TestCase):
     def setUp(self) -> None:
         self.service = Mock()
         self.service.hasRoles = has_roles([])
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
 
     def test_autoDetect_Vitodens_asGazBoiler(self):
         c = PyViCareDeviceConfig(
-            self.service, "0", "E3_Vitodens_200_xxxx/E3_Dictionary", "Online")
+            self.accessor, self.service, "E3_Vitodens_200_xxxx/E3_Dictionary", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("GazBoiler", type(device_type).__name__)
 
     def test_autoDetect_Unknown_asGeneric(self):
-        c = PyViCareDeviceConfig(self.service, "0", "myRobot", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "myRobot", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("HeatingDevice", type(device_type).__name__)
 
     def test_autoDetect_VScot_asGazBoiler(self):
-        c = PyViCareDeviceConfig(self.service, "0", "VScotHO1_200", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "VScotHO1_200", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("GazBoiler", type(device_type).__name__)
 
     def test_autoDetect_RoleBoiler_asGazBoiler(self):
         self.service.hasRoles = has_roles(["type:boiler"])
-        c = PyViCareDeviceConfig(self.service, "0", "Unknown", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "Unknown", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("GazBoiler", type(device_type).__name__)
 
     def test_autoDetect_RoleHeatpump_asHeatpump(self):
         self.service.hasRoles = has_roles(["type:heatpump"])
-        c = PyViCareDeviceConfig(self.service, "0", "Unknown", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "Unknown", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("HeatPump", type(device_type).__name__)
 
     def test_autoDetect_RoleRadiator_asRadiatorActuator(self):
         self.service.hasRoles = has_roles(["type:radiator"])
-        c = PyViCareDeviceConfig(self.service, "0", "Unknown", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "Unknown", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("RadiatorActuator", type(device_type).__name__)
 
     def test_autoDetect_RoleClimateSensor_asRoomSensor(self):
         self.service.hasRoles = has_roles(["type:climateSensor"])
-        c = PyViCareDeviceConfig(self.service, "0", "Unknown", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "Unknown", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("RoomSensor", type(device_type).__name__)
 
     def test_autoDetect_RoleVentilation_asVentilation(self):
         self.service.hasRoles = has_roles(["type:ventilation"])
-        c = PyViCareDeviceConfig(self.service, "0", "Unknown", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "Unknown", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("VentilationDevice", type(device_type).__name__)
 
     def test_autoDetect_RoleVentilationCentral_asVentilation(self):
         self.service.hasRoles = has_roles(["type:ventilation;central"])
-        c = PyViCareDeviceConfig(self.service, "0", "Unknown", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "Unknown", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("VentilationDevice", type(device_type).__name__)
 
     def test_autoDetect_Vitoair_FS_300F_asVentilation(self):
-        c = PyViCareDeviceConfig(self.service, "0", "E3_ViAir_300F", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "E3_ViAir_300F", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("VentilationDevice", type(device_type).__name__)
 
     def test_autoDetect_RoleVentilationPurifier_asVentilation(self):
         self.service.hasRoles = has_roles(["type:ventilation;purifier"])
-        c = PyViCareDeviceConfig(self.service, "0", "Unknown", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "Unknown", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("VentilationDevice", type(device_type).__name__)
 
     def test_autoDetect_Vitopure_350_asVentilation(self):
-        c = PyViCareDeviceConfig(self.service, "0", "E3_VitoPure", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "E3_VitoPure", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("VentilationDevice", type(device_type).__name__)
 
     def test_autoDetect_RoleESS_asElectricalEnergySystem(self):
         self.service.hasRoles = has_roles(["type:ess"])
-        c = PyViCareDeviceConfig(self.service, "0", "Unknown", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "Unknown", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("ElectricalEnergySystem", type(device_type).__name__)
 
     def test_autoDetect_E3_RoomControl_asRoomControl(self):
-        c = PyViCareDeviceConfig(self.service, "0", "E3_RoomControl_One_525", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "E3_RoomControl_One_525", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("RoomControl", type(device_type).__name__)
 
     def test_autoDetect_Smart_RoomControl_asRoomControl(self):
-        c = PyViCareDeviceConfig(self.service, "0", "Smart_RoomControl", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "Smart_RoomControl", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("RoomControl", type(device_type).__name__)
 
     def test_autoDetect_RoleRoomControl_asRoomControl(self):
         self.service.hasRoles = has_roles(["type:virtual;smartRoomControl"])
-        c = PyViCareDeviceConfig(self.service, "0", "Unknown", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "Unknown", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("RoomControl", type(device_type).__name__)
 
     def test_autoDetect_Vitocharge05_asElectricalEnergySystem(self):
-        c = PyViCareDeviceConfig(self.service, "0", "E3_VitoCharge_05", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "E3_VitoCharge_05", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("ElectricalEnergySystem", type(device_type).__name__)
 
     def test_autoDetect_VitoconnectOpto1_asGateway(self):
-        c = PyViCareDeviceConfig(self.service, "0", "Heatbox1", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "Heatbox1", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("Gateway", type(device_type).__name__)
 
     def test_autoDetect_VitoconnectOpto2_asGateway(self):
-        c = PyViCareDeviceConfig(self.service, "0", "Heatbox2_SRC", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "Heatbox2_SRC", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("Gateway", type(device_type).__name__)
 
     def test_autoDetect_TCU100_asGateway(self):
-        c = PyViCareDeviceConfig(self.service, "0", "E3_TCU41_x04", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "E3_TCU41_x04", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("Gateway", type(device_type).__name__)
 
     def test_autoDetect_TCU200_asGateway(self):
-        c = PyViCareDeviceConfig(self.service, "0", "E3_TCU19_x05", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "E3_TCU19_x05", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("Gateway", type(device_type).__name__)
 
     def test_autoDetect_TCU300_asGateway(self):
-        c = PyViCareDeviceConfig(self.service, "0", "E3_TCU10_x07", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "E3_TCU10_x07", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("Gateway", type(device_type).__name__)
 
     def test_autoDetect_Ecotronic_asPelletsBoiler(self):
         self.service.hasRoles = has_roles(["type:boiler"])
-        c = PyViCareDeviceConfig(self.service, "0", "Ecotronic", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "Ecotronic", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("PelletsBoiler", type(device_type).__name__)
 
     def test_autoDetect_Vitoladens_asOilBoiler(self):
         self.service.hasRoles = has_roles(["type:boiler"])
-        c = PyViCareDeviceConfig(self.service, "0", "Vitoladens", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "Vitoladens", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("OilBoiler", type(device_type).__name__)
 
     def test_autoDetect_RoleGateway_asGateway(self):
         self.service.hasRoles = has_roles(["type:gateway;VitoconnectOpto1"])
-        c = PyViCareDeviceConfig(self.service, "0", "Unknown", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "Unknown", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("Gateway", type(device_type).__name__)
 
     def test_autoDetect_RoleGateway_asGateway_vc_opto2(self):
         self.service.hasRoles = has_roles(["type:gateway;VitoconnectOpto2/OT2"])
-        c = PyViCareDeviceConfig(self.service, "0", "Unknown", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "Unknown", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("Gateway", type(device_type).__name__)
 
     def test_autoDetect_RoleGateway_asGateway_TCU100(self):
         self.service.hasRoles = has_roles(["type:gateway;TCU100"])
-        c = PyViCareDeviceConfig(self.service, "0", "Unknown", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "Unknown", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("Gateway", type(device_type).__name__)
 
     def test_autoDetect_RoleGateway_asGateway_TCU200(self):
         self.service.hasRoles = has_roles(["type:gateway;TCU200"])
-        c = PyViCareDeviceConfig(self.service, "0", "Unknown", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "Unknown", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("Gateway", type(device_type).__name__)
 
     def test_autoDetect_RoleGateway_asGateway_TCU300(self):
         self.service.hasRoles = has_roles(["type:gateway;TCU300"])
-        c = PyViCareDeviceConfig(self.service, "0", "Unknown", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "Unknown", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("Gateway", type(device_type).__name__)
 
     def test_legacy_device(self):
         self.service.hasRoles = has_roles(["type:legacy"])
-        c = PyViCareDeviceConfig(self.service, "0", "Unknown", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "Unknown", "Online")
         device = c.asAutoDetectDevice()
         self.assertEqual(device.isLegacyDevice(), True)
         self.assertEqual(device.isE3Device(), False)
 
     def test_e3_device(self):
         self.service.hasRoles = has_roles(["type:E3"])
-        c = PyViCareDeviceConfig(self.service, "0", "Unknown", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "Unknown", "Online")
         device = c.asAutoDetectDevice()
         self.assertEqual(device.isLegacyDevice(), False)
         self.assertEqual(device.isE3Device(), True)
@@ -202,7 +233,7 @@ class PyViCareDeviceConfigTest(unittest.TestCase):
             {"feature": "heating.compressors.0"},
         ]})
         c = PyViCareDeviceConfig(
-            self.service, "0", "CU401B_S", "Online")
+            self.accessor, self.service, "CU401B_S", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("Hybrid", type(device_type).__name__)
 
@@ -213,7 +244,7 @@ class PyViCareDeviceConfigTest(unittest.TestCase):
             {"feature": "heating.compressors.0"},
         ]})
         c = PyViCareDeviceConfig(
-            self.service, "0", "Vitocal300", "Online")
+            self.accessor, self.service, "Vitocal300", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("HeatPump", type(device_type).__name__)
 
@@ -226,7 +257,7 @@ class PyViCareDeviceConfigTest(unittest.TestCase):
             {"feature": "heating.compressors.0"},
         ]})
         c = PyViCareDeviceConfig(
-            self.service, "0", "Vitodens200", "Online")
+            self.accessor, self.service, "Vitodens200", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("Hybrid", type(device_type).__name__)
 
@@ -234,7 +265,7 @@ class PyViCareDeviceConfigTest(unittest.TestCase):
         self.service.hasRoles = has_roles(["type:heatpump"])
         self.service.fetch_all_features = Mock(side_effect=OSError("API error"))
         c = PyViCareDeviceConfig(
-            self.service, "0", "CU401B_S", "Online")
+            self.accessor, self.service, "CU401B_S", "Online")
         device_type = c.asAutoDetectDevice()
         self.assertEqual("HeatPump", type(device_type).__name__)
 
@@ -243,7 +274,7 @@ class PyViCareDeviceConfigTest(unittest.TestCase):
         self.service.fetch_all_features = Mock(
             side_effect=PyViCareNotPaidForError({"errorType": "PACKAGE_NOT_PAID_FOR"}))
         c = PyViCareDeviceConfig(
-            self.service, "0", "CU401B_S", "Online")
+            self.accessor, self.service, "CU401B_S", "Online")
         device_type = c.asAutoDetectDevice()
         # Without the fix, asAutoDetectDevice would propagate the exception
         # and crash integration setup. With the fix, hybrid detection falls
@@ -254,7 +285,7 @@ class PyViCareDeviceConfigTest(unittest.TestCase):
         self.service.fetch_all_features = Mock(
             side_effect=PyViCareNotPaidForError({"errorType": "PACKAGE_NOT_PAID_FOR"}))
         c = PyViCareDeviceConfig(
-            self.service, "0", "CU401B_S", "Online")
+            self.accessor, self.service, "CU401B_S", "Online")
         dump = json.loads(c.dump_secure())
         # Diagnostics should produce a usable dump rather than crashing
         # when the account lacks the paid feature package.
@@ -262,33 +293,40 @@ class PyViCareDeviceConfigTest(unittest.TestCase):
         self.assertEqual(dump["data"], [])
 
     def test_getDeviceType_heating(self):
-        c = PyViCareDeviceConfig(self.service, "0", "Vitocal", "Online", "heating")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "Vitocal", "Online", "heating")
         self.assertEqual(c.getDeviceType(), "heating")
 
     def test_getDeviceType_vitoconnect(self):
-        c = PyViCareDeviceConfig(self.service, "0", "Heatbox1", "Online", "vitoconnect")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "Heatbox1", "Online", "vitoconnect")
         self.assertEqual(c.getDeviceType(), "vitoconnect")
 
 
     def test_getDeviceType_none_when_not_provided(self):
-        c = PyViCareDeviceConfig(self.service, "0", "Vitocal", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "Vitocal", "Online")
         self.assertIsNone(c.getDeviceType())
 
     def test_getRoles(self):
         roles = ["type:heatpump", "type:E3"]
-        c = PyViCareDeviceConfig(self.service, "0", "Vitocal", "Online", "heating", roles)
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "Vitocal", "Online", "heating", roles)
         self.assertEqual(c.getRoles(), roles)
 
     def test_getRoles_empty_when_not_provided(self):
-        c = PyViCareDeviceConfig(self.service, "0", "Vitocal", "Online")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "Vitocal", "Online")
         self.assertEqual(c.getRoles(), [])
 
     def test_isGateway_true_for_gateway_role(self):
         self.service._isGateway = Mock(return_value=True)  # pylint: disable=protected-access
-        c = PyViCareDeviceConfig(self.service, "0", "Heatbox1", "Online", "vitoconnect")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "Heatbox1", "Online", "vitoconnect")
         self.assertTrue(c.isGateway())
 
     def test_isGateway_false_for_non_gateway_role(self):
         self.service._isGateway = Mock(return_value=False)  # pylint: disable=protected-access
-        c = PyViCareDeviceConfig(self.service, "0", "Vitocal", "Online", "heating")
+        c = PyViCareDeviceConfig(
+            self.accessor, self.service, "Vitocal", "Online", "heating")
         self.assertFalse(c.isGateway())

--- a/tests/test_PyViCareDeviceConfig.py
+++ b/tests/test_PyViCareDeviceConfig.py
@@ -16,7 +16,7 @@ class PyViCareDeviceConfigTest(unittest.TestCase):
     def setUp(self) -> None:
         self.service = Mock()
         self.service.hasRoles = has_roles([])
-        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
+        self.accessor = ViCareDeviceAccessor(0, "[serial]", "0")
 
     def test_autoDetect_Vitodens_asGazBoiler(self):
         c = PyViCareDeviceConfig(

--- a/tests/test_PyViCareService.py
+++ b/tests/test_PyViCareService.py
@@ -9,31 +9,31 @@ class PyViCareServiceTest(unittest.TestCase):
     def setUp(self):
         self.oauth_mock = Mock()
         self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "[device]")
-        self.service = ViCareService(self.oauth_mock, self.accessor, [])
+        self.service = ViCareService(self.oauth_mock, [])
 
     def test_getProperty(self):
-        self.service.getProperty("someprop")
+        self.service.getProperty(self.accessor, "someprop")
         self.oauth_mock.get.assert_called_once_with(
             '/features/installations/[id]/gateways/[serial]/devices/[device]/features/someprop')
 
     def test_setProperty_object(self):
-        self.service.setProperty("someprop", "doaction", {'name': 'abc'})
+        self.service.setProperty(self.accessor, "someprop", "doaction", {'name': 'abc'})
         self.oauth_mock.post.assert_called_once_with(
             '/features/installations/[id]/gateways/[serial]/devices/[device]/features/someprop/commands/doaction', '{"name": "abc"}')
 
     def test_setProperty_string(self):
-        self.service.setProperty("someprop", "doaction", '{}')
+        self.service.setProperty(self.accessor, "someprop", "doaction", '{}')
         self.oauth_mock.post.assert_called_once_with(
             '/features/installations/[id]/gateways/[serial]/devices/[device]/features/someprop/commands/doaction', '{}')
 
     def test_getProperty_gateway(self):
-        self.service = ViCareService(self.oauth_mock, self.accessor, ["type:gateway;VitoconnectOpto1"])
-        self.service.getProperty("someprop")
+        self.service = ViCareService(self.oauth_mock, ["type:gateway;VitoconnectOpto1"])
+        self.service.getProperty(self.accessor, "someprop")
         self.oauth_mock.get.assert_called_once_with(
             '/features/installations/[id]/gateways/[serial]/features/someprop')
 
     def test_fetch_all_features_gateway(self):
-        self.service = ViCareService(self.oauth_mock, self.accessor, ["type:gateway;VitoconnectOpto1"])
-        self.service.fetch_all_features()
+        self.service = ViCareService(self.oauth_mock, ["type:gateway;VitoconnectOpto1"])
+        self.service.fetch_all_features(self.accessor)
         self.oauth_mock.get.assert_called_once_with(
             '/features/installations/[id]/gateways/[serial]/features/')

--- a/tests/test_RoomControl.py
+++ b/tests/test_RoomControl.py
@@ -1,13 +1,15 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareRoomControl import RoomControl
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class RoomControlTest(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/RoomControl.json')
-        self.device = RoomControl(self.service)
+        self.device = RoomControl(self.accessor, self.service)
 
     def test_getAvailableRooms(self):
         rooms = self.device.getAvailableRooms()

--- a/tests/test_Solar.py
+++ b/tests/test_Solar.py
@@ -1,13 +1,15 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareHeatingDevice import HeatingDevice
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class SolarTest(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/Solar.json')
-        self.device = HeatingDevice(self.service)
+        self.device = HeatingDevice(self.accessor, self.service)
 
     def test_isDomesticHotWaterDevice(self):
         self.assertEqual(self.device.isDomesticHotWaterDevice(), True)

--- a/tests/test_VitoairFs300E.py
+++ b/tests/test_VitoairFs300E.py
@@ -1,13 +1,15 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareVentilationDevice import VentilationDevice
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class VitoairFs300(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/VitoairFs300E.json')
-        self.device = VentilationDevice(self.service)
+        self.device = VentilationDevice(self.accessor, self.service)
 
     def test_isDomesticHotWaterDevice(self):
         self.assertEqual(self.device.isDomesticHotWaterDevice(), False)

--- a/tests/test_Vitocal111S.py
+++ b/tests/test_Vitocal111S.py
@@ -1,5 +1,6 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
 from PyViCare.PyViCareHeatPump import HeatPump
 from tests.ViCareServiceMock import ViCareServiceMock
@@ -7,8 +8,9 @@ from tests.ViCareServiceMock import ViCareServiceMock
 
 class Vitocal200(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/Vitocal111S.json')
-        self.device = HeatPump(self.service)
+        self.device = HeatPump(self.accessor, self.service)
 
     def test_ventilation_state(self):
         self.assertEqual(self.device.getVentilationDemand(), "ventilation")

--- a/tests/test_Vitocal151A.py
+++ b/tests/test_Vitocal151A.py
@@ -1,13 +1,15 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareHeatPump import HeatPump
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class Vitocal200(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/Vitocal151A.json')
-        self.device = HeatPump(self.service)
+        self.device = HeatPump(self.accessor, self.service)
 
     def test_getPowerConsumptionCooling(self):
         self.assertEqual(self.device.getPowerConsumptionCoolingUnit(), "kilowattHour")

--- a/tests/test_Vitocal200.py
+++ b/tests/test_Vitocal200.py
@@ -1,5 +1,6 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareHeatPump import HeatPump
 from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
 from tests.helper import now_is
@@ -8,8 +9,9 @@ from tests.ViCareServiceMock import ViCareServiceMock
 
 class Vitocal200(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/Vitocal200.json')
-        self.device = HeatPump(self.service)
+        self.device = HeatPump(self.accessor, self.service)
 
     def test_getAvailableCompressors(self):
         self.assertEqual(self.device.getAvailableCompressors(), ['0'])

--- a/tests/test_Vitocal200S.py
+++ b/tests/test_Vitocal200S.py
@@ -1,13 +1,15 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareHeatPump import HeatPump
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class Vitocal200S(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/Vitocal200S.json')
-        self.device = HeatPump(self.service)
+        self.device = HeatPump(self.accessor, self.service)
 
     def test_getDomesticHotWaterConfiguredTemperature(self):
         self.assertEqual(
@@ -34,8 +36,9 @@ class Vitocal200S(unittest.TestCase):
 
 class Vitocal200S_AWB(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/Vitocal200S_AWB-M-E-AC-201.D10.json')
-        self.device = HeatPump(self.service)
+        self.device = HeatPump(self.accessor, self.service)
 
     def test_compressor_getAmbientTemperature(self):
         self.assertEqual(self.device.getCompressor(0).getAmbientTemperature(), 17.6)

--- a/tests/test_Vitocal200S_with_Vitovent300W.py
+++ b/tests/test_Vitocal200S_with_Vitovent300W.py
@@ -1,13 +1,15 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareHeatPump import HeatPump
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class Vitocal200S_with_Vitovent300W(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/Vitocal200S-with-Vitovent300W.json')
-        self.device = HeatPump(self.service)
+        self.device = HeatPump(self.accessor, self.service)
 
     def test_isDomesticHotWaterDevice(self):
         self.assertEqual(self.device.isDomesticHotWaterDevice(), True)

--- a/tests/test_Vitocal222S.py
+++ b/tests/test_Vitocal222S.py
@@ -1,13 +1,15 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareHeatPump import HeatPump
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class Vitocal222S(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/Vitocal222S.json')
-        self.device = HeatPump(self.service)
+        self.device = HeatPump(self.accessor, self.service)
 
     def test_condensers_getLiquidTemperature(self):
         self.assertEqual(self.device.getCondensor(0).getLiquidTemperature(), 26.1)

--- a/tests/test_Vitocal222S_with_Vitovent.py
+++ b/tests/test_Vitocal222S_with_Vitovent.py
@@ -1,5 +1,6 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareHeatPump import HeatPump
 from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
 from tests.helper import now_is
@@ -8,8 +9,9 @@ from tests.ViCareServiceMock import ViCareServiceMock
 
 class Vitocal222S_with_Vitovent(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/Vitocal222S-with-Vitovent.json')
-        self.device = HeatPump(self.service)
+        self.device = HeatPump(self.accessor, self.service)
 
     def test_getDomesticHotWaterActiveMode_10_10_time(self):
         with now_is('2000-01-01 10:10:00'):

--- a/tests/test_Vitocal250A.py
+++ b/tests/test_Vitocal250A.py
@@ -1,5 +1,6 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareHeatPump import HeatPump
 from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
 from tests.ViCareServiceMock import ViCareServiceMock
@@ -7,8 +8,9 @@ from tests.ViCareServiceMock import ViCareServiceMock
 
 class Vitocal250A(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/Vitocal250A.json')
-        self.device = HeatPump(self.service)
+        self.device = HeatPump(self.accessor, self.service)
 
     def test_compressor_getActive(self):
         self.assertFalse(self.device.compressors[0].getActive())

--- a/tests/test_Vitocal252A.py
+++ b/tests/test_Vitocal252A.py
@@ -1,5 +1,6 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareHeatPump import HeatPump
 from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
 from tests.ViCareServiceMock import ViCareServiceMock
@@ -7,8 +8,9 @@ from tests.ViCareServiceMock import ViCareServiceMock
 
 class Vitocal252A(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/Vitocal252A.json')
-        self.device = HeatPump(self.service)
+        self.device = HeatPump(self.accessor, self.service)
 
     def test_compressor_getActive(self):
         self.assertTrue(self.device.compressors[0].getActive())

--- a/tests/test_Vitocal300G.py
+++ b/tests/test_Vitocal300G.py
@@ -1,13 +1,15 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareHeatPump import HeatPump
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class Vitocal300G(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/Vitocal300G_CU401B.json')
-        self.device = HeatPump(self.service)
+        self.device = HeatPump(self.accessor, self.service)
 
     # COP (Coefficient of Performance) tests
     def test_getCoefficientOfPerformanceHeating(self):

--- a/tests/test_Vitocal333G.py
+++ b/tests/test_Vitocal333G.py
@@ -1,5 +1,6 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareHeatPump import HeatPump
 from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
 from tests.ViCareServiceMock import ViCareServiceMock
@@ -7,8 +8,9 @@ from tests.ViCareServiceMock import ViCareServiceMock
 
 class Vitocal300G(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/Vitocal333G.json')
-        self.device = HeatPump(self.service)
+        self.device = HeatPump(self.accessor, self.service)
 
     def test_getDomesticHotWaterStorageTemperature(self):
         self.assertEqual(

--- a/tests/test_Vitocal333G_with_Vitovent300F.py
+++ b/tests/test_Vitocal333G_with_Vitovent300F.py
@@ -1,13 +1,15 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareHeatPump import HeatPump
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class Vitocal333G_with_Vitovent300F(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/Vitocal333G-with-Vitovent300F.json')
-        self.device = HeatPump(self.service)
+        self.device = HeatPump(self.accessor, self.service)
 
     def test_getHeatExchangerFrostProtectionActive(self):
         self.assertFalse(self.device.getHeatExchangerFrostProtectionActive())

--- a/tests/test_Vitocaldens222F.py
+++ b/tests/test_Vitocaldens222F.py
@@ -1,13 +1,15 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareHybrid import Hybrid
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class Vitocaldens222F(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/Vitocaldens222F.json')
-        self.device = Hybrid(self.service)
+        self.device = Hybrid(self.accessor, self.service)
 
     def test_isDomesticHotWaterDevice(self):
         self.assertEqual(self.device.isDomesticHotWaterDevice(), True)

--- a/tests/test_Vitocharge05.py
+++ b/tests/test_Vitocharge05.py
@@ -1,13 +1,15 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareElectricalEnergySystem import ElectricalEnergySystem
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class Vitocharge05(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/Vitocharge05.json')
-        self.device = ElectricalEnergySystem(self.service)
+        self.device = ElectricalEnergySystem(self.accessor, self.service)
 
     def test_isDomesticHotWaterDevice(self):
         self.assertEqual(self.device.isDomesticHotWaterDevice(), False)

--- a/tests/test_VitochargeVX3.py
+++ b/tests/test_VitochargeVX3.py
@@ -1,13 +1,15 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareElectricalEnergySystem import ElectricalEnergySystem
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class VitochargeVX3(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/Vitocharge03.json')
-        self.device = ElectricalEnergySystem(self.service)
+        self.device = ElectricalEnergySystem(self.accessor, self.service)
 
     def test_isDomesticHotWaterDevice(self):
         self.assertEqual(self.device.isDomesticHotWaterDevice(), False)

--- a/tests/test_VitoconnectOpto1.py
+++ b/tests/test_VitoconnectOpto1.py
@@ -1,13 +1,15 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareGateway import Gateway
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class VitoconnectOpto1(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/VitoconnectOpto1.json')
-        self.device = Gateway(self.service)
+        self.device = Gateway(self.accessor, self.service)
 
     def test_isDomesticHotWaterDevice(self):
         self.assertEqual(self.device.isDomesticHotWaterDevice(), False)

--- a/tests/test_VitoconnectOpto2.py
+++ b/tests/test_VitoconnectOpto2.py
@@ -1,13 +1,15 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareGateway import Gateway
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class VitoconnectOpto2(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/VitoconnectOpto2.json')
-        self.device = Gateway(self.service)
+        self.device = Gateway(self.accessor, self.service)
 
     def test_getSerial(self):
         self.assertEqual(

--- a/tests/test_Vitodens100W.py
+++ b/tests/test_Vitodens100W.py
@@ -1,13 +1,15 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareGazBoiler import GazBoiler
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class Vitodens100W(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/Vitodens100W.json')
-        self.device = GazBoiler(self.service)
+        self.device = GazBoiler(self.accessor, self.service)
 
     def test_getActive(self):
         self.assertEqual(self.device.burners[0].getActive(), True)

--- a/tests/test_Vitodens200W.py
+++ b/tests/test_Vitodens200W.py
@@ -1,5 +1,6 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareGazBoiler import GazBoiler
 from tests.helper import now_is
 from tests.ViCareServiceMock import ViCareServiceMock
@@ -7,8 +8,9 @@ from tests.ViCareServiceMock import ViCareServiceMock
 
 class Vitodens200W(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/Vitodens200W.json')
-        self.device = GazBoiler(self.service)
+        self.device = GazBoiler(self.accessor, self.service)
 
     def test_isDomesticHotWaterDevice(self):
         self.assertEqual(self.device.isDomesticHotWaterDevice(), True)

--- a/tests/test_Vitodens200W_2.py
+++ b/tests/test_Vitodens200W_2.py
@@ -1,5 +1,6 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareGazBoiler import GazBoiler
 from tests.helper import now_is
 from tests.ViCareServiceMock import ViCareServiceMock
@@ -7,8 +8,9 @@ from tests.ViCareServiceMock import ViCareServiceMock
 
 class Vitodens200W_2(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/Vitodens200W_2.json')
-        self.device = GazBoiler(self.service)
+        self.device = GazBoiler(self.accessor, self.service)
 
     def test_getSerial(self):
         self.assertEqual(self.device.getSerial(), '################')

--- a/tests/test_Vitodens200W_B2HF.py
+++ b/tests/test_Vitodens200W_B2HF.py
@@ -1,13 +1,15 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareGazBoiler import GazBoiler
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class Vitodens200W_B2HF(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/Vitodens200W_B2HF.json')
-        self.device = GazBoiler(self.service)
+        self.device = GazBoiler(self.accessor, self.service)
 
     def test_getSupplyPressure(self):
         self.assertEqual(self.device.getSupplyPressure(), 1.5)

--- a/tests/test_Vitodens222W.py
+++ b/tests/test_Vitodens222W.py
@@ -1,5 +1,6 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareGazBoiler import GazBoiler
 from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
 from tests.ViCareServiceMock import ViCareServiceMock
@@ -7,8 +8,9 @@ from tests.ViCareServiceMock import ViCareServiceMock
 
 class Vitodens222W(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/Vitodens222W.json')
-        self.device = GazBoiler(self.service)
+        self.device = GazBoiler(self.accessor, self.service)
 
     def test_getActive(self):
         self.assertEqual(self.device.burners[0].getActive(), True)

--- a/tests/test_Vitodens300W.py
+++ b/tests/test_Vitodens300W.py
@@ -1,5 +1,6 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareGazBoiler import GazBoiler
 from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
 from tests.ViCareServiceMock import ViCareServiceMock
@@ -7,8 +8,9 @@ from tests.ViCareServiceMock import ViCareServiceMock
 
 class Vitodens300W(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/Vitodens300W.json')
-        self.device = GazBoiler(self.service)
+        self.device = GazBoiler(self.accessor, self.service)
 
     def test_getActive(self):
         self.assertEqual(self.device.burners[0].getActive(), False)

--- a/tests/test_Vitodens333F.py
+++ b/tests/test_Vitodens333F.py
@@ -1,5 +1,6 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareGazBoiler import GazBoiler
 from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
 from tests.ViCareServiceMock import ViCareServiceMock
@@ -7,8 +8,9 @@ from tests.ViCareServiceMock import ViCareServiceMock
 
 class Vitodens333F(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/Vitodens333F.json')
-        self.device = GazBoiler(self.service)
+        self.device = GazBoiler(self.accessor, self.service)
 
     # currently missing an up-to-date test response
     def test_getActive(self):

--- a/tests/test_VitolaUniferral.py
+++ b/tests/test_VitolaUniferral.py
@@ -1,13 +1,15 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareOilBoiler import OilBoiler
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class VitolaUniferral(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/VitolaUniferral.json')
-        self.device = OilBoiler(self.service)
+        self.device = OilBoiler(self.accessor, self.service)
 
     def test_getDomesticHotWaterConfiguredTemperature(self):
         self.assertEqual(

--- a/tests/test_Vitoladens300-C_J3RA.py
+++ b/tests/test_Vitoladens300-C_J3RA.py
@@ -1,13 +1,15 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareOilBoiler import OilBoiler
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class Vitoladens300C(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/Vitoladens300-C_J3RA.json')
-        self.device = OilBoiler(self.service)
+        self.device = OilBoiler(self.accessor, self.service)
 
     def test_getActive(self):
         self.assertEqual(self.device.burners[0].getActive(), False)

--- a/tests/test_Vitopure350.py
+++ b/tests/test_Vitopure350.py
@@ -1,13 +1,15 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareVentilationDevice import VentilationDevice
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class Vitopure350(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/Vitopure350.json')
-        self.device = VentilationDevice(self.service)
+        self.device = VentilationDevice(self.accessor, self.service)
 
     def test_getActiveVentilationMode(self):
         self.assertEqual("sensorDriven", self.device.getActiveVentilationMode())

--- a/tests/test_VitovalorPT2.py
+++ b/tests/test_VitovalorPT2.py
@@ -1,13 +1,15 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareFuelCell import FuelCell
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class VitovalorPT2(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/VitovalorPT2.json')
-        self.device = FuelCell(self.service)
+        self.device = FuelCell(self.accessor, self.service)
 
     def test_isDomesticHotWaterDevice(self):
         self.assertEqual(self.device.isDomesticHotWaterDevice(), True)

--- a/tests/test_device_error.py
+++ b/tests/test_device_error.py
@@ -1,13 +1,15 @@
 import unittest
 
 from PyViCare.PyViCareDevice import Device
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class DeviceErrorTest(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/deviceerrors/F.1100.json')
-        self.device = Device(self.service)
+        self.device = Device(self.accessor, self.service)
 
     def test_deviceErrors(self):
         errors = self.device.getDeviceErrors()

--- a/tests/test_zigbee_zk03838_fht.py
+++ b/tests/test_zigbee_zk03838_fht.py
@@ -1,13 +1,15 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareFloorHeating import FloorHeating, FloorHeatingChannel
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class ZK03838MainViaHeatbox2(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/zigbee_zk03838_fht_main.json')
-        self.device = FloorHeating(self.service)
+        self.device = FloorHeating(self.accessor, self.service)
 
     def test_getSerial(self):
         self.assertEqual(
@@ -35,8 +37,9 @@ class ZK03838MainViaHeatbox2(unittest.TestCase):
 
 class ZK03838ChannelViaHeatbox2(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/zigbee_zk03838_fht_channel.json')
-        self.device = FloorHeatingChannel(self.service)
+        self.device = FloorHeatingChannel(self.accessor, self.service)
 
     def test_getSerial(self):
         self.assertEqual(

--- a/tests/test_zigbee_zk03839_cs.py
+++ b/tests/test_zigbee_zk03839_cs.py
@@ -1,13 +1,15 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareRoomSensor import RoomSensor
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class ZK03839ViaHeatbox2(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/zigbee_zk03839_cs.json')
-        self.device = RoomSensor(self.service)
+        self.device = RoomSensor(self.accessor, self.service)
 
     def test_getSerial(self):
         self.assertEqual(self.device.getSerial(), "zigbee-################")

--- a/tests/test_zigbee_zk03840_trv.py
+++ b/tests/test_zigbee_zk03840_trv.py
@@ -1,13 +1,15 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareRadiatorActuator import RadiatorActuator
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class ZK03840ViaHeatbox2(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/zigbee_zk03840_trv.json')
-        self.device = RadiatorActuator(self.service)
+        self.device = RadiatorActuator(self.accessor, self.service)
 
     def test_getSerial(self):
         self.assertEqual(self.device.getSerial(), "zigbee-################")

--- a/tests/test_zigbee_zk05390_repeater.py
+++ b/tests/test_zigbee_zk05390_repeater.py
@@ -1,13 +1,15 @@
 import unittest
 
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareRepeater import Repeater
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
 class ZK05390ViaHeatbox2(unittest.TestCase):
     def setUp(self):
+        self.accessor = ViCareDeviceAccessor("[id]", "[serial]", "0")
         self.service = ViCareServiceMock('response/zigbee_zk05390_repeater.json')
-        self.device = Repeater(self.service)
+        self.device = Repeater(self.accessor, self.service)
 
     def test_getSerial(self):
         self.assertEqual(self.device.getSerial(), "zigbee-################")


### PR DESCRIPTION
Splits the device-identity concern (installation/gateway/device IDs) from the HTTP/cache concern (OAuth, request building, caching). Service instances no longer hold an accessor — it lives on `Device` and `PyViCareDeviceConfig` and is passed at each call site.

Picked up from @CFenner's #628 on current master. The 8-month drift, especially #764's `PACKAGE_NOT_PAID_FOR` / `DeviceCommunicationError` / `InternalServerError` exception handling added to `ViCareCachedService`, made a fresh implementation cleaner than a rebase. Same design intent and API shape as #628 — closes #628.

## Motivation

This is prep work for a gateway-scoped service that can serve multiple devices from a single bulk fetch (`/features/installations/{id}/gateways/{serial}/features?includeDevicesFeatures=true`). Today's per-device `fetch_all_features()` is called N times per coordinator refresh; with a gateway service it could collapse to 1.

Measured on my installation: the bulk endpoint covers every `isEnabled=true` feature on every device (deactivated features are excluded by default, but PyViCare's existing `@handleNotSupported` / `isEnabled` checks already make missing and disabled features behaviourally equivalent). So a per-gateway architecture is functionally lossless for HA's use case — see also home-assistant/core#173776 where this came up.

## What changes

- `Device.__init__(accessor, service)` — stores `self.accessor`, threads it through `getProperty` / `setProperty`
- `PyViCareDeviceConfig.__init__(accessor, service, ...)` — `device_id` derived from `accessor.device_id`; all `as*()` constructors pass `self.accessor` through
- `ViCareService` and `ViCareCachedService` drop the `accessor` instance attribute; `getProperty` / `setProperty` / `fetch_all_features` / `buildGetPropertyUrl` / `reboot_gateway` take accessor as a parameter
- `get_available_burners(device)` (free function in `PyViCareHeatingDevice`) takes a device instead of a service — its 4 callers updated accordingly
- 21 sites in `PyViCareRoomControl` and 1 in `PyViCareHeatingDevice` that called `self.service.getProperty/setProperty` directly now go through the Device delegation (`self.getProperty/setProperty`), which was already the established pattern in the base class
- `ViCareCachedService` keeps the full defensive try/except for `PyViCareNotPaidForError`, `PyViCareDeviceCommunicationError`, `PyViCareInternalServerError` introduced in #764

## What stays the same

Public API surface used by consumers (HA Core, custom integrations):

- `device.getProperty(name)` / `device.setProperty(name, action, data)` — unchanged signatures
- `DeviceConfig.as*()` accessors — unchanged signatures, same return types
- `DeviceConfig.getConfig()` still returns the accessor

Code that constructs `ViCareService` / `ViCareCachedService` / `PyViCareDeviceConfig` directly will need the new signature. The `PyViCare` orchestrator itself handles the wiring.

## Verification

- All 729 tests pass (30 skipped, unchanged from master)
- `mypy PyViCare/` clean (the 3 missing-stub warnings are pre-existing env-only issues that CI handles)
- `ruff check PyViCare/ tests/` — all checks passed

## Credit

Originally proposed by @CFenner in #628 — this PR carries the same design forward on current master.

closes https://github.com/openviess/PyViCare/pull/628