### PR TITLE
feat: enable getBoilerTemperature for Oil and PelletBoilers

### DIFF
--- a/PyViCare/PyViCareGazBoiler.py
+++ b/PyViCare/PyViCareGazBoiler.py
@@ -92,10 +92,6 @@ class GazBoiler(HeatingDevice):
         return self.getProperty("heating.gas.consumption.dhw")["properties"]["year"]["value"][0]
 
     @handleNotSupported
-    def getBoilerTemperature(self):
-        return self.getProperty("heating.boiler.sensors.temperature.main")["properties"]["value"]["value"]
-
-    @handleNotSupported
     def getBoilerTargetTemperature(self):
         return self.getProperty("heating.boiler.temperature")["properties"]["value"]["value"]
 

--- a/PyViCare/PyViCareHeatingDevice.py
+++ b/PyViCare/PyViCareHeatingDevice.py
@@ -391,6 +391,10 @@ class HeatingDevice(Device):
     def getBoilerCommonSupplyTemperature(self):
         return self.getProperty("heating.boiler.sensors.temperature.commonSupply")["properties"]["value"]["value"]
 
+    @handleNotSupported
+    def getBoilerTemperature(self):
+        return self.getProperty("heating.boiler.sensors.temperature.main")["properties"]["value"]["value"]
+
 
 class HeatingDeviceWithComponent:
     """This is the base class for all heating components"""

--- a/tests/test_Ecotronic.py
+++ b/tests/test_Ecotronic.py
@@ -58,3 +58,6 @@ class Ecotronic(unittest.TestCase):
 
     def test_getAshLevel(self):
         self.assertEqual(self.device.getAshLevel(), 43.7)
+
+    def test_getBoilerTemperature(self):
+        self.assertEqual(self.device.getBoilerTemperature(), 63)


### PR DESCRIPTION
Closes #477 (the remaining part).

`getBoilerCommonSupplyTemperature` was already moved to `HeatingDevice`. This does the same for `getBoilerTemperature` (`heating.boiler.sensors.temperature.main`), which is present on oil (Vitoladens) and pellets (Vitoligno/Ecotronic) boilers too but was only reachable on `GazBoiler`. `OilBoiler` and `PelletsBoiler` extend `HeatingDevice` directly, so they could not call it before.

Heat pumps do not expose `...temperature.main` (they use `commonSupply`), so this does not affect Vitocal devices. Test added on the Ecotronic (PelletsBoiler) fixture; GazBoiler keeps the method by inheritance and its tests stay green.