### PR TITLE
feat: add viaGateway mode for shared per-gateway service

### DIFF
--- a/PyViCare/PyViCare.py
+++ b/PyViCare/PyViCare.py
@@ -4,9 +4,11 @@ from datetime import datetime
 from PyViCare.PyViCareAbstractOAuthManager import AbstractViCareOAuthManager
 from PyViCare.PyViCareBrowserOAuthManager import ViCareBrowserOAuthManager
 from PyViCare.PyViCareCachedService import ViCareCachedService
+from PyViCare.PyViCareCachedServiceViaGateway import ViCareCachedServiceViaGateway
 from PyViCare.PyViCareDeviceConfig import PyViCareDeviceConfig
 from PyViCare.PyViCareOAuthManager import ViCareOAuthManager
 from PyViCare.PyViCareService import ViCareDeviceAccessor, ViCareService
+from PyViCare.PyViCareServiceViaGateway import ViCareServiceViaGateway
 from PyViCare.PyViCareUtils import PyViCareInvalidDataError
 
 logger = logging.getLogger(__name__)
@@ -17,9 +19,21 @@ class PyViCare:
     """"Viessmann ViCare API Python tools"""
     def __init__(self) -> None:
         self.cacheDuration = 60
+        self.viaGateway = False
 
     def setCacheDuration(self, cache_duration):
         self.cacheDuration = int(cache_duration)
