### PR TITLE
feat: add weekly per-compressor power consumption getters

### DIFF
--- a/PyViCare/PyViCareHeatPump.py
+++ b/PyViCare/PyViCareHeatPump.py
@@ -678,6 +678,30 @@ class Compressor(HeatingDeviceWithComponent):
         return float(self.getProperty(f"heating.compressors.{self.compressor}.power.consumption.cooling")["properties"]["year"]["value"][0])
 
     @handleNotSupported
+    def getPowerConsumptionHeatingThisWeek(self) -> float:
+        return float(self.getProperty(f"heating.compressors.{self.compressor}.power.consumption.heating.week")["properties"]["value"]["value"])
+
+    @handleNotSupported
+    def getPowerConsumptionHeatingThisWeekUnit(self) -> str:
+        return str(self.getProperty(f"heating.compressors.{self.compressor}.power.consumption.heating.week")["properties"]["value"]["unit"])
+
+    @handleNotSupported
+    def getPowerConsumptionDHWThisWeek(self) -> float:
+        return float(self.getProperty(f"heating.compressors.{self.compressor}.power.consumption.dhw.week")["properties"]["value"]["value"])
+
+    @handleNotSupported
+    def getPowerConsumptionDHWThisWeekUnit(self) -> str:
+        return str(self.getProperty(f"heating.compressors.{self.compressor}.power.consumption.dhw.week")["properties"]["value"]["unit"])
+
+    @handleNotSupported
+    def getPowerConsumptionCoolingThisWeek(self) -> float:
+        return float(self.getProperty(f"heating.compressors.{self.compressor}.power.consumption.cooling.week")["properties"]["value"]["value"])
+
+    @handleNotSupported
+    def getPowerConsumptionCoolingThisWeekUnit(self) -> str:
+        return str(self.getProperty(f"heating.compressors.{self.compressor}.power.consumption.cooling.week")["properties"]["value"]["unit"])
+
+    @handleNotSupported
     def getPowerConsumptionTotalThisYear(self) -> float:
         return float(self.getProperty(f"heating.compressors.{self.compressor}.power.consumption.total")["properties"]["year"]["value"][0])
 

--- a/tests/test_Vitocal333G_with_Vitovent300F.py
+++ b/tests/test_Vitocal333G_with_Vitovent300F.py
@@ -2,6 +2,7 @@ import unittest
 
 from PyViCare.PyViCareService import ViCareDeviceAccessor
 from PyViCare.PyViCareHeatPump import HeatPump
+from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
 from tests.ViCareServiceMock import ViCareServiceMock
 
 
@@ -33,3 +34,15 @@ class Vitocal333G_with_Vitovent300F(unittest.TestCase):
     def test_compressor_getInletPressure(self):
         self.assertEqual(self.device.getCompressor("0").getInletPressure(), 12.9)
         self.assertEqual(self.device.getCompressor("0").getInletPressureUnit(), "bar")
+
+    def test_compressor_getPowerConsumptionHeatingThisWeek(self):
+        self.assertEqual(self.device.getCompressor("0").getPowerConsumptionHeatingThisWeek(), 6.3)
+        self.assertEqual(self.device.getCompressor("0").getPowerConsumptionHeatingThisWeekUnit(), "kilowattHour")
+
+    def test_compressor_getPowerConsumptionDHWThisWeek(self):
+        self.assertEqual(self.device.getCompressor("0").getPowerConsumptionDHWThisWeek(), 2.3)
+        self.assertEqual(self.device.getCompressor("0").getPowerConsumptionDHWThisWeekUnit(), "kilowattHour")
+
+    def test_compressor_getPowerConsumptionCoolingThisWeek_notSupported(self):
+        with self.assertRaises(PyViCareNotSupportedFeatureError):
+            self.device.getCompressor("0").getPowerConsumptionCoolingThisWeek()


### PR DESCRIPTION
Newer Viessmann heat pumps expose per-category energy consumption only as scalar `heating.compressors.{N}.power.consumption.{heating,dhw,cooling}.week` features. The existing device-level `heating.power.consumption.*` getters (day/month/year) return nothing on these devices, so HA has no cooling/heating energy data for them.

Adds `getPowerConsumption{Heating,DHW,Cooling}ThisWeek` + unit getters on the `Compressor` class. Tests cover heating/dhw (real values from the existing Vitocal333G fixture) and cooling raising NotSupported when disabled.

Enables a follow-up Home Assistant sensor (state_class total_increasing, which handles the weekly reset into a cumulative counter).