### PR TITLE
feat: expose ventilation bypass properties

### DIFF
--- a/PyViCare/PyViCareVentilationDevice.py
+++ b/PyViCare/PyViCareVentilationDevice.py
@@ -354,3 +354,15 @@ class VentilationDevice(Device):
     @handleNotSupported
     def getConfiguredLevelFourVolumeFlow(self) -> int:
         return int(self.getProperty("ventilation.levels.levelFour")["properties"]["volumeFlow"]["value"])
+
+    @handleNotSupported
+    def getBypassPosition(self) -> int:
+        return int(self.getProperty("ventilation.bypass.position")["properties"]["value"]["value"])
+
+    @handleNotSupported
+    def getBypassOperatingModesOpen(self) -> bool:
+        return bool(self.getProperty("ventilation.bypass.operating.modes.open")["properties"]["active"]["value"])
+
+    @handleNotSupported
+    def getBypassOperatingModesAutomatic(self) -> bool:
+        return bool(self.getProperty("ventilation.bypass.operating.modes.automatic")["properties"]["active"]["value"])

--- a/tests/test_VitoairFs300E.py
+++ b/tests/test_VitoairFs300E.py
@@ -86,3 +86,12 @@ class VitoairFs300(unittest.TestCase):
 
     def test_getConfiguredLevelFourVolumeFlow(self):
         self.assertEqual(self.device.getConfiguredLevelFourVolumeFlow(), 275)
+
+    def test_getBypassPosition(self):
+        self.assertEqual(self.device.getBypassPosition(), 0)
+
+    def test_getBypassOperatingModesOpen(self):
+        self.assertEqual(self.device.getBypassOperatingModesOpen(), False)
+
+    def test_getBypassOperatingModesAutomatic(self):
+        self.assertEqual(self.device.getBypassOperatingModesAutomatic(), True)


### PR DESCRIPTION
Added support for the following three properties on ventilation devices:

- ventilation.bypass.position
- ventilation.bypass.operating.modes.open
- ventilation.bypass.operating.modes.automatic

The bypass position indicates how much of the air is being fed into the heat recovery mechanism in the ventilation device. Where 0 = all of the air, 100 = none of it. E.g. how much air "bypasses" the heat recovery. In summer this is a critical value to understand if the ventilation system is optimally reducing the temperature in the house.

The open mode, is essentially the "manual" mode of bypass configuration. The automatic mode on the other side means the system is automatically controlling the bypass. Useful to see how the ventilation device was configured.

It was not required to add new test data as a dump of the VitoairFS300 which I own is already checked in.

As a next step I plan on extending the ViCare Home Assistant integration to expose these values as well.