### PR TITLE
Require deprecated>=1.3.0 for wrapt 2.x compatibility

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1213,4 +1213,4 @@ dev = ["pytest", "setuptools"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "86c59f9ac5bba4262fb615580415134180df8ea319cf669cc70d235ae365e26a"
+content-hash = "95261cfc94342ff24b0f2c319400dba85b0d9d9b929f460dce343db79590f7f8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ Changelog = "https://github.com/openviess/PyViCare/releases"
 authlib = ">1.2.0"
 python = "^3.10"
 requests = ">=2.31.0"
-deprecated = "^1.2.15"
+deprecated = "^1.3.0"
 
 [tool.poetry.group.dev.dependencies]
 codespell = "2.4.3"


### PR DESCRIPTION
`Deprecated` before 1.3.0 can't import against `wrapt` 2.x:

```
class ClassicAdapter(wrapt.AdapterFactory):
AttributeError: module 'wrapt' has no attribute 'AdapterFactory'
```

1.3.0 (2025-10-29) is the first `wrapt` 2.x compatible release. Python 3.14 only ships `wrapt` 2.x wheels, so the current `^1.2.15` floor lets an environment resolve to a combination that can't import PyViCare at all. Bumping to `^1.3.0` excludes the broken versions while staying on the 1.x line.

Downstream report: home-assistant/core#177689