+
+    def loadViaGateway(self, via_gateway: bool = True) -> None:
+        """Opt in to per-gateway bulk fetching.
+
+        When enabled, ONE service instance per gateway serves all devices on
+        that gateway via the bulk endpoint
+        `/features/installations/{id}/gateways/{serial}/features?includeDevicesFeatures=true`,
+        instead of one HTTP call per device per refresh. Must be called
+        before initWith* (services are wired during __loadInstallations).
+        """
+        self.viaGateway = via_gateway
 
     def initWithCredentials(self, username: str, password: str, client_id: str, token_file: str):
         self.initWithExternalOAuth(ViCareOAuthManager(
@@ -36,6 +50,11 @@ class PyViCare:
         if self.cacheDuration > 0:
             return ViCareCachedService(self.oauth_manager, roles, self.cacheDuration)
         return ViCareService(self.oauth_manager, roles)
+
+    def __buildGatewayService(self):
+        if self.cacheDuration > 0:
+            return ViCareCachedServiceViaGateway(self.oauth_manager, self.cacheDuration)
+        return ViCareServiceViaGateway(self.oauth_manager)
 
     def __loadInstallations(self):
         installations = self.oauth_manager.get(
@@ -58,10 +77,11 @@ class PyViCare:
     def __extract_all_devices(self):
         for installation in self.installations:
             for gateway in installation.gateways:
+                shared_service = self.__buildGatewayService() if self.viaGateway else None
                 for device in gateway.devices:
                     accessor = ViCareDeviceAccessor(
                         installation.id, gateway.serial, device.id)
-                    service = self.__buildService(device.roles)
+                    service = shared_service if shared_service is not None else self.__buildService(device.roles)
 
                     logger.info("Device found: %s (type=%s)", device.modelId, device.deviceType)
 

--- a/PyViCare/PyViCare.py
+++ b/PyViCare/PyViCare.py
@@ -17,9 +17,10 @@ logger.addHandler(logging.NullHandler())
 
 class PyViCare:
     """"Viessmann ViCare API Python tools"""
+    viaGateway = False
+
     def __init__(self) -> None:
         self.cacheDuration = 60
-        self.viaGateway = False
 
     def setCacheDuration(self, cache_duration):
         self.cacheDuration = int(cache_duration)

--- a/PyViCare/PyViCareCachedService.py
+++ b/PyViCare/PyViCareCachedService.py
@@ -1,73 +1,23 @@
 import logging
-import threading
-from datetime import datetime
-from typing import Any, List, Optional
+from typing import Any, List
 
 from PyViCare.PyViCareAbstractOAuthManager import AbstractViCareOAuthManager
-from PyViCare.PyViCareService import (ViCareDeviceAccessor, ViCareService,
-                                      readFeature)
-from PyViCare.PyViCareUtils import (PyViCareDeviceCommunicationError,
-                                    PyViCareInvalidDataError,
-                                    PyViCareInternalServerError,
-                                    PyViCareNotPaidForError,
-                                    PyViCareNotSupportedFeatureError,
-                                    ViCareTimer)
+from PyViCare.PyViCareCachedServiceBase import ViCareCachedServiceBase
+from PyViCare.PyViCareService import ViCareDeviceAccessor, ViCareService
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 
-class ViCareCachedService(ViCareService):
+class ViCareCachedService(ViCareCachedServiceBase, ViCareService):
 
     def __init__(self, oauth_manager: AbstractViCareOAuthManager, roles: List[str], cacheDuration: int) -> None:
         ViCareService.__init__(self, oauth_manager, roles)
-        self.__cacheDuration = cacheDuration
-        self.__cache: Optional[dict] = None
-        self.__cacheTime: Optional[datetime] = None
-        self.__lock = threading.Lock()
+        self._init_cache(cacheDuration)
 
-    def getProperty(self, accessor: ViCareDeviceAccessor, property_name: str) -> Any:
-        data = self.__get_or_update_cache(accessor)
-        entities = data["data"]
-        return readFeature(entities, property_name)
+    def _fetch_uncached(self, accessor: ViCareDeviceAccessor) -> Any:
+        return ViCareService.fetch_all_features(self, accessor)
 
-    def setProperty(self, accessor: ViCareDeviceAccessor, property_name: str, action: str, data: Any) -> Any:
-        response = super().setProperty(accessor, property_name, action, data)
-        self.clear_cache()
-        return response
-
-    def __get_or_update_cache(self, accessor: ViCareDeviceAccessor):
-        with self.__lock:
-            if self.is_cache_invalid():
-                # we always set the cache time before we fetch the data
-                # to avoid consuming all the api calls if the api is down
-                # see https://github.com/home-assistant/core/issues/67052
-                # we simply return the old cache in this case
-                self.__cacheTime = ViCareTimer().now()
-
-                try:
-                    data = self.fetch_all_features(accessor)
-                except PyViCareNotPaidForError as e:
-                    logger.error("Viessmann API denied access (PACKAGE_NOT_PAID_FOR). Features unavailable: %s", e)
-                    if self.__cache is not None:
-                        return self.__cache
-                    raise PyViCareNotSupportedFeatureError("PACKAGE_NOT_PAID_FOR")
-                except (PyViCareDeviceCommunicationError, PyViCareInternalServerError) as e:
-                    if self.__cache is not None:
-                        logger.warning("API error, returning stale cache: %s", e)
-                        return self.__cache
-                    raise
-
-                if "data" not in data:
-                    logger.error("Missing 'data' property when fetching data.")
-                    raise PyViCareInvalidDataError(data)
-                self.__cache = data
-            return self.__cache
-
-    def is_cache_invalid(self) -> bool:
-        return self.__cache is None or self.__cacheTime is None or (ViCareTimer().now() - self.__cacheTime).seconds > self.__cacheDuration
-
-    def clear_cache(self):
-        with self.__lock:
-            self.__cache = None
-            self.__cacheTime = None
+    def _extract_entities(self, data: dict, accessor: ViCareDeviceAccessor) -> list[dict[str, Any]]:
+        entities: list[dict[str, Any]] = data["data"]
+        return entities

--- a/PyViCare/PyViCareCachedServiceBase.py
+++ b/PyViCare/PyViCareCachedServiceBase.py
@@ -3,7 +3,8 @@ import threading
 from datetime import datetime
 from typing import Any, Optional
 
-from PyViCare.PyViCareService import ViCareDeviceAccessor, readFeature
+from PyViCare.PyViCareService import (ViCareDeviceAccessor, ViCareService,
+                                      readFeature)
 from PyViCare.PyViCareUtils import (PyViCareDeviceCommunicationError,
                                     PyViCareInternalServerError,
                                     PyViCareInvalidDataError,
@@ -15,7 +16,7 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 
-class ViCareCachedServiceBase:
+class ViCareCachedServiceBase(ViCareService):
     """Time-based caching shared by the per-device and per-gateway services.
 
     Subclasses provide `_fetch_uncached` (the HTTP fetch) and `_extract_entities`
@@ -34,8 +35,7 @@ class ViCareCachedServiceBase:
         return readFeature(entities, property_name)
 
     def setProperty(self, accessor: ViCareDeviceAccessor, property_name: str, action: str, data: Any) -> Any:
-        # super() -> concrete service via MRO
-        response = super().setProperty(accessor, property_name, action, data)  # type: ignore[misc]
+        response = super().setProperty(accessor, property_name, action, data)
         self.clear_cache()
         return response
 

--- a/PyViCare/PyViCareCachedServiceBase.py
+++ b/PyViCare/PyViCareCachedServiceBase.py
@@ -1,0 +1,82 @@
+import logging
+import threading
+from datetime import datetime
+from typing import Any, Optional
+
+from PyViCare.PyViCareService import ViCareDeviceAccessor, readFeature
+from PyViCare.PyViCareUtils import (PyViCareDeviceCommunicationError,
+                                    PyViCareInternalServerError,
+                                    PyViCareInvalidDataError,
+                                    PyViCareNotPaidForError,
+                                    PyViCareNotSupportedFeatureError,
+                                    ViCareTimer)
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+
+class ViCareCachedServiceBase:
+    """Time-based caching shared by the per-device and per-gateway services.
+
+    Subclasses provide `_fetch_uncached` (the HTTP fetch) and `_extract_entities`
+    (pick this device's features out of the cached payload).
+    """
+
+    def _init_cache(self, cacheDuration: int) -> None:
+        self._cacheDuration = cacheDuration
+        self._cache: Optional[dict] = None
+        self._cacheTime: Optional[datetime] = None
+        self._cacheLock = threading.Lock()
+
+    def getProperty(self, accessor: ViCareDeviceAccessor, property_name: str) -> Any:
+        data = self._get_or_update_cache(accessor)
+        entities = self._extract_entities(data, accessor)
+        return readFeature(entities, property_name)
+
+    def setProperty(self, accessor: ViCareDeviceAccessor, property_name: str, action: str, data: Any) -> Any:
+        # super() -> concrete service via MRO
+        response = super().setProperty(accessor, property_name, action, data)  # type: ignore[misc]
+        self.clear_cache()
+        return response
+
+    def _get_or_update_cache(self, accessor: ViCareDeviceAccessor):
+        with self._cacheLock:
+            if self.is_cache_invalid():
+                # we always set the cache time before we fetch the data
+                # to avoid consuming all the api calls if the api is down
+                # see https://github.com/home-assistant/core/issues/67052
+                # we simply return the old cache in this case
+                self._cacheTime = ViCareTimer().now()
+
+                try:
+                    data = self._fetch_uncached(accessor)
+                except PyViCareNotPaidForError as e:
+                    logger.error("Viessmann API denied access (PACKAGE_NOT_PAID_FOR). Features unavailable: %s", e)
+                    if self._cache is not None:
+                        return self._cache
+                    raise PyViCareNotSupportedFeatureError("PACKAGE_NOT_PAID_FOR")
+                except (PyViCareDeviceCommunicationError, PyViCareInternalServerError) as e:
+                    if self._cache is not None:
+                        logger.warning("API error, returning stale cache: %s", e)
+                        return self._cache
+                    raise
+
+                if "data" not in data:
+                    logger.error("Missing 'data' property when fetching data.")
+                    raise PyViCareInvalidDataError(data)
+                self._cache = data
+            return self._cache
+
+    def is_cache_invalid(self) -> bool:
+        return self._cache is None or self._cacheTime is None or (ViCareTimer().now() - self._cacheTime).seconds > self._cacheDuration
+
+    def clear_cache(self):
+        with self._cacheLock:
+            self._cache = None
+            self._cacheTime = None
+
+    def _fetch_uncached(self, accessor: ViCareDeviceAccessor) -> Any:
+        raise NotImplementedError
+
+    def _extract_entities(self, data: dict, accessor: ViCareDeviceAccessor) -> list[dict[str, Any]]:
+        raise NotImplementedError

--- a/PyViCare/PyViCareCachedServiceViaGateway.py
+++ b/PyViCare/PyViCareCachedServiceViaGateway.py
@@ -1,92 +1,34 @@
 import logging
-import threading
-from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from PyViCare.PyViCareAbstractOAuthManager import AbstractViCareOAuthManager
-from PyViCare.PyViCareService import ViCareDeviceAccessor, readFeature
+from PyViCare.PyViCareCachedServiceBase import ViCareCachedServiceBase
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareServiceViaGateway import (
     ViCareServiceViaGateway, filter_features_for_device)
-from PyViCare.PyViCareUtils import (PyViCareDeviceCommunicationError,
-                                    PyViCareInternalServerError,
-                                    PyViCareInvalidDataError,
-                                    PyViCareNotPaidForError,
-                                    PyViCareNotSupportedFeatureError,
-                                    ViCareTimer)
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 
-class ViCareCachedServiceViaGateway(ViCareServiceViaGateway):
+class ViCareCachedServiceViaGateway(ViCareCachedServiceBase, ViCareServiceViaGateway):
     """Cached variant of the gateway bulk-fetch service.
 
-    A single instance is shared across all devices on the gateway. The bulk
-    response is cached once per (oauth, gateway) and every device's
-    getProperty reads from the same cached payload. setProperty invalidates
-    the whole cache because writes can affect any feature on any device.
+    One instance is shared across all devices on the gateway; every device's
+    getProperty reads from the same cached bulk payload. setProperty clears the
+    whole cache.
     """
 
     def __init__(self, oauth_manager: AbstractViCareOAuthManager, cacheDuration: int) -> None:
         ViCareServiceViaGateway.__init__(self, oauth_manager)
-        self.__cacheDuration = cacheDuration
-        self.__cache: Optional[dict] = None
-        self.__cacheTime: Optional[datetime] = None
-        self.__lock = threading.Lock()
+        self._init_cache(cacheDuration)
 
-    def getProperty(self, accessor: ViCareDeviceAccessor, property_name: str) -> Any:
-        data = self.__get_or_update_cache(accessor)
-        entities = filter_features_for_device(data["data"], accessor.device_id)
-        return readFeature(entities, property_name)
+    def _fetch_uncached(self, accessor: ViCareDeviceAccessor) -> Any:
+        return ViCareServiceViaGateway.fetch_all_features(self, accessor)
+
+    def _extract_entities(self, data: dict, accessor: ViCareDeviceAccessor) -> list[dict[str, Any]]:
+        return filter_features_for_device(data["data"], accessor.device_id)
 
     def fetch_all_features(self, accessor: ViCareDeviceAccessor) -> Any:
-        # Cached too: in gateway mode there is exactly one bulk endpoint per
-        # gateway, so concurrent fetch_all_features() callers (e.g. one
-        # DataUpdateCoordinator per device) all consume the same response.
-        # Returning the cached payload here is the only way the shared
-        # service actually delivers the API-call savings.
-        return self.__get_or_update_cache(accessor)
-
-    def setProperty(self, accessor: ViCareDeviceAccessor, property_name: str, action: str, data: Any) -> Any:
-        response = super().setProperty(accessor, property_name, action, data)
-        self.clear_cache()
-        return response
-
-    def _fetch_bulk_uncached(self, accessor: ViCareDeviceAccessor) -> Any:
-        return super().fetch_all_features(accessor)
-
-    def __get_or_update_cache(self, accessor: ViCareDeviceAccessor):
-        with self.__lock:
-            if self.is_cache_invalid():
-                # we always set the cache time before we fetch the data
-                # to avoid consuming all the api calls if the api is down
-                # see https://github.com/home-assistant/core/issues/67052
-                # we simply return the old cache in this case
-                self.__cacheTime = ViCareTimer().now()
-
-                try:
-                    data = self._fetch_bulk_uncached(accessor)
-                except PyViCareNotPaidForError as e:
-                    logger.error("Viessmann API denied access (PACKAGE_NOT_PAID_FOR). Features unavailable: %s", e)
-                    if self.__cache is not None:
-                        return self.__cache
-                    raise PyViCareNotSupportedFeatureError("PACKAGE_NOT_PAID_FOR")
-                except (PyViCareDeviceCommunicationError, PyViCareInternalServerError) as e:
-                    if self.__cache is not None:
-                        logger.warning("API error, returning stale cache: %s", e)
-                        return self.__cache
-                    raise
-
-                if "data" not in data:
-                    logger.error("Missing 'data' property when fetching data.")
-                    raise PyViCareInvalidDataError(data)
-                self.__cache = data
-            return self.__cache
-
-    def is_cache_invalid(self) -> bool:
-        return self.__cache is None or self.__cacheTime is None or (ViCareTimer().now() - self.__cacheTime).seconds > self.__cacheDuration
-
-    def clear_cache(self):
-        with self.__lock:
-            self.__cache = None
-            self.__cacheTime = None
+        # cached too, so per-device coordinators share one bulk fetch
+        return self._get_or_update_cache(accessor)

--- a/PyViCare/PyViCareCachedServiceViaGateway.py
+++ b/PyViCare/PyViCareCachedServiceViaGateway.py
@@ -1,0 +1,92 @@
+import logging
+import threading
+from datetime import datetime
+from typing import Any, Optional
+
+from PyViCare.PyViCareAbstractOAuthManager import AbstractViCareOAuthManager
+from PyViCare.PyViCareService import ViCareDeviceAccessor, readFeature
+from PyViCare.PyViCareServiceViaGateway import (
+    ViCareServiceViaGateway, filter_features_for_device)
+from PyViCare.PyViCareUtils import (PyViCareDeviceCommunicationError,
+                                    PyViCareInternalServerError,
+                                    PyViCareInvalidDataError,
+                                    PyViCareNotPaidForError,
+                                    PyViCareNotSupportedFeatureError,
+                                    ViCareTimer)
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+
+class ViCareCachedServiceViaGateway(ViCareServiceViaGateway):
+    """Cached variant of the gateway bulk-fetch service.
+
+    A single instance is shared across all devices on the gateway. The bulk
+    response is cached once per (oauth, gateway) and every device's
+    getProperty reads from the same cached payload. setProperty invalidates
+    the whole cache because writes can affect any feature on any device.
+    """
+
+    def __init__(self, oauth_manager: AbstractViCareOAuthManager, cacheDuration: int) -> None:
+        ViCareServiceViaGateway.__init__(self, oauth_manager)
+        self.__cacheDuration = cacheDuration
+        self.__cache: Optional[dict] = None
+        self.__cacheTime: Optional[datetime] = None
+        self.__lock = threading.Lock()
+
+    def getProperty(self, accessor: ViCareDeviceAccessor, property_name: str) -> Any:
+        data = self.__get_or_update_cache(accessor)
+        entities = filter_features_for_device(data["data"], accessor.device_id)
+        return readFeature(entities, property_name)
+
+    def fetch_all_features(self, accessor: ViCareDeviceAccessor) -> Any:
+        # Cached too: in gateway mode there is exactly one bulk endpoint per
+        # gateway, so concurrent fetch_all_features() callers (e.g. one
+        # DataUpdateCoordinator per device) all consume the same response.
+        # Returning the cached payload here is the only way the shared
+        # service actually delivers the API-call savings.
+        return self.__get_or_update_cache(accessor)
+
+    def setProperty(self, accessor: ViCareDeviceAccessor, property_name: str, action: str, data: Any) -> Any:
+        response = super().setProperty(accessor, property_name, action, data)
+        self.clear_cache()
+        return response
+
+    def _fetch_bulk_uncached(self, accessor: ViCareDeviceAccessor) -> Any:
+        return super().fetch_all_features(accessor)
+
+    def __get_or_update_cache(self, accessor: ViCareDeviceAccessor):
+        with self.__lock:
+            if self.is_cache_invalid():
+                # we always set the cache time before we fetch the data
+                # to avoid consuming all the api calls if the api is down
+                # see https://github.com/home-assistant/core/issues/67052
+                # we simply return the old cache in this case
+                self.__cacheTime = ViCareTimer().now()
+
+                try:
+                    data = self._fetch_bulk_uncached(accessor)
+                except PyViCareNotPaidForError as e:
+                    logger.error("Viessmann API denied access (PACKAGE_NOT_PAID_FOR). Features unavailable: %s", e)
+                    if self.__cache is not None:
+                        return self.__cache
+                    raise PyViCareNotSupportedFeatureError("PACKAGE_NOT_PAID_FOR")
+                except (PyViCareDeviceCommunicationError, PyViCareInternalServerError) as e:
+                    if self.__cache is not None:
+                        logger.warning("API error, returning stale cache: %s", e)
+                        return self.__cache
+                    raise
+
+                if "data" not in data:
+                    logger.error("Missing 'data' property when fetching data.")
+                    raise PyViCareInvalidDataError(data)
+                self.__cache = data
+            return self.__cache
+
+    def is_cache_invalid(self) -> bool:
+        return self.__cache is None or self.__cacheTime is None or (ViCareTimer().now() - self.__cacheTime).seconds > self.__cacheDuration
+
+    def clear_cache(self):
+        with self.__lock:
+            self.__cache = None
+            self.__cacheTime = None

--- a/PyViCare/PyViCareCachedServiceViaGateway.py
+++ b/PyViCare/PyViCareCachedServiceViaGateway.py
@@ -19,7 +19,7 @@ class ViCareCachedServiceViaGateway(ViCareCachedServiceBase, ViCareServiceViaGat
     whole cache.
     """
 
-    def __init__(self, oauth_manager: AbstractViCareOAuthManager, cacheDuration: int) -> None:
+    def __init__(self, oauth_manager: AbstractViCareOAuthManager, cacheDuration: int) -> None:  # pylint: disable=super-init-not-called
         ViCareServiceViaGateway.__init__(self, oauth_manager)
         self._init_cache(cacheDuration)
 

--- a/PyViCare/PyViCareDevice.py
+++ b/PyViCare/PyViCareDevice.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from PyViCare.PyViCareService import ViCareDeviceAccessor, ViCareService
+from PyViCare.PyViCareService import ViCareDeviceAccessor, ViCareService, hasRoles
 from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError, handleAPICommandErrors, handleNotSupported
 
 
@@ -11,9 +11,10 @@ class Device:
     Note that currently, a new token is generated for each run.
     """
 
-    def __init__(self, accessor: ViCareDeviceAccessor, service: ViCareService) -> None:
+    def __init__(self, accessor: ViCareDeviceAccessor, service: ViCareService, roles: list[str] | None = None) -> None:
         self.accessor = accessor
         self.service = service
+        self.roles = roles if roles is not None else []
 
     def getProperty(self, property_name: str) -> Any:
         return self.service.getProperty(self.accessor, property_name)
@@ -30,10 +31,10 @@ class Device:
         return list[Any](self.getProperty("device.messages.errors.raw")["properties"]["entries"]["value"])
 
     def isLegacyDevice(self) -> bool:
-        return self.service.hasRoles(["type:legacy"])
+        return hasRoles(["type:legacy"], self.roles)
 
     def isE3Device(self) -> bool:
-        return self.service.hasRoles(["type:E3"])
+        return hasRoles(["type:E3"], self.roles)
 
     def isDomesticHotWaterDevice(self):
         return self._isTypeDevice("heating.dhw")

--- a/PyViCare/PyViCareDeviceConfig.py
+++ b/PyViCare/PyViCareDeviceConfig.py
@@ -16,7 +16,8 @@ from PyViCare.PyViCareRoomSensor import RoomSensor
 from PyViCare.PyViCareRepeater import Repeater
 from PyViCare.PyViCareElectricalEnergySystem import ElectricalEnergySystem
 from PyViCare.PyViCareGateway import Gateway
-from PyViCare.PyViCareService import ViCareDeviceAccessor, ViCareService, hasRoles
+from PyViCare.PyViCareService import (ViCareDeviceAccessor, ViCareService,
+                                      hasRoles, is_gateway_role)
 from PyViCare.PyViCareUtils import PyViCareNotPaidForError
 from PyViCare.PyViCareVentilationDevice import VentilationDevice
 
@@ -105,13 +106,7 @@ class PyViCareDeviceConfig:
         return hasRoles(requested_roles, self.roles)
 
     def isGateway(self):
-        return (
-            self.hasRoles(["type:gateway;VitoconnectOpto1"])
-            or self.hasRoles(["type:gateway;VitoconnectOpto2/OT2"])
-            or self.hasRoles(["type:gateway;TCU100"])
-            or self.hasRoles(["type:gateway;TCU200"])
-            or self.hasRoles(["type:gateway;TCU300"])
-        )
+        return is_gateway_role(self.roles)
 
     # see: https://vitodata300.viessmann.com/vd300/ApplicationHelp/VD300/1031_de_DE/Ger%C3%A4teliste.html
     def asAutoDetectDevice(self):

--- a/PyViCare/PyViCareDeviceConfig.py
+++ b/PyViCare/PyViCareDeviceConfig.py
@@ -16,7 +16,7 @@ from PyViCare.PyViCareRoomSensor import RoomSensor
 from PyViCare.PyViCareRepeater import Repeater
 from PyViCare.PyViCareElectricalEnergySystem import ElectricalEnergySystem
 from PyViCare.PyViCareGateway import Gateway
-from PyViCare.PyViCareService import ViCareDeviceAccessor, ViCareService
+from PyViCare.PyViCareService import ViCareDeviceAccessor, ViCareService, hasRoles
 from PyViCare.PyViCareUtils import PyViCareNotPaidForError
 from PyViCare.PyViCareVentilationDevice import VentilationDevice
 
@@ -36,52 +36,52 @@ class PyViCareDeviceConfig:
         self.roles = roles if roles is not None else []
 
     def asGeneric(self):
-        return HeatingDevice(self.accessor, self.service)
+        return HeatingDevice(self.accessor, self.service, self.roles)
 
     def asGazBoiler(self):
-        return GazBoiler(self.accessor, self.service)
+        return GazBoiler(self.accessor, self.service, self.roles)
 
     def asFuelCell(self):
-        return FuelCell(self.accessor, self.service)
+        return FuelCell(self.accessor, self.service, self.roles)
 
     def asHeatPump(self):
-        return HeatPump(self.accessor, self.service)
+        return HeatPump(self.accessor, self.service, self.roles)
 
     def asOilBoiler(self):
-        return OilBoiler(self.accessor, self.service)
+        return OilBoiler(self.accessor, self.service, self.roles)
 
     def asPelletsBoiler(self):
-        return PelletsBoiler(self.accessor, self.service)
+        return PelletsBoiler(self.accessor, self.service, self.roles)
 
     def asHybridDevice(self):
-        return Hybrid(self.accessor, self.service)
+        return Hybrid(self.accessor, self.service, self.roles)
 
     def asRadiatorActuator(self):
-        return RadiatorActuator(self.accessor, self.service)
+        return RadiatorActuator(self.accessor, self.service, self.roles)
 
     def asFloorHeating(self):
-        return FloorHeating(self.accessor, self.service)
+        return FloorHeating(self.accessor, self.service, self.roles)
 
     def asFloorHeatingChannel(self):
-        return FloorHeatingChannel(self.accessor, self.service)
+        return FloorHeatingChannel(self.accessor, self.service, self.roles)
 
     def asRoomSensor(self):
-        return RoomSensor(self.accessor, self.service)
+        return RoomSensor(self.accessor, self.service, self.roles)
 
     def asRoomControl(self):
-        return RoomControl(self.accessor, self.service)
+        return RoomControl(self.accessor, self.service, self.roles)
 
     def asRepeater(self):
-        return Repeater(self.accessor, self.service)
+        return Repeater(self.accessor, self.service, self.roles)
 
     def asElectricalEnergySystem(self):
-        return ElectricalEnergySystem(self.accessor, self.service)
+        return ElectricalEnergySystem(self.accessor, self.service, self.roles)
 
     def asGateway(self):
-        return Gateway(self.accessor, self.service)
+        return Gateway(self.accessor, self.service, self.roles)
 
     def asVentilation(self):
-        return VentilationDevice(self.accessor, self.service)
+        return VentilationDevice(self.accessor, self.service, self.roles)
 
     def getConfig(self):
         return self.accessor
@@ -101,8 +101,17 @@ class PyViCareDeviceConfig:
     def getRoles(self):
         return self.roles
 
+    def hasRoles(self, requested_roles):
+        return hasRoles(requested_roles, self.roles)
+
     def isGateway(self):
-        return self.service._isGateway()  # pylint: disable=protected-access
+        return (
+            self.hasRoles(["type:gateway;VitoconnectOpto1"])
+            or self.hasRoles(["type:gateway;VitoconnectOpto2/OT2"])
+            or self.hasRoles(["type:gateway;TCU100"])
+            or self.hasRoles(["type:gateway;TCU200"])
+            or self.hasRoles(["type:gateway;TCU300"])
+        )
 
     # see: https://vitodata300.viessmann.com/vd300/ApplicationHelp/VD300/1031_de_DE/Ger%C3%A4teliste.html
     def asAutoDetectDevice(self):
@@ -131,7 +140,7 @@ class PyViCareDeviceConfig:
         ]
 
         for (creator_method, type_name, roles) in device_types:
-            if re.search(type_name, self.device_model) or self.service.hasRoles(roles):
+            if re.search(type_name, self.device_model) or self.hasRoles(roles):
                 logger.info("detected %s %s", self.device_model, creator_method.__name__)
                 device = creator_method()
                 if isinstance(device, (GazBoiler, HeatPump)) and not isinstance(device, Hybrid):

--- a/PyViCare/PyViCareHeatingDevice.py
+++ b/PyViCare/PyViCareHeatingDevice.py
@@ -2,6 +2,7 @@ from contextlib import suppress
 from typing import Any, List, Optional
 
 from PyViCare.PyViCareDevice import Device
+from PyViCare.PyViCareService import hasRoles
 from PyViCare.PyViCareHeatCurveCalculation import (
     heat_curve_formular_variant1, heat_curve_formular_variant2)
 from PyViCare.PyViCareUtils import (VICARE_DAYS,
@@ -48,9 +49,9 @@ class HeatingDevice(Device):
         return HeatingCircuit(self, circuit)
 
     def get_heat_curve_formular(self):
-        if self.service.hasRoles(["type:heatpump", "type:E3"]):
+        if hasRoles(["type:heatpump", "type:E3"], self.roles):
             return heat_curve_formular_variant1
-        if self.service.hasRoles(["type:heatpump"]) and len(self.getAvailableCircuits()) == 1:
+        if hasRoles(["type:heatpump"], self.roles) and len(self.getAvailableCircuits()) == 1:
             return heat_curve_formular_variant2
         return heat_curve_formular_variant1
 

--- a/PyViCare/PyViCareService.py
+++ b/PyViCare/PyViCareService.py
@@ -20,6 +20,17 @@ def readFeature(entities, property_name):
 def hasRoles(requested_roles: List[str], existing_roles: List[str]) -> bool:
     return len(requested_roles) > 0 and set(requested_roles).issubset(set(existing_roles))
 
+GATEWAY_ROLES = [
+    "type:gateway;VitoconnectOpto1",
+    "type:gateway;VitoconnectOpto2/OT2",
+    "type:gateway;TCU100",
+    "type:gateway;TCU200",
+    "type:gateway;TCU300",
+]
+
+def is_gateway_role(roles: List[str]) -> bool:
+    return any(hasRoles([role], roles) for role in GATEWAY_ROLES)
+
 def buildSetPropertyUrl(accessor, property_name, action):
     return f'/features/installations/{accessor.id}/gateways/{accessor.serial}/devices/{accessor.device_id}/features/{property_name}/commands/{action}'
 
@@ -39,15 +50,12 @@ class ViCareService:
         return self.oauth_manager.get(url)
 
     def buildGetPropertyUrl(self, accessor: ViCareDeviceAccessor, property_name):
-        if self._isGateway():
+        if is_gateway_role(self.roles):
             return f'/features/installations/{accessor.id}/gateways/{accessor.serial}/features/{property_name}'
         return f'/features/installations/{accessor.id}/gateways/{accessor.serial}/devices/{accessor.device_id}/features/{property_name}'
 
     def hasRoles(self, requested_roles) -> bool:
         return hasRoles(requested_roles, self.roles)
-
-    def _isGateway(self) -> bool:
-        return self.hasRoles(["type:gateway;VitoconnectOpto1"]) or self.hasRoles(["type:gateway;VitoconnectOpto2/OT2"]) or self.hasRoles(["type:gateway;TCU100"]) or self.hasRoles(["type:gateway;TCU200"]) or self.hasRoles(["type:gateway;TCU300"])
 
     def setProperty(self, accessor: ViCareDeviceAccessor, property_name: str, action: str, data: Any) -> Any:
         url = buildSetPropertyUrl(accessor, property_name, action)
@@ -57,7 +65,7 @@ class ViCareService:
 
     def fetch_all_features(self, accessor: ViCareDeviceAccessor) -> Any:
         url = f'/features/installations/{accessor.id}/gateways/{accessor.serial}/devices/{accessor.device_id}/features/'
-        if self._isGateway():
+        if is_gateway_role(self.roles):
             url = f'/features/installations/{accessor.id}/gateways/{accessor.serial}/features/'
         return self.oauth_manager.get(url)
 

--- a/PyViCare/PyViCareServiceViaGateway.py
+++ b/PyViCare/PyViCareServiceViaGateway.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 
-def filter_features_for_device(entities, device_id: str):
+def filter_features_for_device(entities: list[dict[str, Any]], device_id: str) -> list[dict[str, Any]]:
     device_segment = f"/devices/{device_id}/"
     return [e for e in entities if device_segment in e.get("uri", "")]
 

--- a/PyViCare/PyViCareServiceViaGateway.py
+++ b/PyViCare/PyViCareServiceViaGateway.py
@@ -1,0 +1,38 @@
+import logging
+from typing import Any
+
+from PyViCare.PyViCareAbstractOAuthManager import AbstractViCareOAuthManager
+from PyViCare.PyViCareService import (ViCareDeviceAccessor, ViCareService,
+                                      readFeature)
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+
+def filter_features_for_device(entities, device_id: str):
+    device_segment = f"/devices/{device_id}/"
+    return [e for e in entities if device_segment in e.get("uri", "")]
+
+
+class ViCareServiceViaGateway(ViCareService):
+    """Service that reads all device features from the gateway-wide bulk endpoint.
+
+    One instance can serve multiple devices on the same gateway: the bulk
+    response contains features for all devices, and getProperty filters by
+    accessor.device_id at read time.
+    """
+
+    def __init__(self, oauth_manager: AbstractViCareOAuthManager) -> None:
+        ViCareService.__init__(self, oauth_manager, [])
+
+    def getProperty(self, accessor: ViCareDeviceAccessor, property_name: str) -> Any:
+        data = self.fetch_all_features(accessor)
+        entities = filter_features_for_device(data["data"], accessor.device_id)
+        return readFeature(entities, property_name)
+
+    def fetch_all_features(self, accessor: ViCareDeviceAccessor) -> Any:
+        url = (
+            f'/features/installations/{accessor.id}'
+            f'/gateways/{accessor.serial}/features?includeDevicesFeatures=true'
+        )
+        return self.oauth_manager.get(url)

--- a/tests/ViCareServiceMock.py
+++ b/tests/ViCareServiceMock.py
@@ -42,6 +42,3 @@ class ViCareServiceMock:
 
     def hasRoles(self, _requested_roles):
         return False
-
-    def _isGateway(self):
-        return False

--- a/tests/response/gatewayWithDevices/heatbox1/Vitodens-300-W-B3HA.json
+++ b/tests/response/gatewayWithDevices/heatbox1/Vitodens-300-W-B3HA.json
@@ -1,0 +1,995 @@
+{
+  "data": [
+      {
+          "feature": "gateway.devices",
+          "gatewayId": "1234567812345678",
+          "timestamp": "2024-12-30T09:35:39.088Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/features/gateway.devices",
+          "properties": {
+              "devices": {
+                  "type": "DeviceList",
+                  "value": [
+                      {
+                          "id": "gateway",
+                          "fingerprint": "gw:hb1,mj:2,mi:8,p:0",
+                          "modelId": "Heatbox1",
+                          "modelVersion": "Xkoj4ZDilfHcRmW_Cfq18DAFtHw",
+                          "name": "Heatbox 1, Vitoconnect",
+                          "type": "vitoconnect",
+                          "roles": [
+                              "type:gateway;VitoconnectOpto1",
+                              "type:legacy"
+                          ],
+                          "status": "online"
+                      },
+                      {
+                          "id": "0",
+                          "fingerprint": "gg:20,gk:cb,si:43,esi:65535",
+                          "modelId": "VScotHO1_40",
+                          "modelVersion": "fgeuENFo7Q2FW2xbH463_tbwzyI",
+                          "name": "VT 200 (HO1A / HO1B)",
+                          "type": "heating",
+                          "roles": [
+                              "capability:productionReport;electric",
+                              "type:boiler",
+                              "type:dhw;integrated",
+                              "type:heating;integrated",
+                              "type:legacy",
+                              "type:product;VScotHO1"
+                          ],
+                          "status": "online"
+                      }
+                  ]
+              }
+          },
+          "commands": {}
+      },
+      {
+          "feature": "gateway.wifi",
+          "gatewayId": "1234567812345678",
+          "timestamp": "2024-12-31T00:32:56.737Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/features/gateway.wifi",
+          "properties": {
+              "strength": {
+                  "type": "number",
+                  "value": -47,
+                  "unit": ""
+              }
+          },
+          "commands": {}
+      },
+      {
+          "feature": "device.messages.errors.raw",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-30T09:35:46.843Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/device.messages.errors.raw",
+          "properties": {
+              "entries": {
+                  "type": "array",
+                  "value": []
+              }
+          },
+          "commands": {}
+      },
+      {
+          "feature": "device.serial",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-30T09:35:46.843Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/device.serial",
+          "properties": {
+              "value": {
+                  "type": "string",
+                  "value": "################"
+              }
+          },
+          "commands": {}
+      },
+      {
+          "feature": "heating.boiler.sensors.temperature.main",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-31T00:36:05.916Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.boiler.sensors.temperature.main",
+          "properties": {
+              "value": {
+                  "type": "number",
+                  "value": 35,
+                  "unit": "celsius"
+              },
+              "status": {
+                  "type": "string",
+                  "value": "connected"
+              }
+          },
+          "commands": {}
+      },
+      {
+          "feature": "heating.boiler.serial",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-30T09:35:46.843Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.boiler.serial",
+          "properties": {
+              "value": {
+                  "type": "string",
+                  "value": "################"
+              }
+          },
+          "commands": {}
+      },
+      {
+          "feature": "heating.boiler.temperature",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-31T00:10:16.279Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.boiler.temperature",
+          "properties": {
+              "value": {
+                  "type": "number",
+                  "value": 36.3,
+                  "unit": "celsius"
+              }
+          },
+          "commands": {}
+      },
+      {
+          "feature": "heating.burners",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-30T09:35:39.269Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.burners",
+          "properties": {
+              "enabled": {
+                  "type": "array",
+                  "value": [
+                      "0"
+                  ]
+              }
+          },
+          "commands": {}
+      },
+      {
+          "feature": "heating.burners.0.modulation",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-31T00:29:26.029Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.burners.0.modulation",
+          "properties": {
+              "value": {
+                  "type": "number",
+                  "value": 0,
+                  "unit": "percent"
+              }
+          },
+          "commands": {}
+      },
+      {
+          "feature": "heating.burners.0.statistics",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-31T00:06:22.999Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.burners.0.statistics",
+          "properties": {
+              "hours": {
+                  "type": "number",
+                  "value": 49541,
+                  "unit": "hour"
+              },
+              "starts": {
+                  "type": "number",
+                  "value": 218130,
+                  "unit": ""
+              }
+          },
+          "commands": {}
+      },
+      {
+          "feature": "heating.burners.0",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-31T00:29:23.934Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.burners.0",
+          "properties": {
+              "active": {
+                  "type": "boolean",
+                  "value": false
+              }
+          },
+          "commands": {}
+      },
+      {
+          "feature": "heating.circuits",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-30T09:35:46.843Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits",
+          "properties": {
+              "enabled": {
+                  "type": "array",
+                  "value": [
+                      "0"
+                  ]
+              }
+          },
+          "commands": {}
+      },
+      {
+          "feature": "heating.circuits.0.circulation.pump",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-30T22:44:32.617Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.circulation.pump",
+          "properties": {
+              "status": {
+                  "type": "string",
+                  "value": "on"
+              }
+          },
+          "commands": {}
+      },
+      {
+          "feature": "heating.circuits.0.frostprotection",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-30T09:35:46.843Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.frostprotection",
+          "properties": {
+              "status": {
+                  "type": "string",
+                  "value": "off"
+              }
+          },
+          "commands": {}
+      },
+      {
+          "feature": "heating.circuits.0.heating.curve",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-30T09:35:47.579Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.heating.curve",
+          "properties": {
+              "shift": {
+                  "type": "number",
+                  "value": 2,
+                  "unit": ""
+              },
+              "slope": {
+                  "type": "number",
+                  "value": 1.4,
+                  "unit": ""
+              }
+          },
+          "commands": {
+              "setCurve": {
+                  "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve",
+                  "name": "setCurve",
+                  "isExecutable": true,
+                  "params": {
+                      "slope": {
+                          "type": "number",
+                          "required": true,
+                          "constraints": {
+                              "min": 0.2,
+                              "max": 3.5,
+                              "stepping": 0.1
+                          }
+                      },
+                      "shift": {
+                          "type": "number",
+                          "required": true,
+                          "constraints": {
+                              "min": -13,
+                              "max": 40,
+                              "stepping": 1
+                          }
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "feature": "heating.circuits.0.heating.schedule",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-30T09:35:46.843Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.heating.schedule",
+          "properties": {
+              "entries": {
+                  "type": "Schedule",
+                  "value": {
+                      "mon": [
+                          {
+                              "start": "06:00",
+                              "end": "22:00",
+                              "mode": "normal",
+                              "position": 0
+                          }
+                      ],
+                      "tue": [
+                          {
+                              "start": "06:00",
+                              "end": "22:00",
+                              "mode": "normal",
+                              "position": 0
+                          }
+                      ],
+                      "wed": [
+                          {
+                              "start": "06:00",
+                              "end": "22:00",
+                              "mode": "normal",
+                              "position": 0
+                          }
+                      ],
+                      "thu": [
+                          {
+                              "start": "06:00",
+                              "end": "22:00",
+                              "mode": "normal",
+                              "position": 0
+                          }
+                      ],
+                      "fri": [
+                          {
+                              "start": "06:00",
+                              "end": "22:00",
+                              "mode": "normal",
+                              "position": 0
+                          }
+                      ],
+                      "sat": [
+                          {
+                              "start": "07:00",
+                              "end": "23:00",
+                              "mode": "normal",
+                              "position": 0
+                          }
+                      ],
+                      "sun": [
+                          {
+                              "start": "07:00",
+                              "end": "23:00",
+                              "mode": "normal",
+                              "position": 0
+                          }
+                      ]
+                  }
+              },
+              "active": {
+                  "type": "boolean",
+                  "value": true
+              }
+          },
+          "commands": {
+              "setSchedule": {
+                  "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule",
+                  "name": "setSchedule",
+                  "isExecutable": true,
+                  "params": {
+                      "newSchedule": {
+                          "type": "Schedule",
+                          "required": true,
+                          "constraints": {
+                              "modes": [
+                                  "normal"
+                              ],
+                              "maxEntries": 4,
+                              "resolution": 10,
+                              "defaultMode": "reduced",
+                              "overlapAllowed": true
+                          }
+                      }
+                  }
+              },
+              "resetSchedule": {
+                  "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.heating.schedule/commands/resetSchedule",
+                  "name": "resetSchedule",
+                  "isExecutable": false,
+                  "params": {}
+              }
+          }
+      },
+      {
+          "feature": "heating.circuits.0.operating.modes.active",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-30T09:35:46.843Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.modes.active",
+          "properties": {
+              "value": {
+                  "type": "string",
+                  "value": "heating"
+              }
+          },
+          "commands": {
+              "setMode": {
+                  "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode",
+                  "name": "setMode",
+                  "isExecutable": true,
+                  "params": {
+                      "mode": {
+                          "type": "string",
+                          "required": true,
+                          "constraints": {
+                              "enum": [
+                                  "forcedNormal",
+                                  "forcedReduced",
+                                  "heating",
+                                  "standby"
+                              ]
+                          }
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "feature": "heating.circuits.0.operating.modes.forcedNormal",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-30T09:35:46.843Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.modes.forcedNormal",
+          "properties": {
+              "active": {
+                  "type": "boolean",
+                  "value": false
+              }
+          },
+          "commands": {}
+      },
+      {
+          "feature": "heating.circuits.0.operating.modes.forcedReduced",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-30T09:35:46.843Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.modes.forcedReduced",
+          "properties": {
+              "active": {
+                  "type": "boolean",
+                  "value": false
+              }
+          },
+          "commands": {}
+      },
+      {
+          "feature": "heating.circuits.0.operating.modes.heating",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-30T09:35:46.843Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.modes.heating",
+          "properties": {
+              "active": {
+                  "type": "boolean",
+                  "value": true
+              }
+          },
+          "commands": {}
+      },
+      {
+          "feature": "heating.circuits.0.operating.modes.standby",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-30T09:35:46.843Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.modes.standby",
+          "properties": {
+              "active": {
+                  "type": "boolean",
+                  "value": false
+              }
+          },
+          "commands": {}
+      },
+      {
+          "feature": "heating.circuits.0.operating.programs.active",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-30T20:59:17.072Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.programs.active",
+          "properties": {
+              "value": {
+                  "type": "string",
+                  "value": "reduced"
+              }
+          },
+          "commands": {}
+      },
+      {
+          "feature": "heating.circuits.0.operating.programs.comfort",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-30T09:35:46.843Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.programs.comfort",
+          "properties": {
+              "temperature": {
+                  "type": "number",
+                  "value": 21,
+                  "unit": "celsius"
+              },
+              "active": {
+                  "type": "boolean",
+                  "value": false
+              },
+              "demand": {
+                  "type": "string",
+                  "value": "unknown"
+              }
+          },
+          "commands": {
+              "activate": {
+                  "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/activate",
+                  "name": "activate",
+                  "isExecutable": false,
+                  "params": {
+                      "temperature": {
+                          "type": "number",
+                          "required": false,
+                          "constraints": {
+                              "min": 4,
+                              "max": 37,
+                              "stepping": 1
+                          }
+                      }
+                  }
+              },
+              "setTemperature": {
+                  "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/setTemperature",
+                  "name": "setTemperature",
+                  "isExecutable": true,
+                  "params": {
+                      "targetTemperature": {
+                          "type": "number",
+                          "required": true,
+                          "constraints": {
+                              "min": 4,
+                              "max": 37,
+                              "stepping": 1
+                          }
+                      }
+                  }
+              },
+              "deactivate": {
+                  "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/deactivate",
+                  "name": "deactivate",
+                  "isExecutable": false,
+                  "params": {}
+              }
+          }
+      },
+      {
+          "feature": "heating.circuits.0.operating.programs.eco",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-30T20:59:17.072Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.programs.eco",
+          "properties": {
+              "active": {
+                  "type": "boolean",
+                  "value": false
+              },
+              "temperature": {
+                  "type": "number",
+                  "value": 21,
+                  "unit": "celsius"
+              }
+          },
+          "commands": {
+              "activate": {
+                  "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.programs.eco/commands/activate",
+                  "name": "activate",
+                  "isExecutable": false,
+                  "params": {}
+              },
+              "deactivate": {
+                  "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.programs.eco/commands/deactivate",
+                  "name": "deactivate",
+                  "isExecutable": false,
+                  "params": {}
+              }
+          }
+      },
+      {
+          "feature": "heating.circuits.0.operating.programs.external",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-30T09:35:46.843Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.programs.external",
+          "properties": {
+              "active": {
+                  "type": "boolean",
+                  "value": false
+              },
+              "temperature": {
+                  "type": "number",
+                  "value": 0,
+                  "unit": ""
+              }
+          },
+          "commands": {}
+      },
+      {
+          "feature": "heating.circuits.0.operating.programs.normal",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-30T20:59:17.072Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.programs.normal",
+          "properties": {
+              "active": {
+                  "type": "boolean",
+                  "value": false
+              },
+              "demand": {
+                  "type": "string",
+                  "value": "unknown"
+              },
+              "temperature": {
+                  "type": "number",
+                  "value": 21,
+                  "unit": "celsius"
+              }
+          },
+          "commands": {
+              "setTemperature": {
+                  "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature",
+                  "name": "setTemperature",
+                  "isExecutable": true,
+                  "params": {
+                      "targetTemperature": {
+                          "required": true,
+                          "constraints": {
+                              "min": 3,
+                              "max": 37,
+                              "stepping": 1
+                          },
+                          "type": "number"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "feature": "heating.circuits.0.operating.programs.reduced",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-30T20:59:17.072Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.programs.reduced",
+          "properties": {
+              "active": {
+                  "type": "boolean",
+                  "value": true
+              },
+              "demand": {
+                  "type": "string",
+                  "value": "unknown"
+              },
+              "temperature": {
+                  "type": "number",
+                  "value": 16,
+                  "unit": "celsius"
+              }
+          },
+          "commands": {
+              "setTemperature": {
+                  "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.programs.reduced/commands/setTemperature",
+                  "name": "setTemperature",
+                  "isExecutable": true,
+                  "params": {
+                      "targetTemperature": {
+                          "required": true,
+                          "constraints": {
+                              "min": 3,
+                              "max": 37,
+                              "stepping": 1
+                          },
+                          "type": "number"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "feature": "heating.circuits.0.operating.programs.standby",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-30T09:35:46.843Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.programs.standby",
+          "properties": {
+              "active": {
+                  "type": "boolean",
+                  "value": false
+              }
+          },
+          "commands": {}
+      },
+      {
+          "feature": "heating.circuits.0.sensors.temperature.supply",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-31T00:35:45.591Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.sensors.temperature.supply",
+          "properties": {
+              "value": {
+                  "type": "number",
+                  "value": 35.5,
+                  "unit": "celsius"
+              },
+              "status": {
+                  "type": "string",
+                  "value": "connected"
+              }
+          },
+          "commands": {}
+      },
+      {
+          "feature": "heating.circuits.0",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-30T09:35:46.843Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0",
+          "properties": {
+              "active": {
+                  "type": "boolean",
+                  "value": true
+              },
+              "name": {
+                  "type": "string",
+                  "value": "Heizkreis OG"
+              },
+              "type": {
+                  "type": "string",
+                  "value": "heatingCircuit"
+              }
+          },
+          "commands": {
+              "setName": {
+                  "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0/commands/setName",
+                  "name": "setName",
+                  "isExecutable": true,
+                  "params": {
+                      "name": {
+                          "type": "string",
+                          "required": true,
+                          "constraints": {
+                              "minLength": 1,
+                              "maxLength": 20
+                          }
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "feature": "heating.controller.serial",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-30T09:35:46.843Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.controller.serial",
+          "properties": {
+              "value": {
+                  "type": "string",
+                  "value": ""
+              }
+          },
+          "commands": {}
+      },
+      {
+          "feature": "heating.operating.programs.holiday",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-30T09:35:47.579Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.operating.programs.holiday",
+          "properties": {
+              "active": {
+                  "type": "boolean",
+                  "value": false
+              },
+              "start": {
+                  "type": "string",
+                  "value": ""
+              },
+              "end": {
+                  "type": "string",
+                  "value": ""
+              }
+          },
+          "commands": {
+              "changeEndDate": {
+                  "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate",
+                  "name": "changeEndDate",
+                  "isExecutable": false,
+                  "params": {
+                      "end": {
+                          "type": "string",
+                          "required": true,
+                          "constraints": {
+                              "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
+                              "sameDayAllowed": false
+                          }
+                      }
+                  }
+              },
+              "schedule": {
+                  "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.operating.programs.holiday/commands/schedule",
+                  "name": "schedule",
+                  "isExecutable": true,
+                  "params": {
+                      "start": {
+                          "type": "string",
+                          "required": true,
+                          "constraints": {
+                              "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$"
+                          }
+                      },
+                      "end": {
+                          "type": "string",
+                          "required": true,
+                          "constraints": {
+                              "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
+                              "sameDayAllowed": false
+                          }
+                      }
+                  }
+              },
+              "unschedule": {
+                  "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.operating.programs.holiday/commands/unschedule",
+                  "name": "unschedule",
+                  "isExecutable": true,
+                  "params": {}
+              }
+          }
+      },
+      {
+          "feature": "heating.sensors.temperature.outside",
+          "gatewayId": "1234567812345678",
+          "deviceId": "0",
+          "timestamp": "2024-12-30T22:16:07.625Z",
+          "isEnabled": true,
+          "isReady": true,
+          "apiVersion": 1,
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.sensors.temperature.outside",
+          "properties": {
+              "value": {
+                  "type": "number",
+                  "value": 6.4,
+                  "unit": "celsius"
+              },
+              "status": {
+                  "type": "string",
+                  "value": "connected"
+              }
+          },
+          "commands": {}
+      },
+      {
+          "apiVersion": 1,
+          "isEnabled": true,
+          "isReady": true,
+          "timestamp": "2024-12-30T09:35:46.843Z",
+          "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.name",
+          "feature": "heating.circuits.0.name",
+          "deviceId": "0",
+          "gatewayId": "1234567812345678",
+          "components": [],
+          "commands": {
+              "setName": {
+                  "uri": "https://api.viessmann.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.name/commands/setName",
+                  "name": "setName",
+                  "isExecutable": true,
+                  "params": {
+                      "name": {
+                          "type": "string",
+                          "required": true,
+                          "constraints": {
+                              "minLength": 1,
+                              "maxLength": 20
+                          }
+                      }
+                  }
+              }
+          },
+          "properties": {
+              "name": {
+                  "type": "string",
+                  "value": "Heizkreis OG"
+              }
+          }
+      }
+  ]
+}

--- a/tests/response/gatewayWithDevices/heatbox2/Vitodens-300-W-WB3D-with-TRV.json
+++ b/tests/response/gatewayWithDevices/heatbox2/Vitodens-300-W-WB3D-with-TRV.json
@@ -1,0 +1,2610 @@
+{
+    "data": [
+        {
+            "feature": "gateway.devices",
+            "gatewayId": "1234567812345678",
+            "timestamp": "2025-10-15T01:22:15.903Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/features/gateway.devices",
+            "properties": {
+                "devices": {
+                    "type": "DeviceList",
+                    "value": [
+                        {
+                            "id": "gateway",
+                            "fingerprint": "gw:hb2,mj:2,mi:51,p:5",
+                            "modelId": "Heatbox2_SRC",
+                            "modelVersion": "4kpuORsfPdzAPz3mRmDbihveTRA",
+                            "name": "Heatbox2_SRC",
+                            "type": "vitoconnect",
+                            "roles": [
+                                "capability:src",
+                                "type:gateway;VitoconnectOpto2/OT2",
+                                "type:gatewayConfiguration",
+                                "type:hb2",
+                                "type:legacy"
+                            ],
+                            "status": "online"
+                        },
+                        {
+                            "id": "RoomControl-1",
+                            "fingerprint": "src:hb2:ext,mj:2,mi:51,p:5",
+                            "modelId": "Smart_RoomControl",
+                            "modelVersion": "JL6oCC5_OSGxElBWK5kOOHeL0eI",
+                            "name": "Smart_RoomControl",
+                            "type": "roomControl",
+                            "roles": [
+                                "capability:monetization;FTDC",
+                                "capability:monetization;OWD",
+                                "capability:src;FTDC",
+                                "capability:src;OWD",
+                                "capability:zigbeeCoordinator",
+                                "type:legacy",
+                                "type:virtual;smartRoomControl"
+                            ],
+                            "status": "online"
+                        },
+                        {
+                            "id": "0",
+                            "fingerprint": "gg:20,gk:cb,si:43,esi:65535",
+                            "modelId": "VScotHO1_40",
+                            "modelVersion": "M5va9BMCLzvTp6q3kD5NIOS25oU",
+                            "name": "VScotHO1",
+                            "type": "heating",
+                            "roles": [
+                                "capability:productionReport;electric",
+                                "type:boiler",
+                                "type:brand;Viessmann",
+                                "type:dhw;integrated",
+                                "type:heating;integrated",
+                                "type:legacy",
+                                "type:product;VScotHO1"
+                            ],
+                            "status": "online"
+                        },
+                        {
+                            "id": "zigbee-1234567890abcdef",
+                            "fingerprint": "zigbee:trv,mj:2,mi:51,p:5",
+                            "modelId": "Smart_Device_eTRV_generic_50",
+                            "modelVersion": "ryss_zsbny6eKZG3frt9O4XRuS8",
+                            "name": "Smart_Device_eTRV_generic",
+                            "type": "zigbee",
+                            "roles": [
+                                "type:actuator",
+                                "type:legacy",
+                                "type:radiator",
+                                "type:smartRoomDevice"
+                            ],
+                            "status": "online"
+                        }
+                    ]
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "gateway.bmuconnection",
+            "gatewayId": "1234567812345678",
+            "timestamp": "2025-10-15T01:07:41.773Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/features/gateway.bmuconnection",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "OK"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "gateway.wifi",
+            "gatewayId": "1234567812345678",
+            "timestamp": "2025-10-16T11:26:55.930Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/features/gateway.wifi",
+            "properties": {
+                "strength": {
+                    "type": "number",
+                    "value": -72,
+                    "unit": ""
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "device.timezone",
+            "gatewayId": "1234567812345678",
+            "deviceId": "gateway",
+            "timestamp": "2025-10-15T01:22:16.368Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/gateway/features/device.timezone",
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "Europe/Berlin"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "tcu.wifi",
+            "gatewayId": "1234567812345678",
+            "deviceId": "gateway",
+            "timestamp": "2025-10-16T11:26:55.873Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/gateway/features/tcu.wifi",
+            "properties": {
+                "strength": {
+                    "type": "number",
+                    "value": -72,
+                    "unit": ""
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T01:22:16.385Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms",
+            "properties": {
+                "enabled": {
+                    "type": "array",
+                    "value": [
+                        "0"
+                    ]
+                }
+            },
+            "commands": {
+                "add": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms/commands/add",
+                    "name": "add",
+                    "isExecutable": true,
+                    "params": {
+                        "name": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "minLength": 1,
+                                "maxLength": 40,
+                                "regEx": "^[\\p{L}0-9]+( [\\p{L}0-9]+)*$"
+                            }
+                        },
+                        "type": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "enum": [
+                                    "bathroom",
+                                    "bedroom",
+                                    "hallway",
+                                    "livingroom",
+                                    "kitchen",
+                                    "office",
+                                    "nursery",
+                                    "toilet",
+                                    "other"
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "feature": "rooms.0",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T01:22:16.385Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "value": "Arbeitszimmer"
+                },
+                "type": {
+                    "type": "string",
+                    "value": "office"
+                },
+                "actors": {
+                    "type": "array",
+                    "value": [
+                        {
+                            "deviceId": "zigbee-1234567890abcdef",
+                            "heatingCircuit": 0
+                        }
+                    ]
+                }
+            },
+            "commands": {
+                "addActor": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0/commands/addActor",
+                    "name": "addActor",
+                    "isExecutable": true,
+                    "params": {
+                        "actorDeviceId": {
+                            "type": "string",
+                            "constraints": {},
+                            "required": true
+                        },
+                        "heatingCircuit": {
+                            "type": "number",
+                            "constraints": {
+                                "min": 0,
+                                "max": 3,
+                                "stepping": 1
+                            },
+                            "required": false
+                        }
+                    },
+                    "constraints": {
+                        "enum": [
+                            "cs",
+                            "fht",
+                            "trv",
+                            "airQualitySensor",
+                            "remoteControllerSensor"
+                        ]
+                    }
+                },
+                "moveActor": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0/commands/moveActor",
+                    "name": "moveActor",
+                    "isExecutable": true,
+                    "params": {
+                        "actorDeviceId": {
+                            "type": "string",
+                            "constraints": {},
+                            "required": true
+                        },
+                        "heatingCircuit": {
+                            "type": "number",
+                            "constraints": {
+                                "min": 0,
+                                "max": 3,
+                                "stepping": 1
+                            },
+                            "required": false
+                        },
+                        "newRoomId": {
+                            "type": "number",
+                            "constraints": {
+                                "min": 0,
+                                "max": 23,
+                                "stepping": 1
+                            },
+                            "required": true
+                        }
+                    }
+                },
+                "setName": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0/commands/setName",
+                    "name": "setName",
+                    "isExecutable": true,
+                    "params": {
+                        "name": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "regEx": "^[\\p{L}0-9]+( [\\p{L}0-9]+)*$",
+                                "minLength": 1,
+                                "maxLength": 40
+                            }
+                        }
+                    }
+                },
+                "setType": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0/commands/setType",
+                    "name": "setType",
+                    "isExecutable": true,
+                    "params": {
+                        "type": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "enum": [
+                                    "bathroom",
+                                    "bedroom",
+                                    "hallway",
+                                    "livingroom",
+                                    "kitchen",
+                                    "office",
+                                    "nursery",
+                                    "toilet",
+                                    "other"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "removeActor": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0/commands/removeActor",
+                    "name": "removeActor",
+                    "isExecutable": true,
+                    "params": {
+                        "actorDeviceId": {
+                            "type": "string",
+                            "constraints": {},
+                            "required": true
+                        }
+                    }
+                },
+                "remove": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0/commands/remove",
+                    "name": "remove",
+                    "isExecutable": true,
+                    "params": {}
+                }
+            }
+        },
+        {
+            "feature": "rooms.0.algorithm",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T01:22:16.385Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.algorithm",
+            "properties": {
+                "configuration": {
+                    "type": "object",
+                    "value": {
+                        "hydraulicBalance": true,
+                        "heatupSpeed": "normal",
+                        "trvAlgoActive": false,
+                        "openPointDetection": true,
+                        "virtualClimateSensor": false,
+                        "etrvSync": true,
+                        "useTrvOpenWindow": true,
+                        "heatOnTime": false
+                    }
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.0.childLock",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T01:22:16.385Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.childLock",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "inactive"
+                },
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {
+                "activate": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.childLock/commands/activate",
+                    "name": "activate",
+                    "isExecutable": true,
+                    "params": {}
+                },
+                "deactivate": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.childLock/commands/deactivate",
+                    "name": "deactivate",
+                    "isExecutable": true,
+                    "params": {}
+                },
+                "setActive": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.childLock/commands/setActive",
+                    "name": "setActive",
+                    "isExecutable": true,
+                    "params": {
+                        "active": {
+                            "type": "boolean",
+                            "required": true,
+                            "constraints": {}
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "feature": "rooms.0.condensationRisk",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T01:22:16.385Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.condensationRisk",
+            "properties": {
+                "value": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.0.configuration.hydraulicBalancing",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T01:22:16.385Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.configuration.hydraulicBalancing",
+            "properties": {
+                "value": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.0.configuration.openWindow",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T01:22:16.385Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.configuration.openWindow",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.0.configuration.trvAlgorithmActive",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T01:22:16.385Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.configuration.trvAlgorithmActive",
+            "properties": {
+                "value": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.0.configuration.window.openState",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T01:22:16.385Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.configuration.window.openState",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "commands": {},
+            "deprecated": {
+                "removalDate": "2024-09-15",
+                "info": "none"
+            }
+        },
+        {
+            "feature": "rooms.0.operating.programs.normalHeating",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-16T04:01:13.325Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.operating.programs.normalHeating",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                },
+                "temperature": {
+                    "type": "number",
+                    "value": 20,
+                    "unit": "celsius"
+                }
+            },
+            "commands": {
+                "setTemperature": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.operating.programs.normalHeating/commands/setTemperature",
+                    "name": "setTemperature",
+                    "isExecutable": true,
+                    "params": {
+                        "targetTemperature": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": 8,
+                                "max": 30,
+                                "stepping": 0.5
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "feature": "rooms.0.operating.programs.reducedHeating",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-16T03:15:12.758Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.operating.programs.reducedHeating",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                },
+                "temperature": {
+                    "type": "number",
+                    "value": 18,
+                    "unit": "celsius"
+                }
+            },
+            "commands": {
+                "setTemperature": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.operating.programs.reducedHeating/commands/setTemperature",
+                    "name": "setTemperature",
+                    "isExecutable": true,
+                    "params": {
+                        "targetTemperature": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": 8,
+                                "max": 30,
+                                "stepping": 0.5
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "feature": "rooms.0.operating.state",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-16T04:01:13.325Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.operating.state",
+            "properties": {
+                "level": {
+                    "type": "string",
+                    "value": "normal"
+                },
+                "demand": {
+                    "type": "string",
+                    "value": "heating"
+                },
+                "reason": {
+                    "type": "string",
+                    "value": "schedule"
+                },
+                "modifier": {
+                    "type": "string",
+                    "value": "none"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.0.quickmodes.manual",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-16T04:00:12.181Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.quickmodes.manual",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                },
+                "defaultDuration": {
+                    "type": "number",
+                    "value": 120,
+                    "unit": ""
+                }
+            },
+            "commands": {
+                "activate": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.quickmodes.manual/commands/activate",
+                    "name": "activate",
+                    "isExecutable": true,
+                    "params": {
+                        "temperature": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": 8,
+                                "max": 30,
+                                "stepping": 0.5
+                            }
+                        },
+                        "duration": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "enum": [
+                                    30,
+                                    60,
+                                    90,
+                                    120,
+                                    180,
+                                    210,
+                                    240,
+                                    360
+                                ]
+                            }
+                        }
+                    }
+                },
+                "setTemperature": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.quickmodes.manual/commands/setTemperature",
+                    "name": "setTemperature",
+                    "isExecutable": true,
+                    "params": {
+                        "targetTemperature": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": 8,
+                                "max": 30,
+                                "stepping": 0.5
+                            }
+                        }
+                    }
+                },
+                "deactivate": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.quickmodes.manual/commands/deactivate",
+                    "name": "deactivate",
+                    "isExecutable": true,
+                    "params": {}
+                }
+            }
+        },
+        {
+            "feature": "rooms.0.schedule",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T01:22:16.385Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.schedule",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                },
+                "entries": {
+                    "type": "Schedule",
+                    "value": {
+                        "mon": [
+                            {
+                                "position": 0,
+                                "mode": "normal",
+                                "start": "06:00",
+                                "end": "22:00"
+                            }
+                        ],
+                        "tue": [
+                            {
+                                "position": 0,
+                                "mode": "normal",
+                                "start": "06:00",
+                                "end": "22:00"
+                            }
+                        ],
+                        "wed": [
+                            {
+                                "position": 0,
+                                "mode": "normal",
+                                "start": "06:00",
+                                "end": "22:00"
+                            }
+                        ],
+                        "thu": [
+                            {
+                                "position": 0,
+                                "mode": "normal",
+                                "start": "06:00",
+                                "end": "22:00"
+                            }
+                        ],
+                        "fri": [
+                            {
+                                "position": 0,
+                                "mode": "normal",
+                                "start": "06:00",
+                                "end": "22:00"
+                            }
+                        ],
+                        "sat": [
+                            {
+                                "position": 0,
+                                "mode": "normal",
+                                "start": "06:00",
+                                "end": "22:00"
+                            }
+                        ],
+                        "sun": [
+                            {
+                                "position": 0,
+                                "mode": "normal",
+                                "start": "06:00",
+                                "end": "22:00"
+                            }
+                        ]
+                    }
+                }
+            },
+            "commands": {
+                "setSchedule": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.schedule/commands/setSchedule",
+                    "name": "setSchedule",
+                    "isExecutable": true,
+                    "params": {
+                        "newSchedule": {
+                            "type": "Schedule",
+                            "required": true,
+                            "constraints": {
+                                "modes": [
+                                    "normal"
+                                ],
+                                "maxEntries": 4,
+                                "resolution": 10,
+                                "defaultMode": "reduced",
+                                "overlapAllowed": false
+                            }
+                        }
+                    }
+                },
+                "resetSchedule": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.schedule/commands/resetSchedule",
+                    "name": "resetSchedule",
+                    "isExecutable": true,
+                    "params": {}
+                }
+            }
+        },
+        {
+            "feature": "rooms.0.sensors.co2",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T01:22:16.385Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.sensors.co2",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "notConnected"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.0.sensors.humidity",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T01:22:16.385Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.sensors.humidity",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "notConnected"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.0.sensors.openWindow",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T11:11:12.476Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.sensors.openWindow",
+            "properties": {
+                "value": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.0.sensors.temperature",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-16T11:26:13.133Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.sensors.temperature",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                },
+                "value": {
+                    "type": "number",
+                    "value": 20.6,
+                    "unit": "celsius"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.0.sensors.window.openState",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T11:11:12.476Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.sensors.window.openState",
+            "properties": {
+                "value": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {},
+            "deprecated": {
+                "removalDate": "2024-09-15",
+                "info": "none"
+            }
+        },
+        {
+            "feature": "rooms.0.temperature.levels.normal.heating",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T01:22:16.385Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.temperature.levels.normal.heating",
+            "properties": {
+                "temperature": {
+                    "type": "number",
+                    "value": 20,
+                    "unit": "celsius"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.0.temperature.levels.normal.perceived",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T01:22:16.385Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.temperature.levels.normal.perceived",
+            "properties": {
+                "temperature": {
+                    "type": "number",
+                    "value": 20,
+                    "unit": "celsius"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.0.temperature.levels.reduced.heating",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T01:22:16.385Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.temperature.levels.reduced.heating",
+            "properties": {
+                "temperature": {
+                    "type": "number",
+                    "value": 18,
+                    "unit": "celsius"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.0.temperature.reference",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T01:22:16.385Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.temperature.reference",
+            "properties": {},
+            "commands": {}
+        },
+        {
+            "feature": "rooms.features.supplyChannel0FTDC",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T01:22:16.385Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.features.supplyChannel0FTDC",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.features.supplyChannel0FTDCUseValveInformation",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T01:22:16.385Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.features.supplyChannel0FTDCUseValveInformation",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {},
+            "deprecated": {
+                "removalDate": "2025-09-09",
+                "info": "replaced by rooms.features.supplyChannel0PumpControl"
+            }
+        },
+        {
+            "feature": "rooms.features.supplyChannel0PumpControl",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T01:22:16.385Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.features.supplyChannel0PumpControl",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.features.supplyChannel1FTDC",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T01:22:16.385Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.features.supplyChannel1FTDC",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.features.supplyChannel1FTDCUseValveInformation",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T01:22:16.385Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.features.supplyChannel1FTDCUseValveInformation",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "commands": {},
+            "deprecated": {
+                "removalDate": "2025-09-09",
+                "info": "replaced by rooms.features.supplyChannel1PumpControl"
+            }
+        },
+        {
+            "feature": "rooms.features.supplyChannel1PumpControl",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T01:22:16.385Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.features.supplyChannel1PumpControl",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.features.supplyChannel2FTDC",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T01:22:16.385Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.features.supplyChannel2FTDC",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.features.supplyChannel2FTDCUseValveInformation",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T01:22:16.385Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.features.supplyChannel2FTDCUseValveInformation",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "commands": {},
+            "deprecated": {
+                "removalDate": "2025-09-09",
+                "info": "replaced by rooms.features.supplyChannel2PumpControl"
+            }
+        },
+        {
+            "feature": "rooms.features.supplyChannel2PumpControl",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T01:22:16.385Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.features.supplyChannel2PumpControl",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.features.supplyChannel3FTDC",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T01:22:16.385Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.features.supplyChannel3FTDC",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.features.supplyChannel3FTDCUseValveInformation",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T01:22:16.385Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.features.supplyChannel3FTDCUseValveInformation",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "commands": {},
+            "deprecated": {
+                "removalDate": "2025-09-09",
+                "info": "replaced by rooms.features.supplyChannel3PumpControl"
+            }
+        },
+        {
+            "feature": "rooms.features.supplyChannel3PumpControl",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T01:22:16.385Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.features.supplyChannel3PumpControl",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.others",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T01:22:16.385Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.others",
+            "properties": {
+                "enabled": {
+                    "type": "array",
+                    "value": []
+                }
+            },
+            "commands": {
+                "add": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.others/commands/add",
+                    "name": "add",
+                    "isExecutable": true,
+                    "params": {
+                        "name": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "minLength": 1,
+                                "maxLength": 40
+                            }
+                        },
+                        "heatingCircuit": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "enum": [
+                                    0
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "feature": "rooms.status",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T01:22:16.385Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.status",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                },
+                "variant": {
+                    "type": "string",
+                    "value": "full"
+                }
+            },
+            "commands": {
+                "activate": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.status/commands/activate",
+                    "name": "activate",
+                    "isExecutable": true,
+                    "params": {}
+                },
+                "deactivate": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.status/commands/deactivate",
+                    "name": "deactivate",
+                    "isExecutable": true,
+                    "params": {}
+                },
+                "setActive": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.status/commands/setActive",
+                    "name": "setActive",
+                    "isExecutable": true,
+                    "params": {
+                        "active": {
+                            "type": "boolean",
+                            "required": true,
+                            "constraints": {}
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "feature": "device.serial",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T01:22:16.351Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/device.serial",
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "################"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "heating.boiler.pumps.internal",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T01:22:16.351Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.boiler.pumps.internal",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "on"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "heating.boiler.sensors.temperature.main",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-16T11:27:42.672Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.boiler.sensors.temperature.main",
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 26,
+                    "unit": "celsius"
+                },
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "heating.boiler.serial",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T01:22:16.351Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.boiler.serial",
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "################"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "heating.boiler.temperature",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-16T11:16:34.131Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.boiler.temperature",
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 33,
+                    "unit": "celsius"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "heating.burners",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T01:22:16.351Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.burners",
+            "properties": {
+                "enabled": {
+                    "type": "array",
+                    "value": [
+                        "0"
+                    ]
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "heating.burners.0.modulation",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-16T11:04:10.719Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.burners.0.modulation",
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 0,
+                    "unit": "percent"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "heating.burners.0.statistics",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-16T11:03:38.222Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.burners.0.statistics",
+            "properties": {
+                "hours": {
+                    "type": "number",
+                    "value": 51146,
+                    "unit": "hour"
+                },
+                "starts": {
+                    "type": "number",
+                    "value": 229928,
+                    "unit": ""
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "heating.burners.0",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-16T11:03:58.752Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.burners.0",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "heating.burners.0.automatic",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T01:22:16.351Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.burners.0.automatic",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "ok"
+                },
+                "errorCode": {
+                    "type": "number",
+                    "value": 0,
+                    "unit": ""
+                },
+                "errorDetails": {
+                    "type": "string",
+                    "value": "error"
+                },
+                "audience": {
+                    "type": "string",
+                    "value": "internal"
+                }
+            },
+            "commands": {},
+            "deprecated": {
+                "removalDate": "2024-09-15",
+                "info": "none"
+            }
+        },
+        {
+            "feature": "heating.burners.0.errorStatus",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T01:22:16.351Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.burners.0.errorStatus",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "ok"
+                },
+                "errorCode": {
+                    "type": "number",
+                    "value": 0,
+                    "unit": ""
+                },
+                "errorDetails": {
+                    "type": "string",
+                    "value": "error"
+                },
+                "audience": {
+                    "type": "string",
+                    "value": "internal"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "heating.circuits",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T01:22:16.351Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits",
+            "properties": {
+                "enabled": {
+                    "type": "array",
+                    "value": [
+                        "0"
+                    ]
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "heating.circuits.0.circulation.pump",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T01:22:16.351Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.circulation.pump",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "on"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "heating.circuits.0.frostprotection",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T01:22:16.351Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.frostprotection",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "off"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "heating.circuits.0.heating.curve",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T01:22:16.351Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.heating.curve",
+            "properties": {
+                "shift": {
+                    "type": "number",
+                    "value": 2,
+                    "unit": ""
+                },
+                "slope": {
+                    "type": "number",
+                    "value": 1.4,
+                    "unit": ""
+                }
+            },
+            "commands": {
+                "setCurve": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve",
+                    "name": "setCurve",
+                    "isExecutable": true,
+                    "params": {
+                        "slope": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": 0.2,
+                                "max": 3.5,
+                                "stepping": 0.1
+                            }
+                        },
+                        "shift": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": -13,
+                                "max": 40,
+                                "stepping": 1
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "feature": "heating.circuits.0.heating.schedule",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T01:22:16.351Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.heating.schedule",
+            "properties": {
+                "entries": {
+                    "type": "Schedule",
+                    "value": {
+                        "mon": [
+                            {
+                                "start": "06:00",
+                                "end": "22:00",
+                                "mode": "normal",
+                                "position": 0
+                            }
+                        ],
+                        "tue": [
+                            {
+                                "start": "06:00",
+                                "end": "22:00",
+                                "mode": "normal",
+                                "position": 0
+                            }
+                        ],
+                        "wed": [
+                            {
+                                "start": "06:00",
+                                "end": "22:00",
+                                "mode": "normal",
+                                "position": 0
+                            }
+                        ],
+                        "thu": [
+                            {
+                                "start": "06:00",
+                                "end": "22:00",
+                                "mode": "normal",
+                                "position": 0
+                            }
+                        ],
+                        "fri": [
+                            {
+                                "start": "06:00",
+                                "end": "22:00",
+                                "mode": "normal",
+                                "position": 0
+                            }
+                        ],
+                        "sat": [
+                            {
+                                "start": "06:00",
+                                "end": "22:00",
+                                "mode": "normal",
+                                "position": 0
+                            }
+                        ],
+                        "sun": [
+                            {
+                                "start": "06:00",
+                                "end": "22:00",
+                                "mode": "normal",
+                                "position": 0
+                            }
+                        ]
+                    }
+                },
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "commands": {
+                "setSchedule": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule",
+                    "name": "setSchedule",
+                    "isExecutable": true,
+                    "params": {
+                        "newSchedule": {
+                            "type": "Schedule",
+                            "required": true,
+                            "constraints": {
+                                "modes": [
+                                    "normal"
+                                ],
+                                "maxEntries": 4,
+                                "resolution": 10,
+                                "defaultMode": "reduced",
+                                "overlapAllowed": true
+                            }
+                        }
+                    }
+                },
+                "resetSchedule": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.heating.schedule/commands/resetSchedule",
+                    "name": "resetSchedule",
+                    "isExecutable": true,
+                    "params": {}
+                }
+            }
+        },
+        {
+            "feature": "heating.circuits.0.operating.modes.active",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T01:22:16.351Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.modes.active",
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "heating"
+                }
+            },
+            "commands": {
+                "setMode": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode",
+                    "name": "setMode",
+                    "isExecutable": true,
+                    "params": {
+                        "mode": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "enum": [
+                                    "heating",
+                                    "standby"
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "feature": "heating.circuits.0.operating.modes.forcedNormal",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T01:22:16.351Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.modes.forcedNormal",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "heating.circuits.0.operating.modes.forcedReduced",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T01:22:16.351Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.modes.forcedReduced",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "heating.circuits.0.operating.modes.heating",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T01:22:16.351Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.modes.heating",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "heating.circuits.0.operating.modes.standby",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T01:22:16.351Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.modes.standby",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "heating.circuits.0.operating.programs.active",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-16T11:19:42.996Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.programs.active",
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "normal"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "heating.circuits.0.operating.programs.comfort",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T01:22:16.351Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.programs.comfort",
+            "properties": {
+                "temperature": {
+                    "type": "number",
+                    "value": 21,
+                    "unit": "celsius"
+                },
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                },
+                "demand": {
+                    "type": "string",
+                    "value": "unknown"
+                }
+            },
+            "commands": {
+                "activate": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/activate",
+                    "name": "activate",
+                    "isExecutable": false,
+                    "params": {
+                        "temperature": {
+                            "type": "number",
+                            "required": false,
+                            "constraints": {
+                                "min": 4,
+                                "max": 37,
+                                "stepping": 1
+                            }
+                        }
+                    }
+                },
+                "setTemperature": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/setTemperature",
+                    "name": "setTemperature",
+                    "isExecutable": true,
+                    "params": {
+                        "targetTemperature": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": 4,
+                                "max": 37,
+                                "stepping": 1
+                            }
+                        }
+                    }
+                },
+                "deactivate": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/deactivate",
+                    "name": "deactivate",
+                    "isExecutable": false,
+                    "params": {}
+                }
+            }
+        },
+        {
+            "feature": "heating.circuits.0.operating.programs.eco",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-16T04:00:14.298Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.programs.eco",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                },
+                "temperature": {
+                    "type": "number",
+                    "value": 20,
+                    "unit": "celsius"
+                }
+            },
+            "commands": {
+                "activate": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.programs.eco/commands/activate",
+                    "name": "activate",
+                    "isExecutable": false,
+                    "params": {}
+                },
+                "deactivate": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.programs.eco/commands/deactivate",
+                    "name": "deactivate",
+                    "isExecutable": false,
+                    "params": {}
+                }
+            }
+        },
+        {
+            "feature": "heating.circuits.0.operating.programs.external",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-16T11:19:42.996Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.programs.external",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                },
+                "temperature": {
+                    "type": "number",
+                    "value": 0,
+                    "unit": ""
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "heating.circuits.0.operating.programs.normal",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-16T04:00:14.298Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.programs.normal",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                },
+                "demand": {
+                    "type": "string",
+                    "value": "unknown"
+                },
+                "temperature": {
+                    "type": "number",
+                    "value": 20,
+                    "unit": "celsius"
+                }
+            },
+            "commands": {
+                "setTemperature": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature",
+                    "name": "setTemperature",
+                    "isExecutable": true,
+                    "params": {
+                        "targetTemperature": {
+                            "required": true,
+                            "constraints": {
+                                "min": 3,
+                                "max": 37,
+                                "stepping": 1
+                            },
+                            "type": "number"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "feature": "heating.circuits.0.operating.programs.reduced",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-16T04:00:14.298Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.programs.reduced",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                },
+                "demand": {
+                    "type": "string",
+                    "value": "unknown"
+                },
+                "temperature": {
+                    "type": "number",
+                    "value": 20,
+                    "unit": "celsius"
+                }
+            },
+            "commands": {
+                "setTemperature": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.programs.reduced/commands/setTemperature",
+                    "name": "setTemperature",
+                    "isExecutable": true,
+                    "params": {
+                        "targetTemperature": {
+                            "required": true,
+                            "constraints": {
+                                "min": 3,
+                                "max": 37,
+                                "stepping": 1
+                            },
+                            "type": "number"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "feature": "heating.circuits.0.operating.programs.standby",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T01:22:16.351Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.operating.programs.standby",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "heating.circuits.0.sensors.temperature.supply",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-16T11:27:32.993Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.sensors.temperature.supply",
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 26,
+                    "unit": "celsius"
+                },
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "heating.circuits.0",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T01:22:16.351Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                },
+                "name": {
+                    "type": "string",
+                    "value": "Heizkreis OG"
+                },
+                "type": {
+                    "type": "string",
+                    "value": "heatingCircuit"
+                }
+            },
+            "commands": {
+                "setName": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0/commands/setName",
+                    "name": "setName",
+                    "isExecutable": true,
+                    "params": {
+                        "name": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "minLength": 1,
+                                "maxLength": 20
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "feature": "heating.controller.serial",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T01:22:16.351Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.controller.serial",
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": ""
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "heating.flue.sensors.temperature.main",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-16T11:08:48.027Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.flue.sensors.temperature.main",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                },
+                "value": {
+                    "type": "number",
+                    "value": 27.3,
+                    "unit": "celsius"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "heating.operating.programs.holiday",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T01:22:16.351Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.operating.programs.holiday",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                },
+                "start": {
+                    "type": "string",
+                    "value": ""
+                },
+                "end": {
+                    "type": "string",
+                    "value": ""
+                }
+            },
+            "commands": {
+                "changeEndDate": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate",
+                    "name": "changeEndDate",
+                    "isExecutable": false,
+                    "params": {
+                        "end": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
+                                "sameDayAllowed": false
+                            }
+                        }
+                    }
+                },
+                "schedule": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.operating.programs.holiday/commands/schedule",
+                    "name": "schedule",
+                    "isExecutable": true,
+                    "params": {
+                        "start": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$"
+                            }
+                        },
+                        "end": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
+                                "sameDayAllowed": false
+                            }
+                        }
+                    }
+                },
+                "unschedule": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.operating.programs.holiday/commands/unschedule",
+                    "name": "unschedule",
+                    "isExecutable": true,
+                    "params": {}
+                }
+            }
+        },
+        {
+            "feature": "heating.sensors.temperature.outside",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-16T11:27:12.141Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.sensors.temperature.outside",
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 18.2,
+                    "unit": "celsius"
+                },
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "device.configuration.measurementWeight",
+            "gatewayId": "1234567812345678",
+            "deviceId": "zigbee-1234567890abcdef",
+            "timestamp": "2025-10-15T01:22:16.561Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/zigbee-1234567890abcdef/features/device.configuration.measurementWeight",
+            "properties": {
+                "weight": {
+                    "type": "number",
+                    "value": 20,
+                    "unit": ""
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "device.heatingCircuitId",
+            "gatewayId": "1234567812345678",
+            "deviceId": "zigbee-1234567890abcdef",
+            "timestamp": "2025-10-15T01:25:32.977Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/zigbee-1234567890abcdef/features/device.heatingCircuitId",
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 0,
+                    "unit": ""
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "device.identification",
+            "gatewayId": "1234567812345678",
+            "deviceId": "zigbee-1234567890abcdef",
+            "timestamp": "2025-10-15T01:25:32.977Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/zigbee-1234567890abcdef/features/device.identification",
+            "properties": {
+                "triggered": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "device.information",
+            "gatewayId": "1234567812345678",
+            "deviceId": "zigbee-1234567890abcdef",
+            "timestamp": "2025-10-15T01:22:16.561Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/zigbee-1234567890abcdef/features/device.information",
+            "properties": {
+                "manufacturer": {
+                    "type": "string",
+                    "value": "Viessmann"
+                },
+                "modelId": {
+                    "type": "string",
+                    "value": "7637434"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "device.messages.status.raw",
+            "gatewayId": "1234567812345678",
+            "deviceId": "zigbee-1234567890abcdef",
+            "timestamp": "2025-10-15T01:25:32.977Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/zigbee-1234567890abcdef/features/device.messages.status.raw",
+            "properties": {
+                "entries": {
+                    "type": "array",
+                    "value": []
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "device.name",
+            "gatewayId": "1234567812345678",
+            "deviceId": "zigbee-1234567890abcdef",
+            "timestamp": "2025-10-15T01:25:32.977Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/zigbee-1234567890abcdef/features/device.name",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "value": ""
+                }
+            },
+            "commands": {
+                "setName": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/zigbee-1234567890abcdef/features/device.name/commands/setName",
+                    "name": "setName",
+                    "isExecutable": true,
+                    "params": {
+                        "name": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "regEx": "^[\\p{L}0-9]+( [\\p{L}0-9]+)*$",
+                                "minLength": 1,
+                                "maxLength": 40
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "feature": "device.power.battery",
+            "gatewayId": "1234567812345678",
+            "deviceId": "zigbee-1234567890abcdef",
+            "timestamp": "2025-10-15T01:25:32.977Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/zigbee-1234567890abcdef/features/device.power.battery",
+            "properties": {
+                "level": {
+                    "type": "number",
+                    "value": 92,
+                    "unit": "percent"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "device.sensors.temperature",
+            "gatewayId": "1234567812345678",
+            "deviceId": "zigbee-1234567890abcdef",
+            "timestamp": "2025-10-16T11:20:55.446Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/zigbee-1234567890abcdef/features/device.sensors.temperature",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                },
+                "value": {
+                    "type": "number",
+                    "value": 20.8,
+                    "unit": "celsius"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "device.zigbee.lqi",
+            "gatewayId": "1234567812345678",
+            "deviceId": "zigbee-1234567890abcdef",
+            "timestamp": "2025-10-16T11:19:12.569Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/zigbee-1234567890abcdef/features/device.zigbee.lqi",
+            "properties": {
+                "strength": {
+                    "type": "number",
+                    "value": 21,
+                    "unit": "percent"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "device.zigbee.parent.id",
+            "gatewayId": "1234567812345678",
+            "deviceId": "zigbee-1234567890abcdef",
+            "timestamp": "2025-10-15T01:25:32.977Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/zigbee-1234567890abcdef/features/device.zigbee.parent.id",
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "fedcba0987654321"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "device.zigbee.parent.rx",
+            "gatewayId": "1234567812345678",
+            "deviceId": "zigbee-1234567890abcdef",
+            "timestamp": "2025-10-16T11:26:13.735Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/zigbee-1234567890abcdef/features/device.zigbee.parent.rx",
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 58,
+                    "unit": ""
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "device.zigbee.parent.tx",
+            "gatewayId": "1234567812345678",
+            "deviceId": "zigbee-1234567890abcdef",
+            "timestamp": "2025-10-16T11:25:57.826Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/zigbee-1234567890abcdef/features/device.zigbee.parent.tx",
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 76,
+                    "unit": ""
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "trv.childLock",
+            "gatewayId": "1234567812345678",
+            "deviceId": "zigbee-1234567890abcdef",
+            "timestamp": "2025-10-15T01:25:32.977Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/zigbee-1234567890abcdef/features/trv.childLock",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "inactive"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "trv.mountingMode",
+            "gatewayId": "1234567812345678",
+            "deviceId": "zigbee-1234567890abcdef",
+            "timestamp": "2025-10-15T01:25:32.977Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/zigbee-1234567890abcdef/features/trv.mountingMode",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "trv.temperature",
+            "gatewayId": "1234567812345678",
+            "deviceId": "zigbee-1234567890abcdef",
+            "timestamp": "2025-10-16T04:00:12.215Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/zigbee-1234567890abcdef/features/trv.temperature",
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 20,
+                    "unit": "celsius"
+                }
+            },
+            "commands": {
+                "setTargetTemperature": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/zigbee-1234567890abcdef/features/trv.temperature/commands/setTargetTemperature",
+                    "name": "setTargetTemperature",
+                    "isExecutable": true,
+                    "params": {
+                        "temperature": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": 8,
+                                "max": 30,
+                                "stepping": 0.5
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "feature": "trv.valve.position",
+            "gatewayId": "1234567812345678",
+            "deviceId": "zigbee-1234567890abcdef",
+            "timestamp": "2025-10-16T11:25:12.316Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/zigbee-1234567890abcdef/features/trv.valve.position",
+            "properties": {
+                "position": {
+                    "type": "number",
+                    "value": 17,
+                    "unit": "percent"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "apiVersion": 1,
+            "isEnabled": true,
+            "isReady": true,
+            "timestamp": "2025-10-15T01:22:16.351Z",
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.name",
+            "feature": "heating.circuits.0.name",
+            "deviceId": "0",
+            "gatewayId": "1234567812345678",
+            "components": [],
+            "commands": {
+                "setName": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.circuits.0.name/commands/setName",
+                    "name": "setName",
+                    "isExecutable": true,
+                    "params": {
+                        "name": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "minLength": 1,
+                                "maxLength": 20
+                            }
+                        }
+                    }
+                }
+            },
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "value": "Heizkreis OG"
+                }
+            }
+        }
+    ]
+}

--- a/tests/response/gatewayWithDevices/tcu1/Vitopure-350.json
+++ b/tests/response/gatewayWithDevices/tcu1/Vitopure-350.json
@@ -1,0 +1,1845 @@
+{
+    "data": [
+        {
+            "feature": "gateway.devices",
+            "gatewayId": "1234567812345678",
+            "timestamp": "2025-10-15T01:07:15.076Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/features/gateway.devices",
+            "properties": {
+                "devices": {
+                    "type": "DeviceList",
+                    "value": [
+                        {
+                            "id": "0",
+                            "fingerprint": "ecu;7973843400382125;0099.0500.2413.0002;0099.0500.2408.0001",
+                            "modelId": "E3_VitoPure",
+                            "modelVersion": "bIuvE8S0ArAZWWYWjdcI-WOSAjk",
+                            "name": "E3_VitoPure",
+                            "type": "ventilation",
+                            "roles": [
+                                "type:B2C",
+                                "type:E3",
+                                "type:brand;Viessmann",
+                                "type:gatewayConfiguration",
+                                "type:product;Vitopure",
+                                "type:ventilation;purifier"
+                            ],
+                            "status": "online"
+                        },
+                        {
+                            "id": "TCU",
+                            "fingerprint": "tcu:0041;33.325.2314.86;0041.0506.2409.0067",
+                            "modelId": "E3_TCU41_x04",
+                            "modelVersion": "yWzDUlv5aCHhVF4y5nlSCOBvkuQ",
+                            "name": "E3_TCU41_x04",
+                            "type": "tcu",
+                            "roles": [
+                                "capability:src",
+                                "capability:zigbeeCoordinator",
+                                "type:E3",
+                                "type:gateway;TCU100"
+                            ],
+                            "status": "online"
+                        },
+                        {
+                            "id": "RoomControl-1",
+                            "fingerprint": "src:0041;33.325.2314.86;0046.0503.2341.0017",
+                            "modelId": "E3_RoomControl_One_03",
+                            "modelVersion": "RY6b3QmbAaLt4mDbfXghuwEaPAw",
+                            "name": "E3_RoomControl_One_03",
+                            "type": "roomControl",
+                            "roles": [
+                                "capability:monetization;FTDC",
+                                "capability:monetization;OWD",
+                                "capability:src;FTDC",
+                                "capability:src;OWD",
+                                "capability:zigbeeCoordinator",
+                                "type:E3",
+                                "type:virtual;smartRoomControl"
+                            ],
+                            "status": "online"
+                        }
+                    ]
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "gateway.wifi",
+            "gatewayId": "1234567812345678",
+            "timestamp": "2025-10-16T11:25:59.041Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/features/gateway.wifi",
+            "properties": {
+                "strength": {
+                    "type": "number",
+                    "value": -67,
+                    "unit": ""
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "ventilation",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T12:08:11.935Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "ventilation.control.filterChange",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T12:08:11.935Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.control.filterChange",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "ventilation.fan.supply",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T12:08:11.935Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.fan.supply",
+            "properties": {
+                "current": {
+                    "type": "number",
+                    "value": 555,
+                    "unit": "rotationPerMinute"
+                },
+                "target": {
+                    "type": "number",
+                    "value": 585,
+                    "unit": "rotationPerMinute"
+                },
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "ventilation.fan.supply.runtime",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T12:08:11.935Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.fan.supply.runtime",
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 797,
+                    "unit": "hour"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "ventilation.filter.pollution.blocked",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T12:08:11.935Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.filter.pollution.blocked",
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 5,
+                    "unit": "percent"
+                },
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "ventilation.filter.runtime",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-16T10:54:24.735Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.filter.runtime",
+            "properties": {
+                "operatingHours": {
+                    "type": "number",
+                    "value": 5368,
+                    "unit": "hours"
+                },
+                "remainingHours": {
+                    "type": "number",
+                    "value": 3392,
+                    "unit": "hours"
+                },
+                "overdueHours": {
+                    "type": "number",
+                    "value": 0,
+                    "unit": "hours"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "ventilation.operating.modes.filterChange",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T12:08:11.935Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.operating.modes.filterChange",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "ventilation.operating.modes.permanent",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T12:08:11.935Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.operating.modes.permanent",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {
+                "setLevel": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.operating.modes.permanent/commands/setLevel",
+                    "name": "setLevel",
+                    "isExecutable": true,
+                    "params": {
+                        "level": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "enum": [
+                                    "levelOne",
+                                    "levelTwo",
+                                    "levelThree",
+                                    "levelFour"
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "feature": "ventilation.operating.modes.sensorDriven",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T12:08:11.935Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.operating.modes.sensorDriven",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "ventilation.operating.modes.ventilation",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T12:08:11.935Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.operating.modes.ventilation",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "ventilation.operating.programs.active",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T12:08:11.935Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.operating.programs.active",
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "levelTwo"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "ventilation.quickmodes.forcedLevelFour",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T12:08:11.935Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.quickmodes.forcedLevelFour",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                },
+                "defaultRuntime": {
+                    "type": "number",
+                    "value": 30,
+                    "unit": "minutes"
+                },
+                "isCommandExecutable": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "commands": {
+                "activate": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.quickmodes.forcedLevelFour/commands/activate",
+                    "name": "activate",
+                    "isExecutable": true,
+                    "params": {
+                        "timeout": {
+                            "type": "number",
+                            "required": false,
+                            "constraints": {
+                                "min": 1,
+                                "max": 1440,
+                                "stepping": 1
+                            }
+                        }
+                    }
+                },
+                "deactivate": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.quickmodes.forcedLevelFour/commands/deactivate",
+                    "name": "deactivate",
+                    "isExecutable": true,
+                    "params": {}
+                },
+                "setTimeout": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.quickmodes.forcedLevelFour/commands/setTimeout",
+                    "name": "setTimeout",
+                    "isExecutable": true,
+                    "params": {
+                        "timeout": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": 1,
+                                "max": 1440,
+                                "stepping": 1
+                            }
+                        }
+                    }
+                },
+                "setDefaultRuntime": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.quickmodes.forcedLevelFour/commands/setDefaultRuntime",
+                    "name": "setDefaultRuntime",
+                    "isExecutable": true,
+                    "params": {
+                        "defaultRuntime": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": 1,
+                                "max": 1440,
+                                "stepping": 1
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "feature": "ventilation.quickmodes.silent",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T12:08:11.935Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.quickmodes.silent",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                },
+                "defaultRuntime": {
+                    "type": "number",
+                    "value": 30,
+                    "unit": "minutes"
+                },
+                "isCommandExecutable": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "commands": {
+                "activate": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.quickmodes.silent/commands/activate",
+                    "name": "activate",
+                    "isExecutable": true,
+                    "params": {
+                        "timeout": {
+                            "type": "number",
+                            "required": false,
+                            "constraints": {
+                                "min": 1,
+                                "max": 1440,
+                                "stepping": 1
+                            }
+                        }
+                    }
+                },
+                "deactivate": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.quickmodes.silent/commands/deactivate",
+                    "name": "deactivate",
+                    "isExecutable": true,
+                    "params": {}
+                },
+                "setTimeout": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.quickmodes.silent/commands/setTimeout",
+                    "name": "setTimeout",
+                    "isExecutable": true,
+                    "params": {
+                        "timeout": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": 1,
+                                "max": 1440,
+                                "stepping": 1
+                            }
+                        }
+                    }
+                },
+                "setDefaultRuntime": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.quickmodes.silent/commands/setDefaultRuntime",
+                    "name": "setDefaultRuntime",
+                    "isExecutable": true,
+                    "params": {
+                        "defaultRuntime": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": 1,
+                                "max": 1440,
+                                "stepping": 1
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "feature": "ventilation.quickmodes.standby",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T12:08:11.935Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.quickmodes.standby",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "commands": {
+                "activate": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.quickmodes.standby/commands/activate",
+                    "name": "activate",
+                    "isExecutable": true,
+                    "params": {}
+                },
+                "deactivate": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.quickmodes.standby/commands/deactivate",
+                    "name": "deactivate",
+                    "isExecutable": true,
+                    "params": {}
+                },
+                "setActive": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.quickmodes.standby/commands/setActive",
+                    "name": "setActive",
+                    "isExecutable": true,
+                    "params": {
+                        "active": {
+                            "type": "boolean",
+                            "required": true,
+                            "constraints": {}
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "feature": "ventilation.sensors.airBorneDust.pm1",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-16T11:38:33.443Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.sensors.airBorneDust.pm1",
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 0,
+                    "unit": "microgrammsPerCubicMeter"
+                },
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "ventilation.sensors.airBorneDust.pm10",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-16T11:38:48.339Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.sensors.airBorneDust.pm10",
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 0,
+                    "unit": "microgrammsPerCubicMeter"
+                },
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "ventilation.sensors.airBorneDust.pm2d5",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-16T11:38:48.339Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.sensors.airBorneDust.pm2d5",
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 0,
+                    "unit": "microgrammsPerCubicMeter"
+                },
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "ventilation.sensors.airBorneDust.pm4",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-16T11:38:48.339Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.sensors.airBorneDust.pm4",
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 0,
+                    "unit": "microgrammsPerCubicMeter"
+                },
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "ventilation.sensors.airQuality",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-16T06:14:18.430Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.sensors.airQuality",
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 24,
+                    "unit": ""
+                },
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                }
+            },
+            "commands": {},
+            "deprecated": {
+                "removalDate": "2024-09-15",
+                "info": "replaced by ventilation.airQuality.abstract"
+            }
+        },
+        {
+            "feature": "ventilation.sensors.humidity.supply",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-16T11:36:20.830Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.sensors.humidity.supply",
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 56,
+                    "unit": "percent"
+                },
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "ventilation.sensors.temperature.supply",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-16T11:22:18.481Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.sensors.temperature.supply",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                },
+                "value": {
+                    "type": "number",
+                    "value": 21.6,
+                    "unit": "celsius"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "ventilation.sensors.volatileOrganicCompounds",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-16T11:16:55.392Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.sensors.volatileOrganicCompounds",
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 73,
+                    "unit": ""
+                },
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "tcu.wifi",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-16T11:25:58.825Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/tcu.wifi",
+            "properties": {
+                "strength": {
+                    "type": "number",
+                    "value": -67,
+                    "unit": ""
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "device.productIdentification",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T12:08:11.935Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/device.productIdentification",
+            "properties": {
+                "product": {
+                    "type": "object",
+                    "value": {
+                        "busType": "OwnBus",
+                        "busAddress": 0,
+                        "viessmannIdentificationNumber": "7973843400382125",
+                        "productFamily": "B_00059_VP300"
+                    }
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "device.messages.info.raw",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T12:08:11.935Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/device.messages.info.raw",
+            "properties": {
+                "entries": {
+                    "type": "array",
+                    "value": []
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "device.messages.service.raw",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T12:08:11.935Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/device.messages.service.raw",
+            "properties": {
+                "entries": {
+                    "type": "array",
+                    "value": []
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "device.messages.status.raw",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T12:08:11.935Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/device.messages.status.raw",
+            "properties": {
+                "entries": {
+                    "type": "array",
+                    "value": []
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "device.setDefaultValues",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T12:08:11.935Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/device.setDefaultValues",
+            "properties": {},
+            "commands": {}
+        },
+        {
+            "feature": "device.time.daylightSaving",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T12:08:11.935Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/device.time.daylightSaving",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {
+                "activate": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/device.time.daylightSaving/commands/activate",
+                    "name": "activate",
+                    "isExecutable": true,
+                    "params": {
+                        "begin": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "regEx": "^[\\d]{2}-[\\d]{2}$"
+                            }
+                        },
+                        "end": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "regEx": "^[\\d]{2}-[\\d]{2}$"
+                            }
+                        }
+                    }
+                },
+                "deactivate": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/device.time.daylightSaving/commands/deactivate",
+                    "name": "deactivate",
+                    "isExecutable": true,
+                    "params": {}
+                }
+            }
+        },
+        {
+            "feature": "heating.boiler.serial",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T12:08:11.935Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.boiler.serial",
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "################"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "heating.device.time",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-16T11:44:08.618Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.device.time",
+            "properties": {},
+            "commands": {
+                "setTime": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.device.time/commands/setTime",
+                    "name": "setTime",
+                    "isExecutable": true,
+                    "params": {
+                        "value": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "regEx": "^[0-9]{4}-((0[13578]|1[02])-(0[1-9]|[12][0-9]|3[01])|(0[469]|11)-(0[1-9]|[12][0-9]|30)|(02)-(0[1-9]|[12][0-9]))T(0[0-9]|1[0-9]|2[0-3]):(0[0-9]|[1-5][0-9]):(0[0-9]|[1-5][0-9])$"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "feature": "device.variant",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T12:08:11.935Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/device.variant",
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "Vitopure350"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "heating.device.variant",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T12:08:11.935Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/heating.device.variant",
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "Vitopure350"
+                }
+            },
+            "commands": {},
+            "deprecated": {
+                "removalDate": "2025-03-15",
+                "info": "replaced by device.variant"
+            }
+        },
+        {
+            "feature": "ventilation.operating.modes.active",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T12:08:11.935Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.operating.modes.active",
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "sensorDriven"
+                }
+            },
+            "commands": {
+                "setMode": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.operating.modes.active/commands/setMode",
+                    "name": "setMode",
+                    "isExecutable": true,
+                    "params": {
+                        "mode": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "enum": [
+                                    "permanent",
+                                    "ventilation",
+                                    "sensorDriven"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "setModeContinuousSensorOverride": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.operating.modes.active/commands/setModeContinuousSensorOverride",
+                    "name": "setModeContinuousSensorOverride",
+                    "isExecutable": false,
+                    "params": {}
+                }
+            }
+        },
+        {
+            "feature": "ventilation.operating.state",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T12:08:11.935Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.operating.state",
+            "properties": {
+                "level": {
+                    "type": "string",
+                    "value": "unknown"
+                },
+                "demand": {
+                    "type": "string",
+                    "value": "unknown"
+                },
+                "reason": {
+                    "type": "string",
+                    "value": "standby"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "ventilation.schedule",
+            "gatewayId": "1234567812345678",
+            "deviceId": "0",
+            "timestamp": "2025-10-15T12:08:11.935Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.schedule",
+            "properties": {
+                "entries": {
+                    "type": "Schedule",
+                    "value": {
+                        "mon": [
+                            {
+                                "mode": "levelTwo",
+                                "start": "06:00",
+                                "end": "22:00",
+                                "position": 0
+                            }
+                        ],
+                        "tue": [
+                            {
+                                "mode": "levelTwo",
+                                "start": "06:00",
+                                "end": "22:00",
+                                "position": 0
+                            }
+                        ],
+                        "wed": [
+                            {
+                                "mode": "levelTwo",
+                                "start": "06:00",
+                                "end": "22:00",
+                                "position": 0
+                            }
+                        ],
+                        "thu": [
+                            {
+                                "mode": "levelTwo",
+                                "start": "06:00",
+                                "end": "22:00",
+                                "position": 0
+                            }
+                        ],
+                        "fri": [
+                            {
+                                "mode": "levelTwo",
+                                "start": "06:00",
+                                "end": "22:00",
+                                "position": 0
+                            }
+                        ],
+                        "sat": [
+                            {
+                                "mode": "levelTwo",
+                                "start": "06:00",
+                                "end": "22:00",
+                                "position": 0
+                            }
+                        ],
+                        "sun": [
+                            {
+                                "mode": "levelTwo",
+                                "start": "06:00",
+                                "end": "22:00",
+                                "position": 0
+                            }
+                        ]
+                    }
+                },
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "commands": {
+                "setSchedule": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.schedule/commands/setSchedule",
+                    "name": "setSchedule",
+                    "isExecutable": true,
+                    "params": {
+                        "newSchedule": {
+                            "type": "Schedule",
+                            "required": true,
+                            "constraints": {
+                                "modes": [
+                                    "levelOne",
+                                    "levelTwo",
+                                    "levelThree",
+                                    "levelFour"
+                                ],
+                                "maxEntries": 4,
+                                "resolution": 10,
+                                "defaultMode": "standby",
+                                "overlapAllowed": false
+                            }
+                        }
+                    }
+                },
+                "resetSchedule": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/0/features/ventilation.schedule/commands/resetSchedule",
+                    "name": "resetSchedule",
+                    "isExecutable": true,
+                    "params": {}
+                }
+            }
+        },
+        {
+            "feature": "tcu.features.wirelessRemoteController",
+            "gatewayId": "1234567812345678",
+            "deviceId": "TCU",
+            "timestamp": "2025-10-15T12:08:11.975Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/TCU/features/tcu.features.wirelessRemoteController",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.0.condensationRisk",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T12:08:12.006Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.condensationRisk",
+            "properties": {
+                "value": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.1.condensationRisk",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T12:08:12.006Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.1.condensationRisk",
+            "properties": {
+                "value": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.0.configuration.hydraulicBalancing",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T12:08:12.006Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.configuration.hydraulicBalancing",
+            "properties": {
+                "value": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.1.configuration.hydraulicBalancing",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T12:08:12.006Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.1.configuration.hydraulicBalancing",
+            "properties": {
+                "value": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.0.configuration.trvAlgorithmActive",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T12:08:12.006Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.configuration.trvAlgorithmActive",
+            "properties": {
+                "value": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.1.configuration.trvAlgorithmActive",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T12:08:12.006Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.1.configuration.trvAlgorithmActive",
+            "properties": {
+                "value": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.0.sensors.co2",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T12:08:12.006Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.sensors.co2",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "notConnected"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.1.sensors.co2",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T12:08:12.006Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.1.sensors.co2",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "notConnected"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.0.sensors.humidity",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T12:08:12.006Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.sensors.humidity",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "notConnected"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.1.sensors.humidity",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T12:08:12.006Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.1.sensors.humidity",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "notConnected"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.0.sensors.temperature",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T12:08:12.006Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0.sensors.temperature",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "notConnected"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.1.sensors.temperature",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T12:08:12.006Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.1.sensors.temperature",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "notConnected"
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.features.remotePresenceProbability",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T12:08:12.006Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.features.remotePresenceProbability",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.features.supplyChannel0FTDC",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T12:08:12.006Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.features.supplyChannel0FTDC",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.features.supplyChannel1FTDC",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T12:08:12.006Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.features.supplyChannel1FTDC",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.features.supplyChannel2FTDC",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T12:08:12.006Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.features.supplyChannel2FTDC",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms.features.supplyChannel3FTDC",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T12:08:12.006Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.features.supplyChannel3FTDC",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {}
+        },
+        {
+            "feature": "rooms",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T12:08:12.006Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms",
+            "properties": {
+                "enabled": {
+                    "type": "array",
+                    "value": [
+                        "0",
+                        "1"
+                    ]
+                }
+            },
+            "commands": {
+                "add": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms/commands/add",
+                    "name": "add",
+                    "isExecutable": true,
+                    "params": {
+                        "name": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "minLength": 1,
+                                "maxLength": 39,
+                                "regEx": "^[\\p{L}0-9]+( [\\p{L}0-9]+)*$"
+                            }
+                        },
+                        "type": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "enum": [
+                                    "bathroom",
+                                    "bedroom",
+                                    "hallway",
+                                    "livingroom",
+                                    "kitchen",
+                                    "office",
+                                    "nursery",
+                                    "toilet",
+                                    "other"
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "feature": "rooms.0",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T12:08:12.006Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "value": "Badezimmer"
+                },
+                "type": {
+                    "type": "string",
+                    "value": "bathroom"
+                },
+                "actors": {
+                    "type": "array",
+                    "value": []
+                }
+            },
+            "commands": {
+                "addActor": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0/commands/addActor",
+                    "name": "addActor",
+                    "isExecutable": true,
+                    "params": {
+                        "actorDeviceId": {
+                            "type": "string",
+                            "constraints": {},
+                            "required": true
+                        },
+                        "heatingCircuit": {
+                            "type": "number",
+                            "constraints": {
+                                "min": 0,
+                                "max": 3,
+                                "stepping": 1
+                            },
+                            "required": false
+                        }
+                    },
+                    "constraints": {
+                        "enum": [
+                            "cs",
+                            "fht",
+                            "trv",
+                            "airQualitySensor",
+                            "remoteControllerSensor"
+                        ]
+                    }
+                },
+                "moveActor": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0/commands/moveActor",
+                    "name": "moveActor",
+                    "isExecutable": true,
+                    "params": {
+                        "actorDeviceId": {
+                            "type": "string",
+                            "constraints": {},
+                            "required": true
+                        },
+                        "heatingCircuit": {
+                            "type": "number",
+                            "constraints": {
+                                "min": 0,
+                                "max": 3,
+                                "stepping": 1
+                            },
+                            "required": false
+                        },
+                        "newRoomId": {
+                            "type": "number",
+                            "constraints": {
+                                "min": 0,
+                                "max": 23,
+                                "stepping": 1
+                            },
+                            "required": true
+                        }
+                    }
+                },
+                "setName": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0/commands/setName",
+                    "name": "setName",
+                    "isExecutable": true,
+                    "params": {
+                        "name": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "regEx": "^[\\p{L}0-9]+( [\\p{L}0-9]+)*$",
+                                "minLength": 1,
+                                "maxLength": 39
+                            }
+                        }
+                    }
+                },
+                "setType": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0/commands/setType",
+                    "name": "setType",
+                    "isExecutable": true,
+                    "params": {
+                        "type": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "enum": [
+                                    "bathroom",
+                                    "bedroom",
+                                    "hallway",
+                                    "livingroom",
+                                    "kitchen",
+                                    "office",
+                                    "nursery",
+                                    "toilet",
+                                    "other"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "removeActor": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0/commands/removeActor",
+                    "name": "removeActor",
+                    "isExecutable": true,
+                    "params": {
+                        "actorDeviceId": {
+                            "type": "string",
+                            "constraints": {},
+                            "required": true
+                        }
+                    }
+                },
+                "remove": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.0/commands/remove",
+                    "name": "remove",
+                    "isExecutable": true,
+                    "params": {}
+                }
+            }
+        },
+        {
+            "feature": "rooms.1",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T12:08:12.006Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.1",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "value": "Treppenhaus"
+                },
+                "type": {
+                    "type": "string",
+                    "value": "other"
+                },
+                "actors": {
+                    "type": "array",
+                    "value": []
+                }
+            },
+            "commands": {
+                "addActor": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.1/commands/addActor",
+                    "name": "addActor",
+                    "isExecutable": true,
+                    "params": {
+                        "actorDeviceId": {
+                            "type": "string",
+                            "constraints": {},
+                            "required": true
+                        },
+                        "heatingCircuit": {
+                            "type": "number",
+                            "constraints": {
+                                "min": 0,
+                                "max": 3,
+                                "stepping": 1
+                            },
+                            "required": false
+                        }
+                    },
+                    "constraints": {
+                        "enum": [
+                            "cs",
+                            "fht",
+                            "trv",
+                            "airQualitySensor",
+                            "remoteControllerSensor"
+                        ]
+                    }
+                },
+                "moveActor": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.1/commands/moveActor",
+                    "name": "moveActor",
+                    "isExecutable": true,
+                    "params": {
+                        "actorDeviceId": {
+                            "type": "string",
+                            "constraints": {},
+                            "required": true
+                        },
+                        "heatingCircuit": {
+                            "type": "number",
+                            "constraints": {
+                                "min": 0,
+                                "max": 3,
+                                "stepping": 1
+                            },
+                            "required": false
+                        },
+                        "newRoomId": {
+                            "type": "number",
+                            "constraints": {
+                                "min": 0,
+                                "max": 23,
+                                "stepping": 1
+                            },
+                            "required": true
+                        }
+                    }
+                },
+                "setName": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.1/commands/setName",
+                    "name": "setName",
+                    "isExecutable": true,
+                    "params": {
+                        "name": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "regEx": "^[\\p{L}0-9]+( [\\p{L}0-9]+)*$",
+                                "minLength": 1,
+                                "maxLength": 39
+                            }
+                        }
+                    }
+                },
+                "setType": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.1/commands/setType",
+                    "name": "setType",
+                    "isExecutable": true,
+                    "params": {
+                        "type": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "enum": [
+                                    "bathroom",
+                                    "bedroom",
+                                    "hallway",
+                                    "livingroom",
+                                    "kitchen",
+                                    "office",
+                                    "nursery",
+                                    "toilet",
+                                    "other"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "removeActor": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.1/commands/removeActor",
+                    "name": "removeActor",
+                    "isExecutable": true,
+                    "params": {
+                        "actorDeviceId": {
+                            "type": "string",
+                            "constraints": {},
+                            "required": true
+                        }
+                    }
+                },
+                "remove": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.1/commands/remove",
+                    "name": "remove",
+                    "isExecutable": true,
+                    "params": {}
+                }
+            }
+        },
+        {
+            "feature": "rooms.others",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T12:08:12.006Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.others",
+            "properties": {
+                "enabled": {
+                    "type": "array",
+                    "value": []
+                }
+            },
+            "commands": {
+                "add": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.others/commands/add",
+                    "name": "add",
+                    "isExecutable": false,
+                    "params": {
+                        "name": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "minLength": 1,
+                                "maxLength": 39
+                            }
+                        },
+                        "heatingCircuit": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "enum": []
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "feature": "rooms.status",
+            "gatewayId": "1234567812345678",
+            "deviceId": "RoomControl-1",
+            "timestamp": "2025-10-15T12:08:12.006Z",
+            "isEnabled": true,
+            "isReady": true,
+            "apiVersion": 1,
+            "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.status",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                },
+                "variant": {
+                    "type": "string",
+                    "value": "full"
+                }
+            },
+            "commands": {
+                "activate": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.status/commands/activate",
+                    "name": "activate",
+                    "isExecutable": true,
+                    "params": {}
+                },
+                "deactivate": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.status/commands/deactivate",
+                    "name": "deactivate",
+                    "isExecutable": true,
+                    "params": {}
+                },
+                "setActive": {
+                    "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/2323232/gateways/1234567812345678/devices/RoomControl-1/features/rooms.status/commands/setActive",
+                    "name": "setActive",
+                    "isExecutable": true,
+                    "params": {
+                        "active": {
+                            "type": "boolean",
+                            "required": true,
+                            "constraints": {}
+                        }
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tests/test_PyViCareCachedServiceViaGateway.py
+++ b/tests/test_PyViCareCachedServiceViaGateway.py
@@ -1,0 +1,146 @@
+import unittest
+from unittest.mock import Mock
+
+from PyViCare.PyViCareCachedServiceViaGateway import \
+    ViCareCachedServiceViaGateway
+from PyViCare.PyViCareService import ViCareDeviceAccessor
+from PyViCare.PyViCareUtils import (PyViCareDeviceCommunicationError,
+                                    PyViCareInternalServerError,
+                                    PyViCareInvalidDataError,
+                                    PyViCareNotSupportedFeatureError)
+from tests.helper import now_is
+
+
+BULK_RESPONSE = {
+    "data": [
+        {
+            "feature": "device.serial",
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/[id]/gateways/[serial]/devices/[dev1]/features/device.serial",
+            "isEnabled": True,
+        },
+        {
+            "feature": "device.serial",
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/[id]/gateways/[serial]/devices/[dev2]/features/device.serial",
+            "isEnabled": True,
+        },
+    ]
+}
+
+
+class PyViCareCachedServiceViaGatewayTest(unittest.TestCase):
+
+    CACHE_DURATION = 60
+
+    def setUp(self):
+        self.oauth_mock = Mock()
+        self.oauth_mock.get.return_value = BULK_RESPONSE
+        self.service = ViCareCachedServiceViaGateway(
+            self.oauth_mock, self.CACHE_DURATION)
+        self.accessor1 = ViCareDeviceAccessor("[id]", "[serial]", "[dev1]")
+        self.accessor2 = ViCareDeviceAccessor("[id]", "[serial]", "[dev2]")
+
+    def test_fetch_all_features_is_cached(self):
+        """Coordinators calling fetch_all_features() directly must share the cache.
+
+        This is the critical optimization for HA's per-device DataUpdateCoordinator
+        pattern: each coordinator does clear_cache + fetch_all_features per refresh.
+        In gateway mode there is one bulk endpoint per gateway, so concurrent
+        fetch_all_features calls must collapse to a single HTTP call.
+        """
+        with now_is('2000-01-01 00:00:00'):
+            r1 = self.service.fetch_all_features(self.accessor1)
+            r2 = self.service.fetch_all_features(self.accessor2)
+            r3 = self.service.fetch_all_features(self.accessor1)
+        self.assertEqual(self.oauth_mock.get.call_count, 1)
+        self.assertEqual(r1, r2)
+        self.assertEqual(r1, r3)
+
+    def test_two_devices_share_single_bulk_fetch(self):
+        with now_is('2000-01-01 00:00:00'):
+            self.service.getProperty(self.accessor1, "device.serial")
+            self.service.getProperty(self.accessor2, "device.serial")
+            self.service.getProperty(self.accessor1, "device.serial")
+        self.assertEqual(self.oauth_mock.get.call_count, 1)
+        self.oauth_mock.get.assert_called_once_with(
+            '/features/installations/[id]/gateways/[serial]/features?includeDevicesFeatures=true')
+
+    def test_cache_respects_TTL(self):
+        with now_is('2000-01-01 00:00:00'):
+            self.service.getProperty(self.accessor1, "device.serial")
+        with now_is('2000-01-01 00:00:30'):
+            self.service.getProperty(self.accessor1, "device.serial")
+        self.assertEqual(self.oauth_mock.get.call_count, 1)
+        with now_is('2000-01-01 00:01:10'):
+            self.service.getProperty(self.accessor1, "device.serial")
+        self.assertEqual(self.oauth_mock.get.call_count, 2)
+
+    def test_setProperty_invalidates_cache_for_all_devices(self):
+        with now_is('2000-01-01 00:00:00'):
+            self.service.getProperty(self.accessor1, "device.serial")
+            self.service.getProperty(self.accessor2, "device.serial")
+            self.assertEqual(self.oauth_mock.get.call_count, 1)
+            self.assertEqual(self.service.is_cache_invalid(), False)
+
+            self.service.setProperty(self.accessor1, "x.y", "doaction", {"a": 1})
+            self.assertEqual(self.service.is_cache_invalid(), True)
+
+            self.service.getProperty(self.accessor2, "device.serial")
+            self.assertEqual(self.oauth_mock.get.call_count, 2)
+
+    def test_getProperty_filters_to_caller_device(self):
+        with now_is('2000-01-01 00:00:00'):
+            f1 = self.service.getProperty(self.accessor1, "device.serial")
+            f2 = self.service.getProperty(self.accessor2, "device.serial")
+        self.assertIn("[dev1]", f1["uri"])
+        self.assertIn("[dev2]", f2["uri"])
+
+    def test_getProperty_missing_raises(self):
+        self.assertRaises(
+            PyViCareNotSupportedFeatureError,
+            self.service.getProperty, self.accessor1, "no.such.feature")
+
+    def test_device_communication_error_returns_stale_cache(self):
+        with now_is('2000-01-01 00:00:00'):
+            self.service.getProperty(self.accessor1, "device.serial")
+
+        self.oauth_mock.get.side_effect = PyViCareDeviceCommunicationError(
+            {"errorType": "DEVICE_COMMUNICATION_ERROR",
+             "extendedPayload": {"reason": "GATEWAY_OFFLINE"}})
+
+        with now_is('2000-01-01 00:01:10'):
+            result = self.service.getProperty(self.accessor1, "device.serial")
+        self.assertIsNotNone(result)
+
+    def test_server_error_returns_stale_cache(self):
+        with now_is('2000-01-01 00:00:00'):
+            self.service.getProperty(self.accessor1, "device.serial")
+
+        self.oauth_mock.get.side_effect = PyViCareInternalServerError(
+            {"statusCode": 500, "message": "Internal server error",
+             "viErrorId": "test"})
+
+        with now_is('2000-01-01 00:01:10'):
+            result = self.service.getProperty(self.accessor1, "device.serial")
+        self.assertIsNotNone(result)
+
+    def test_device_communication_error_raises_without_cache(self):
+        self.oauth_mock.get.side_effect = PyViCareDeviceCommunicationError(
+            {"errorType": "DEVICE_COMMUNICATION_ERROR",
+             "extendedPayload": {"reason": "DEVICE_OFFLINE"}})
+
+        with now_is('2000-01-01 00:00:00'):
+            self.assertRaises(
+                PyViCareDeviceCommunicationError,
+                self.service.getProperty, self.accessor1, "device.serial")
+
+    def test_invalid_data_still_raises_with_cache(self):
+        with now_is('2000-01-01 00:00:00'):
+            self.service.getProperty(self.accessor1, "device.serial")
+
+        self.oauth_mock.get.side_effect = None
+        self.oauth_mock.get.return_value = {"unexpected": "response"}
+
+        with now_is('2000-01-01 00:01:10'):
+            self.assertRaises(
+                PyViCareInvalidDataError,
+                self.service.getProperty, self.accessor1, "device.serial")

--- a/tests/test_PyViCareDeviceConfig.py
+++ b/tests/test_PyViCareDeviceConfig.py
@@ -3,19 +3,14 @@ import unittest
 from unittest.mock import Mock
 
 from PyViCare.PyViCareDeviceConfig import PyViCareDeviceConfig
-from PyViCare.PyViCareService import ViCareDeviceAccessor, hasRoles
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareUtils import PyViCareNotPaidForError
-
-
-def has_roles(roles):
-    return lambda requested_roles: hasRoles(requested_roles, roles)
 
 
 class PyViCareDeviceConfigTest(unittest.TestCase):
 
     def setUp(self) -> None:
         self.service = Mock()
-        self.service.hasRoles = has_roles([])
         self.accessor = ViCareDeviceAccessor(0, "[serial]", "0")
 
     def test_autoDetect_Vitodens_asGazBoiler(self):
@@ -37,44 +32,38 @@ class PyViCareDeviceConfigTest(unittest.TestCase):
         self.assertEqual("GazBoiler", type(device_type).__name__)
 
     def test_autoDetect_RoleBoiler_asGazBoiler(self):
-        self.service.hasRoles = has_roles(["type:boiler"])
         c = PyViCareDeviceConfig(
-            self.accessor, self.service, "Unknown", "Online")
+            self.accessor, self.service, "Unknown", "Online", roles=["type:boiler"])
         device_type = c.asAutoDetectDevice()
         self.assertEqual("GazBoiler", type(device_type).__name__)
 
     def test_autoDetect_RoleHeatpump_asHeatpump(self):
-        self.service.hasRoles = has_roles(["type:heatpump"])
         c = PyViCareDeviceConfig(
-            self.accessor, self.service, "Unknown", "Online")
+            self.accessor, self.service, "Unknown", "Online", roles=["type:heatpump"])
         device_type = c.asAutoDetectDevice()
         self.assertEqual("HeatPump", type(device_type).__name__)
 
     def test_autoDetect_RoleRadiator_asRadiatorActuator(self):
-        self.service.hasRoles = has_roles(["type:radiator"])
         c = PyViCareDeviceConfig(
-            self.accessor, self.service, "Unknown", "Online")
+            self.accessor, self.service, "Unknown", "Online", roles=["type:radiator"])
         device_type = c.asAutoDetectDevice()
         self.assertEqual("RadiatorActuator", type(device_type).__name__)
 
     def test_autoDetect_RoleClimateSensor_asRoomSensor(self):
-        self.service.hasRoles = has_roles(["type:climateSensor"])
         c = PyViCareDeviceConfig(
-            self.accessor, self.service, "Unknown", "Online")
+            self.accessor, self.service, "Unknown", "Online", roles=["type:climateSensor"])
         device_type = c.asAutoDetectDevice()
         self.assertEqual("RoomSensor", type(device_type).__name__)
 
     def test_autoDetect_RoleVentilation_asVentilation(self):
-        self.service.hasRoles = has_roles(["type:ventilation"])
         c = PyViCareDeviceConfig(
-            self.accessor, self.service, "Unknown", "Online")
+            self.accessor, self.service, "Unknown", "Online", roles=["type:ventilation"])
         device_type = c.asAutoDetectDevice()
         self.assertEqual("VentilationDevice", type(device_type).__name__)
 
     def test_autoDetect_RoleVentilationCentral_asVentilation(self):
-        self.service.hasRoles = has_roles(["type:ventilation;central"])
         c = PyViCareDeviceConfig(
-            self.accessor, self.service, "Unknown", "Online")
+            self.accessor, self.service, "Unknown", "Online", roles=["type:ventilation;central"])
         device_type = c.asAutoDetectDevice()
         self.assertEqual("VentilationDevice", type(device_type).__name__)
 
@@ -85,9 +74,8 @@ class PyViCareDeviceConfigTest(unittest.TestCase):
         self.assertEqual("VentilationDevice", type(device_type).__name__)
 
     def test_autoDetect_RoleVentilationPurifier_asVentilation(self):
-        self.service.hasRoles = has_roles(["type:ventilation;purifier"])
         c = PyViCareDeviceConfig(
-            self.accessor, self.service, "Unknown", "Online")
+            self.accessor, self.service, "Unknown", "Online", roles=["type:ventilation;purifier"])
         device_type = c.asAutoDetectDevice()
         self.assertEqual("VentilationDevice", type(device_type).__name__)
 
@@ -98,9 +86,8 @@ class PyViCareDeviceConfigTest(unittest.TestCase):
         self.assertEqual("VentilationDevice", type(device_type).__name__)
 
     def test_autoDetect_RoleESS_asElectricalEnergySystem(self):
-        self.service.hasRoles = has_roles(["type:ess"])
         c = PyViCareDeviceConfig(
-            self.accessor, self.service, "Unknown", "Online")
+            self.accessor, self.service, "Unknown", "Online", roles=["type:ess"])
         device_type = c.asAutoDetectDevice()
         self.assertEqual("ElectricalEnergySystem", type(device_type).__name__)
 
@@ -117,9 +104,8 @@ class PyViCareDeviceConfigTest(unittest.TestCase):
         self.assertEqual("RoomControl", type(device_type).__name__)
 
     def test_autoDetect_RoleRoomControl_asRoomControl(self):
-        self.service.hasRoles = has_roles(["type:virtual;smartRoomControl"])
         c = PyViCareDeviceConfig(
-            self.accessor, self.service, "Unknown", "Online")
+            self.accessor, self.service, "Unknown", "Online", roles=["type:virtual;smartRoomControl"])
         device_type = c.asAutoDetectDevice()
         self.assertEqual("RoomControl", type(device_type).__name__)
 
@@ -160,72 +146,62 @@ class PyViCareDeviceConfigTest(unittest.TestCase):
         self.assertEqual("Gateway", type(device_type).__name__)
 
     def test_autoDetect_Ecotronic_asPelletsBoiler(self):
-        self.service.hasRoles = has_roles(["type:boiler"])
         c = PyViCareDeviceConfig(
-            self.accessor, self.service, "Ecotronic", "Online")
+            self.accessor, self.service, "Ecotronic", "Online", roles=["type:boiler"])
         device_type = c.asAutoDetectDevice()
         self.assertEqual("PelletsBoiler", type(device_type).__name__)
 
     def test_autoDetect_Vitoladens_asOilBoiler(self):
-        self.service.hasRoles = has_roles(["type:boiler"])
         c = PyViCareDeviceConfig(
-            self.accessor, self.service, "Vitoladens", "Online")
+            self.accessor, self.service, "Vitoladens", "Online", roles=["type:boiler"])
         device_type = c.asAutoDetectDevice()
         self.assertEqual("OilBoiler", type(device_type).__name__)
 
     def test_autoDetect_RoleGateway_asGateway(self):
-        self.service.hasRoles = has_roles(["type:gateway;VitoconnectOpto1"])
         c = PyViCareDeviceConfig(
-            self.accessor, self.service, "Unknown", "Online")
+            self.accessor, self.service, "Unknown", "Online", roles=["type:gateway;VitoconnectOpto1"])
         device_type = c.asAutoDetectDevice()
         self.assertEqual("Gateway", type(device_type).__name__)
 
     def test_autoDetect_RoleGateway_asGateway_vc_opto2(self):
-        self.service.hasRoles = has_roles(["type:gateway;VitoconnectOpto2/OT2"])
         c = PyViCareDeviceConfig(
-            self.accessor, self.service, "Unknown", "Online")
+            self.accessor, self.service, "Unknown", "Online", roles=["type:gateway;VitoconnectOpto2/OT2"])
         device_type = c.asAutoDetectDevice()
         self.assertEqual("Gateway", type(device_type).__name__)
 
     def test_autoDetect_RoleGateway_asGateway_TCU100(self):
-        self.service.hasRoles = has_roles(["type:gateway;TCU100"])
         c = PyViCareDeviceConfig(
-            self.accessor, self.service, "Unknown", "Online")
+            self.accessor, self.service, "Unknown", "Online", roles=["type:gateway;TCU100"])
         device_type = c.asAutoDetectDevice()
         self.assertEqual("Gateway", type(device_type).__name__)
 
     def test_autoDetect_RoleGateway_asGateway_TCU200(self):
-        self.service.hasRoles = has_roles(["type:gateway;TCU200"])
         c = PyViCareDeviceConfig(
-            self.accessor, self.service, "Unknown", "Online")
+            self.accessor, self.service, "Unknown", "Online", roles=["type:gateway;TCU200"])
         device_type = c.asAutoDetectDevice()
         self.assertEqual("Gateway", type(device_type).__name__)
 
     def test_autoDetect_RoleGateway_asGateway_TCU300(self):
-        self.service.hasRoles = has_roles(["type:gateway;TCU300"])
         c = PyViCareDeviceConfig(
-            self.accessor, self.service, "Unknown", "Online")
+            self.accessor, self.service, "Unknown", "Online", roles=["type:gateway;TCU300"])
         device_type = c.asAutoDetectDevice()
         self.assertEqual("Gateway", type(device_type).__name__)
 
     def test_legacy_device(self):
-        self.service.hasRoles = has_roles(["type:legacy"])
         c = PyViCareDeviceConfig(
-            self.accessor, self.service, "Unknown", "Online")
+            self.accessor, self.service, "Unknown", "Online", roles=["type:legacy"])
         device = c.asAutoDetectDevice()
         self.assertEqual(device.isLegacyDevice(), True)
         self.assertEqual(device.isE3Device(), False)
 
     def test_e3_device(self):
-        self.service.hasRoles = has_roles(["type:E3"])
         c = PyViCareDeviceConfig(
-            self.accessor, self.service, "Unknown", "Online")
+            self.accessor, self.service, "Unknown", "Online", roles=["type:E3"])
         device = c.asAutoDetectDevice()
         self.assertEqual(device.isLegacyDevice(), False)
         self.assertEqual(device.isE3Device(), True)
 
     def test_autoDetect_CU401B_S_with_burners_and_compressors_asHybrid(self):
-        self.service.hasRoles = has_roles(["type:heatpump"])
         self.service.fetch_all_features = Mock(return_value={"data": [
             {"feature": "heating.burners"},
             {"feature": "heating.burners.0"},
@@ -233,23 +209,21 @@ class PyViCareDeviceConfigTest(unittest.TestCase):
             {"feature": "heating.compressors.0"},
         ]})
         c = PyViCareDeviceConfig(
-            self.accessor, self.service, "CU401B_S", "Online")
+            self.accessor, self.service, "CU401B_S", "Online", roles=["type:heatpump"])
         device_type = c.asAutoDetectDevice()
         self.assertEqual("Hybrid", type(device_type).__name__)
 
     def test_autoDetect_HeatPump_without_burners_stays_HeatPump(self):
-        self.service.hasRoles = has_roles(["type:heatpump"])
         self.service.fetch_all_features = Mock(return_value={"data": [
             {"feature": "heating.compressors"},
             {"feature": "heating.compressors.0"},
         ]})
         c = PyViCareDeviceConfig(
-            self.accessor, self.service, "Vitocal300", "Online")
+            self.accessor, self.service, "Vitocal300", "Online", roles=["type:heatpump"])
         device_type = c.asAutoDetectDevice()
         self.assertEqual("HeatPump", type(device_type).__name__)
 
     def test_autoDetect_GazBoiler_with_compressors_asHybrid(self):
-        self.service.hasRoles = has_roles(["type:boiler"])
         self.service.fetch_all_features = Mock(return_value={"data": [
             {"feature": "heating.burners"},
             {"feature": "heating.burners.0"},
@@ -257,24 +231,22 @@ class PyViCareDeviceConfigTest(unittest.TestCase):
             {"feature": "heating.compressors.0"},
         ]})
         c = PyViCareDeviceConfig(
-            self.accessor, self.service, "Vitodens200", "Online")
+            self.accessor, self.service, "Vitodens200", "Online", roles=["type:boiler"])
         device_type = c.asAutoDetectDevice()
         self.assertEqual("Hybrid", type(device_type).__name__)
 
     def test_autoDetect_feature_fetch_failure_keeps_original(self):
-        self.service.hasRoles = has_roles(["type:heatpump"])
         self.service.fetch_all_features = Mock(side_effect=OSError("API error"))
         c = PyViCareDeviceConfig(
-            self.accessor, self.service, "CU401B_S", "Online")
+            self.accessor, self.service, "CU401B_S", "Online", roles=["type:heatpump"])
         device_type = c.asAutoDetectDevice()
         self.assertEqual("HeatPump", type(device_type).__name__)
 
     def test_autoDetect_NotPaidFor_keeps_original(self):
-        self.service.hasRoles = has_roles(["type:heatpump"])
         self.service.fetch_all_features = Mock(
             side_effect=PyViCareNotPaidForError({"errorType": "PACKAGE_NOT_PAID_FOR"}))
         c = PyViCareDeviceConfig(
-            self.accessor, self.service, "CU401B_S", "Online")
+            self.accessor, self.service, "CU401B_S", "Online", roles=["type:heatpump"])
         device_type = c.asAutoDetectDevice()
         # Without the fix, asAutoDetectDevice would propagate the exception
         # and crash integration setup. With the fix, hybrid detection falls
@@ -320,13 +292,13 @@ class PyViCareDeviceConfigTest(unittest.TestCase):
         self.assertEqual(c.getRoles(), [])
 
     def test_isGateway_true_for_gateway_role(self):
-        self.service._isGateway = Mock(return_value=True)  # pylint: disable=protected-access
         c = PyViCareDeviceConfig(
-            self.accessor, self.service, "Heatbox1", "Online", "vitoconnect")
+            self.accessor, self.service, "Heatbox1", "Online", "vitoconnect",
+            roles=["type:gateway;VitoconnectOpto1"])
         self.assertTrue(c.isGateway())
 
     def test_isGateway_false_for_non_gateway_role(self):
-        self.service._isGateway = Mock(return_value=False)  # pylint: disable=protected-access
         c = PyViCareDeviceConfig(
-            self.accessor, self.service, "Vitocal", "Online", "heating")
+            self.accessor, self.service, "Vitocal", "Online", "heating",
+            roles=["type:heatpump"])
         self.assertFalse(c.isGateway())

--- a/tests/test_PyViCareServiceViaGateway.py
+++ b/tests/test_PyViCareServiceViaGateway.py
@@ -1,0 +1,75 @@
+import unittest
+from unittest.mock import Mock
+
+from PyViCare.PyViCareService import ViCareDeviceAccessor
+from PyViCare.PyViCareServiceViaGateway import (
+    ViCareServiceViaGateway, filter_features_for_device)
+from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
+
+
+class PyViCareServiceViaGatewayTest(unittest.TestCase):
+
+    BULK_RESPONSE = {
+        "data": [
+            {
+                "feature": "device.serial",
+                "uri": "https://api.viessmann.com/iot/v2/features/installations/[id]/gateways/[serial]/devices/[dev1]/features/device.serial",
+                "isEnabled": True,
+            },
+            {
+                "feature": "device.messages.errors.raw",
+                "uri": "https://api.viessmann.com/iot/v2/features/installations/[id]/gateways/[serial]/devices/[dev1]/features/device.messages.errors.raw",
+                "isEnabled": True,
+            },
+            {
+                "feature": "device.serial",
+                "uri": "https://api.viessmann.com/iot/v2/features/installations/[id]/gateways/[serial]/devices/[dev2]/features/device.serial",
+                "isEnabled": True,
+            },
+        ]
+    }
+
+    def setUp(self):
+        self.oauth_mock = Mock()
+        self.oauth_mock.get.return_value = self.BULK_RESPONSE
+        self.service = ViCareServiceViaGateway(self.oauth_mock)
+        self.accessor1 = ViCareDeviceAccessor("[id]", "[serial]", "[dev1]")
+        self.accessor2 = ViCareDeviceAccessor("[id]", "[serial]", "[dev2]")
+
+    def test_fetch_all_features_uses_bulk_url(self):
+        self.service.fetch_all_features(self.accessor1)
+        self.oauth_mock.get.assert_called_once_with(
+            '/features/installations/[id]/gateways/[serial]/features?includeDevicesFeatures=true')
+
+    def test_getProperty_filters_to_caller_device(self):
+        feature = self.service.getProperty(self.accessor1, "device.serial")
+        self.assertIn("[dev1]", feature["uri"])
+
+    def test_getProperty_finds_feature_for_each_device(self):
+        f1 = self.service.getProperty(self.accessor1, "device.serial")
+        f2 = self.service.getProperty(self.accessor2, "device.serial")
+        self.assertIn("[dev1]", f1["uri"])
+        self.assertIn("[dev2]", f2["uri"])
+
+    def test_getProperty_missing_feature_raises(self):
+        self.assertRaises(
+            PyViCareNotSupportedFeatureError,
+            self.service.getProperty, self.accessor1, "does.not.exist")
+
+    def test_getProperty_missing_feature_for_other_device_raises(self):
+        # device.messages.errors.raw exists only for dev1; dev2 must raise
+        self.assertRaises(
+            PyViCareNotSupportedFeatureError,
+            self.service.getProperty, self.accessor2, "device.messages.errors.raw")
+
+    def test_setProperty_uses_per_device_url(self):
+        self.service.setProperty(self.accessor1, "x.y", "doaction", {"a": 1})
+        self.oauth_mock.post.assert_called_once_with(
+            '/features/installations/[id]/gateways/[serial]/devices/[dev1]/features/x.y/commands/doaction',
+            '{"a": 1}')
+
+    def test_filter_features_for_device_handles_missing_uri(self):
+        entities = [{"feature": "x"}, {"feature": "y", "uri": "/devices/[dev1]/features/y"}]
+        result = filter_features_for_device(entities, "[dev1]")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["feature"], "y")

--- a/tests/test_via_gateway_integration.py
+++ b/tests/test_via_gateway_integration.py
@@ -9,6 +9,7 @@ import unittest
 from unittest.mock import Mock
 
 from PyViCare.PyViCare import PyViCare
+from PyViCare.PyViCareCachedService import ViCareCachedService
 from PyViCare.PyViCareCachedServiceViaGateway import \
     ViCareCachedServiceViaGateway
 from tests.helper import readJson
@@ -98,7 +99,6 @@ class PyViCareViaGatewayIntegrationTest(unittest.TestCase):
 
     def test_default_mode_uses_per_device_service(self):
         # Without loadViaGateway, behavior is unchanged: per-device cached service
-        from PyViCare.PyViCareCachedService import ViCareCachedService
         oauth = Mock()
         oauth.get.return_value = INSTALLATIONS_HEATBOX1
         vicare = PyViCare()

--- a/tests/test_via_gateway_integration.py
+++ b/tests/test_via_gateway_integration.py
@@ -1,0 +1,125 @@
+"""End-to-end test: PyViCare in viaGateway mode shares one service per gateway.
+
+Builds PyViCare with a mocked OAuth manager that serves
+- the installations/gateways listing
+- the bulk gateway features response (lifted from PR #626 fixtures)
+and verifies that all devices on a gateway share a single bulk fetch.
+"""
+import unittest
+from unittest.mock import Mock
+
+from PyViCare.PyViCare import PyViCare
+from PyViCare.PyViCareCachedServiceViaGateway import \
+    ViCareCachedServiceViaGateway
+from tests.helper import readJson
+
+
+INSTALLATIONS_HEATBOX1 = {
+    "data": [{
+        "id": 1234567,
+        "description": "Test Installation",
+        "address": {"street": "Teststreet"},
+        "gateways": [{
+            "serial": "1234567812345678",
+            "producedAt": "2024-01-01T00:00:00.000Z",
+            "autoUpdate": True,
+            "aggregatedStatus": "Online",
+            "registeredAt": "2024-01-01T00:00:00.000Z",
+            "devices": [
+                {"id": "gateway", "modelId": "Heatbox1", "status": "Online",
+                 "deviceType": "vitoconnect", "roles": ["type:gateway;VitoconnectOpto1"],
+                 "createdAt": "2024-01-01T00:00:00.000Z"},
+                {"id": "0", "modelId": "E3_Vitodens_300_W_B3HA", "status": "Online",
+                 "deviceType": "heating", "roles": ["type:boiler", "type:E3"],
+                 "createdAt": "2024-01-01T00:00:00.000Z"},
+            ],
+        }],
+    }]
+}
+
+
+class PyViCareViaGatewayIntegrationTest(unittest.TestCase):
+
+    def _build(self, installations, bulk_response):
+        oauth = Mock()
+        installations_url = "/equipment/installations?includeGateways=true"
+
+        def get(url):
+            if url == installations_url:
+                return installations
+            return bulk_response
+
+        oauth.get.side_effect = get
+        vicare = PyViCare()
+        vicare.loadViaGateway(True)
+        vicare.initWithExternalOAuth(oauth)
+        return vicare, oauth
+
+    def test_loadViaGateway_wires_gateway_service(self):
+        bulk = readJson("response/gatewayWithDevices/heatbox1/Vitodens-300-W-B3HA.json")
+        vicare, _ = self._build(INSTALLATIONS_HEATBOX1, bulk)
+        # all devices on the gateway share the same service instance
+        services = {id(d.service) for d in vicare.devices}
+        self.assertEqual(len(services), 1)
+        for device in vicare.devices:
+            self.assertIsInstance(device.service, ViCareCachedServiceViaGateway)
+
+    def test_devices_share_single_bulk_fetch(self):
+        bulk = readJson("response/gatewayWithDevices/heatbox1/Vitodens-300-W-B3HA.json")
+        vicare, oauth = self._build(INSTALLATIONS_HEATBOX1, bulk)
+
+        # 1 installations call done during init
+        installations_calls = sum(
+            1 for c in oauth.get.call_args_list
+            if c.args[0] == "/equipment/installations?includeGateways=true")
+        self.assertEqual(installations_calls, 1)
+
+        # Pick a feature that exists in the bulk response per device, then
+        # request it from every device on the gateway. All getProperty calls
+        # must hit the single shared cache → exactly one bulk fetch in total.
+        per_device_feature = {}
+        for entity in bulk["data"]:
+            uri = entity.get("uri", "")
+            if "/devices/" not in uri:
+                continue
+            dev_id = uri.split("/devices/")[1].split("/")[0]
+            per_device_feature.setdefault(dev_id, entity["feature"])
+
+        for device_config in vicare.devices:
+            feature = per_device_feature.get(device_config.device_id)
+            if feature is None:
+                continue
+            device_config.service.getProperty(device_config.accessor, feature)
+
+        bulk_calls = sum(
+            1 for c in oauth.get.call_args_list
+            if c.args[0] != "/equipment/installations?includeGateways=true")
+        self.assertEqual(bulk_calls, 1)
+
+    def test_default_mode_uses_per_device_service(self):
+        # Without loadViaGateway, behavior is unchanged: per-device cached service
+        from PyViCare.PyViCareCachedService import ViCareCachedService
+        oauth = Mock()
+        oauth.get.return_value = INSTALLATIONS_HEATBOX1
+        vicare = PyViCare()
+        vicare.initWithExternalOAuth(oauth)
+        for device in vicare.devices:
+            self.assertIsInstance(device.service, ViCareCachedService)
+        # different instances per device
+        services = {id(d.service) for d in vicare.devices}
+        self.assertEqual(len(services), len(vicare.devices))
+
+    def test_bulk_response_isEnabled_features_are_visible_per_device(self):
+        bulk = readJson("response/gatewayWithDevices/heatbox1/Vitodens-300-W-B3HA.json")
+        vicare, _ = self._build(INSTALLATIONS_HEATBOX1, bulk)
+        # The heating device should be able to read SOME feature that exists in the bulk
+        # response for its device_id. Pick any feature with /devices/0/ in its uri.
+        device_zero_features = [
+            e["feature"] for e in bulk["data"]
+            if "/devices/0/" in e.get("uri", "")
+        ]
+        self.assertGreater(len(device_zero_features), 0,
+                           "fixture should contain features for device 0")
+        heating = next(d for d in vicare.devices if d.device_id == "0")
+        feature = heating.service.getProperty(heating.accessor, device_zero_features[0])
+        self.assertEqual(feature["feature"], device_zero_features[0])


### PR DESCRIPTION
## Summary

Adds an opt-in service mode where ONE `ViCareCachedServiceViaGateway` instance serves all devices on a gateway from a single bulk API call, instead of N per-device calls per refresh.

```python
vicare = PyViCare()
vicare.loadViaGateway(True)   # default False; must precede initWith*
vicare.initWithCredentials(...)
```

Per-device entry points (`device.getProperty`, `DeviceConfig.as*`) are unchanged. Default behavior is unchanged.

## Why

The Viessmann API exposes a per-gateway bulk endpoint:
```
GET /features/installations/{id}/gateways/{serial}/features?includeDevicesFeatures=true
```
It returns all `isEnabled=true` features for every device on the gateway in one call. For overlapping features the property values + timestamps are byte-identical to per-device fetches.

For free-tier users (1450 API calls/day) this is meaningful headroom: a 4-device gateway drops from 4 calls per refresh to 1.

## Architecture

```
ViCareService                       (per-device, transport)
└── ViCareCachedService             (per-device, with cache; default)

ViCareServiceViaGateway             (per-gateway, transport)
└── ViCareCachedServiceViaGateway   (per-gateway, with cache; opt-in)
```

The shared service is wired in `PyViCare.__extract_all_devices`: one service per gateway in viaGateway mode, one per device otherwise. `setProperty` still uses the per-device URL in both modes (writes target one feature on one device; no bulk write endpoint exists).

Both `getProperty` and `fetch_all_features` are cached against the same payload. The `fetch_all_features` cache is the key optimization for HA Core's DataUpdateCoordinator pattern (per-device coordinators call `service.clear_cache + service.fetch_all_features` per refresh — without caching that path, N coordinators on a shared service would still trigger N bulk fetches per cycle).

Defensive error handling (`PACKAGE_NOT_PAID_FOR`, `DeviceCommunicationError`, `InternalServerError`) mirrors `ViCareCachedService`.

## Precursor refactor

Commit 1 moves role-based decisions (`hasRoles`, `isGateway`, `isLegacyDevice`, `isE3Device`, `get_heat_curve_formular`) from Service to Device/DeviceConfig. In shared-service mode the service cannot answer per-device role questions because its roles list would be whichever device was processed first. Service-side `hasRoles`/`_isGateway` are kept for backwards compatibility (still used by the per-device service for URL shape selection).

Public API unchanged. Test mocks updated to pass roles via the `PyViCareDeviceConfig` constructor instead of patching `service.hasRoles`.

## Credit

Carries the design intent of #626 by @CFenner forward. The bulk response test fixtures (heatbox1/heatbox2/tcu1) are lifted from that draft. Implementation is fresh on current master because #774 made the previous sketch incompatible (accessor lives on Device now, service is stateless), and the original draft did not actually share the service instance across devices.

## Tests

20 new tests covering URL building, per-device filtering of the bulk response, shared-cache behavior across devices, TTL respect, `setProperty` cache invalidation, stale-cache fallback on transient errors, end-to-end PyViCare wiring with mocked OAuth.

749 → 750 total tests passing, ruff clean, pylint 10/10 on changed modules.

Refs: #626, #774, home-assistant/core#173776